### PR TITLE
Fix Some Small Bugs in Proto/API Generation

### DIFF
--- a/Content/Python/API/gen_api.py
+++ b/Content/Python/API/gen_api.py
@@ -298,4 +298,5 @@ if __name__ == "__main__":
         raise Exception("This script requires Python 3.9 or greater (found {}.{}.{})"
                         .format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))
     root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tempo")
+    sys.path.append(root_dir)
     generate_tempo_api(root_dir)

--- a/Plugins/TempoCore/TempoCore.uplugin
+++ b/Plugins/TempoCore/TempoCore.uplugin
@@ -41,12 +41,10 @@
 			"$(ProjectDir)\\Scripts\\PreBuild.bat \"$(EngineDir)\" \"$(ProjectFile)\" \"$(ProjectDir)\" \"$(TargetName)\" \"$(TargetConfiguration)\" \"$(TargetPlatform)\" \"$(PluginDir)\\Source\\ThirdParty\\gRPC\\Binaries\\Windows\""
 		],
 		"Mac": [
-			"$(ProjectDir)/Scripts/GenProtos.sh \"$(EngineDir)\" \"$(ProjectFile)\" \"$(ProjectDir)\" \"$(TargetName)\" \"$(TargetConfiguration)\" \"$(TargetPlatform)\" \"$(PluginDir)/Source/ThirdParty/gRPC/Binaries/Mac\"",
-			"$(ProjectDir)/Scripts/GenAPI.sh \"$(ProjectDir)\""
+			"$(ProjectDir)/Scripts/PreBuild.sh \"$(EngineDir)\" \"$(ProjectFile)\" \"$(ProjectDir)\" \"$(TargetName)\" \"$(TargetConfiguration)\" \"$(TargetPlatform)\" \"$(PluginDir)/Source/ThirdParty/gRPC/Binaries/Mac\"",
 		],
 		"Linux": [
-			"$(ProjectDir)/Scripts/GenProtos.sh \"$(EngineDir)\" \"$(ProjectFile)\" \"$(ProjectDir)\" \"$(TargetName)\" \"$(TargetConfiguration)\" \"$(TargetPlatform)\" \"$(PluginDir)/Source/ThirdParty/gRPC/Binaries/Linux\"",
-			"$(ProjectDir)/Scripts/GenAPI.sh \"$(ProjectDir)\""
+			"$(ProjectDir)/Scripts/PreBuild.sh \"$(EngineDir)\" \"$(ProjectFile)\" \"$(ProjectDir)\" \"$(TargetName)\" \"$(TargetConfiguration)\" \"$(TargetPlatform)\" \"$(PluginDir)/Source/ThirdParty/gRPC/Binaries/Linux\"",
 		]
 	}
 }

--- a/Scripts/GenAPI.sh
+++ b/Scripts/GenAPI.sh
@@ -29,13 +29,18 @@ else
   source "$VENV_DIR/bin/activate"
 fi
 
+set +e # Proceed despite errors from pip. That could just mean the user has no internet connection.
 # Install a few dependencies to the virtual environment. If this list grows put them in a requirements.txt file.
-pip install --upgrade pip --quiet
-pip install protobuf==4.25.3 --quiet
-pip install Jinja2==3.1.3 --quiet
+pip install --upgrade pip --quiet --quiet --retries 0
+pip install protobuf==4.25.3 --quiet --quiet --retries 0
+pip install Jinja2==3.1.3 --quiet --quiet --retries 0
+set -e
 
 # Finally build and install the Tempo API (and its dependencies) to the virtual environment.
 python "$PROJECT_ROOT/Content/Python/API/gen_api.py"
-pip install "$PROJECT_ROOT/Content/Python/API" --quiet
+set +e # Again proceed despite errors from pip.
+pip uninstall tempo --yes --quiet --quiet # Uninstall first to remove any stale files
+pip install "$PROJECT_ROOT/Content/Python/API" --quiet --quiet --retries 0
+set -e
 
 echo "Done"

--- a/Scripts/PreBuild.bat
+++ b/Scripts/PreBuild.bat
@@ -1,7 +1,6 @@
 @echo off
 
-REM Simply call the bash versions from the same directory
-REM For some reason calling multiple batch files as prebuild steps doesn't work? So we combine them here.
+REM Simply call the individual scripts from the same directory
 bash %~dp0GenProtos.sh %*
 bash %~dp0GenAPI.sh %3
 

--- a/Scripts/PreBuild.sh
+++ b/Scripts/PreBuild.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Simply call the individual scripts from the same directory
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+bash "$SCRIPT_DIR/GenProtos.sh" "$@"
+bash "$SCRIPT_DIR/GenAPI.sh" "$3"


### PR DESCRIPTION
Fixes a handful of small bugs I found while implementing TempoSensors:
- If you moved a proto file, you'd end up with a stale file in the pip-installed tempo. Uninstalling before installing fixes that
- Errors in GenAPI.sh caused the rest of the build to stop, but errors in GenProtos.sh didn't. I don't know why that is, but combining them into a single prebuild step (like we already do on Windows) fixes it
- We need to append the `tempo` path to the Python sys root before generating the API so the generated proto py files can import each other