### PR TITLE
Add setting for Scripting Compression Level

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -15,6 +15,7 @@ TimeMode=WallClock
 SimulatedStepsPerSecond=10
 EngineScriptingPort=10001
 WorldScriptingPort=10002
+ScriptingCompressionLevel=None
 MaxEventProcessingTimeMicroSeconds=1000
 MaxEventWaitTimeNanoSeconds=1000
 

--- a/Plugins/TempoCore/Source/TempoCoreShared/Public/TempoCoreSettings.h
+++ b/Plugins/TempoCore/Source/TempoCoreShared/Public/TempoCoreSettings.h
@@ -27,6 +27,7 @@ public:
 	// Scripting Settings.
 	int32 GetEngineScriptingPort() const { return EngineScriptingPort; }
 	int32 GetWorldScriptingPort() const { return WorldScriptingPort; }
+	EScriptingCompressionLevel GetScriptingCompressionLevel() const { return ScriptingCompressionLevel; }
 	int32 GetMaxEventProcessingTime() const { return MaxEventProcessingTimeMicroSeconds; }
 	int32 GetMaxEventWaitTime() const { return MaxEventWaitTimeNanoSeconds; }
 
@@ -49,6 +50,11 @@ private:
 	// The port number to listen for world scripting connections on.
 	UPROPERTY(EditAnywhere, Config, Category="Scripting", meta=(ClampMin=1024, ClampMax=65535, UIMin=1024, UIMax=65535))
 	int32 WorldScriptingPort = 10002;
+
+	// The default compression level to use for Tempo Scripting messages. When the client is on the same machine no
+	// compression is fastest. Otherwise, compression may help reduce network bandwidth.
+	UPROPERTY(EditAnywhere, Config, Category="Scripting")
+	EScriptingCompressionLevel ScriptingCompressionLevel = EScriptingCompressionLevel::None;
 	
 	// We will spend as much as this amount of time (in microseconds) processing events each Tick.
 	// Except in FixedStep mode, where we process all received events every Tick.

--- a/Plugins/TempoCore/Source/TempoCoreShared/Public/TempoCoreTypes.h
+++ b/Plugins/TempoCore/Source/TempoCoreShared/Public/TempoCoreTypes.h
@@ -6,7 +6,7 @@
 
 #include "TempoCoreTypes.generated.h"
 
-UENUM(Blueprintable)
+UENUM(Blueprintable, BlueprintType)
 enum class ETimeMode: uint8
 {
 	// Time advances strictly according to the wall clock ("real time").
@@ -16,3 +16,12 @@ enum class ETimeMode: uint8
 	Max UMETA(Hidden)
 };
 ENUM_RANGE_BY_COUNT(ETimeMode, ETimeMode::Max);
+
+UENUM(Blueprintable, BlueprintType)
+enum class EScriptingCompressionLevel: uint8
+{
+	None = 0,
+	Low = 1,
+	Med = 2,
+	High = 3
+};


### PR DESCRIPTION
gRPC has its own compression options. I experimented with them, and the fastest option when the client and server are on the same machine is no compression. However this adds a compression setting, so we can experiment later with server and client on different machines.