### PR TITLE
Turn Off Depth Prepass Optimization

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -49,7 +49,8 @@ r.DefaultFeature.LocalExposure.HighlightContrastScale=0.8
 r.DefaultFeature.LocalExposure.ShadowContrastScale=0.8
 r.CustomDepthTemporalAAJitter=False
 r.CustomDepth=3
-r.SceneCapture.DepthPrepassOptimization=True
+;We would like to use this optimization, but it causes trees and characters (or maybe all animated meshes?) to not appear in the depth image.
+;r.SceneCapture.DepthPrepassOptimization=True
 
 [/Script/WorldPartitionEditor.WorldPartitionEditorSettings]
 CommandletClass=Class'/Script/UnrealEd.WorldPartitionConvertCommandlet'
@@ -87,4 +88,3 @@ OcclusionPlugin=
 SoundCueCookQualityIndex=-1
 -TargetedRHIs=SF_VULKAN_SM5
 +TargetedRHIs=SF_VULKAN_SM6
-


### PR DESCRIPTION
This causes trees and pedestrians (or maybe all animated meshes?) to not appear in the depth image. Turning this off temporarily while we search for a better solution.