### PR TITLE
Fix Linux-only crash

### DIFF
--- a/Plugins/TempoSensors/Source/TempoSensorsShared/Public/TempoMeasurementRequestingInterface.h
+++ b/Plugins/TempoSensors/Source/TempoSensorsShared/Public/TempoMeasurementRequestingInterface.h
@@ -13,7 +13,10 @@ template <typename ColorType>
 struct TTextureRead
 {
 	TTextureRead(const FIntPoint& ImageSizeIn, int32 SequenceIdIn, double CaptureTimeIn)
-		   : ImageSize(ImageSizeIn), SequenceId(SequenceIdIn), CaptureTime(CaptureTimeIn), Image(TArray(&FColor::Green, ImageSize.X * ImageSize.Y)) {}
+		   : ImageSize(ImageSizeIn), SequenceId(SequenceIdIn), CaptureTime(CaptureTimeIn)
+	{
+		Image.SetNumUninitialized(ImageSize.X * ImageSize.Y);
+	}
 
 	FIntPoint ImageSize;
 	int32 SequenceId;


### PR DESCRIPTION
Got a crash when trying to run image capture on Linux, related to using the address of the static FColor::Green