### PR TITLE
Fix Tempo Package Errors

### DIFF
--- a/Plugins/TempoCore/Source/TempoScripting/Private/TempoScripting.cpp
+++ b/Plugins/TempoCore/Source/TempoScripting/Private/TempoScripting.cpp
@@ -5,7 +5,9 @@
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/message.h"
 
+#if WITH_EDITOR
 #include "IHotReload.h"
+#endif
 
 #define LOCTEXT_NAMESPACE "FTempoScriptingModule"
 
@@ -13,6 +15,7 @@ DEFINE_LOG_CATEGORY(LogTempoScripting);
 
 void FTempoScriptingModule::StartupModule()
 {
+#if WITH_EDITOR
 	// We disallow hot reload for TempoScripting module for the same reason we force TempoScripting
 	// to re-export all the symbols from gRPC and Protobuf: these libraries have lots of static
 	// global state that must exist in exactly one place in the whole executable. That doesn't play
@@ -27,6 +30,7 @@ void FTempoScriptingModule::StartupModule()
 		google::protobuf::DescriptorPool::ResetGeneratedDatabase();
 		google::protobuf::MessageFactory::ResetGeneratedFactory();
 	});
+#endif
 }
 
 void FTempoScriptingModule::ShutdownModule()

--- a/Plugins/TempoCore/Source/TempoScripting/TempoScripting.Build.cs
+++ b/Plugins/TempoCore/Source/TempoScripting/TempoScripting.Build.cs
@@ -40,12 +40,15 @@ public class TempoScripting : TempoModuleRules
 				// Unreal
 				"CoreUObject",
 				"Engine",
-				"HotReload",
 				// Tempo
 				"TempoCoreShared",
 			}
 			);
 		
+		if (Target.bBuildEditor)
+		{
+			PrivateDependencyModuleNames.Add("HotReload");
+		}
 		
 		DynamicallyLoadedModuleNames.AddRange(
 			new string[]

--- a/Scripts/InstallToolChain.sh
+++ b/Scripts/InstallToolChain.sh
@@ -59,7 +59,7 @@ else
      exit;
   fi
   
-  echo "Rebuilding UnrealBuildTool...";
+  echo "Rebuilding UnrealBuildTool and AutomationTool...";
   
   cd "$UNREAL_ENGINE_PATH"
   
@@ -84,4 +84,5 @@ else
   fi
   
   eval "$DOTNET" build "./Engine/Source/Programs/UnrealBuildTool/UnrealBuildTool.csproj" -c Development
+  eval "$DOTNET" build "./Engine/Source/Programs/AutomationTool/AutomationTool.csproj" -c Development
 fi


### PR DESCRIPTION
TempoScripting's dependency on HotReload module causes package errors. Thankfully, we only need that when running in the Editor, so removing it otherwise fixes the problem.

Separately, we also need to rebuild AutomationTool when we rebuild UnrealBuildTool so it will know about 
the TempoModuleRules class we introduced.