### PR TITLE
Fix DOS Line break in Run.sh

### DIFF
--- a/Scripts/Run.sh
+++ b/Scripts/Run.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Somehow a DOS-style line break snuck in here, which causes a warning on Unix platforms.