### PR TITLE
Remove compression for color images

### DIFF
--- a/Plugins/TempoSensors/Source/TempoCamera/Public/TempoCamera.h
+++ b/Plugins/TempoSensors/Source/TempoCamera/Public/TempoCamera.h
@@ -17,15 +17,11 @@ struct FCameraPixelNoDepth
 {
 	static constexpr bool bSupportsDepth = false; 
 	
-	FColor Color() const
-	{
-		return FColor(U1, U2, U3);
-	}
+	uint8 B() const { return U1; }
+	uint8 G() const { return U2; }
+	uint8 R() const { return U3; }
 	
-	uint8 Label() const
-	{
-		return U4;
-	}
+	uint8 Label() const { return U4; }
 
 	// This only exists so it can be used as a template parameter
 	// alongside FCameraPixelWithDepth. We don't want to use a virtual
@@ -49,15 +45,11 @@ struct FCameraPixelWithDepth
 {
 	static constexpr bool bSupportsDepth = true;
 	
-	FColor Color() const
-	{
-		return FColor(U1, U2, U3);
-	}
+	uint8 B() const { return U1; }
+	uint8 G() const { return U2; }
+	uint8 R() const { return U3; }
 	
-	uint8 Label() const
-	{
-		return U4;
-	}
+	uint8 Label() const { return U4; }
 	
 	float Depth(float MinDepth, float MaxDepth, float MaxDiscretizedDepth) const
 	{


### PR DESCRIPTION
TimingInsights revealed that this jpg compression cost more time in decoding than it gained in sending. It also caused compression artifacts in certain scenes. This removes it entirely while we consider alternative compression approaches.