### PR TITLE
Add FlushPendingRenderingCommands to TempoSensorInterface

### DIFF
--- a/Plugins/TempoSensors/Source/TempoCamera/Private/TempoCamera.cpp
+++ b/Plugins/TempoSensors/Source/TempoCamera/Private/TempoCamera.cpp
@@ -271,3 +271,9 @@ void UTempoCamera::FlushMeasurementResponses()
 		DecodeAndRespond(TextureRead.Get());
 	}
 }
+
+void UTempoCamera::FlushPendingRenderingCommands() const
+{
+	TextureReadQueueNoDepth.FlushPendingTextureReads();
+	TextureReadQueueWithDepth.FlushPendingTextureReads();
+}

--- a/Plugins/TempoSensors/Source/TempoCamera/Public/TempoCamera.h
+++ b/Plugins/TempoSensors/Source/TempoCamera/Public/TempoCamera.h
@@ -108,6 +108,8 @@ public:
 
 	virtual bool HasPendingRenderingCommands() override { return TextureReadQueueNoDepth.HasOutstandingTextureReads() || TextureReadQueueWithDepth.HasOutstandingTextureReads(); }
 
+	virtual void FlushPendingRenderingCommands() const override;
+	
 protected:
 	virtual bool HasPendingRequests() const override {return !PendingColorImageRequests.IsEmpty() || !PendingLabelImageRequests.IsEmpty() || !PendingDepthImageRequests.IsEmpty(); }
 	

--- a/Plugins/TempoSensors/Source/TempoSensors/Public/TempoSensorServiceSubsystem.h
+++ b/Plugins/TempoSensors/Source/TempoSensors/Public/TempoSensorServiceSubsystem.h
@@ -51,7 +51,7 @@ private:
 
 	void StreamLabelImages(const TempoCamera::LabelImageRequest& Request, const TResponseDelegate<TempoCamera::LabelImage>& ResponseContinuation) const;
 
-	void ForEachSensor(const TFunction<bool(class ITempoSensorInterface*)>& Callback) const;
+	void ForEachSensor(const TFunction<void(class ITempoSensorInterface*)>& Callback) const;
 
 	template <typename RequestType, typename ResponseType>
 	void RequestImages(const RequestType& Request, const TResponseDelegate<ResponseType>& ResponseContinuation) const;

--- a/Plugins/TempoSensors/Source/TempoSensorsShared/Public/TempoSceneCaptureComponent2D.h
+++ b/Plugins/TempoSensors/Source/TempoSensorsShared/Public/TempoSceneCaptureComponent2D.h
@@ -38,6 +38,14 @@ struct TTextureReadQueue
 		PendingTextureReads.Emplace(TextureRead);
 	}
 
+	void FlushPendingTextureReads() const
+	{
+		for (const auto& PendingTextureRead : PendingTextureReads)
+		{
+			PendingTextureRead->RenderFence.Wait();
+		}
+	}
+
 	TUniquePtr<TTextureRead<PixelType>> DequeuePendingTextureRead()
 	{
 		if (!PendingTextureReads.IsEmpty() && PendingTextureReads[0]->RenderFence.IsFenceComplete())
@@ -74,6 +82,8 @@ public:
 	virtual void FlushMeasurementResponses() override {}
 
 	virtual bool HasPendingRenderingCommands() override { return false; }
+
+	virtual void FlushPendingRenderingCommands() const override {}
 	
 protected:
 	virtual void BeginPlay() override;

--- a/Plugins/TempoSensors/Source/TempoSensorsShared/Public/TempoSensorInterface.h
+++ b/Plugins/TempoSensors/Source/TempoSensorsShared/Public/TempoSensorInterface.h
@@ -31,4 +31,6 @@ public:
 	virtual void FlushMeasurementResponses() = 0;
 
 	virtual bool HasPendingRenderingCommands() = 0;
+
+	virtual void FlushPendingRenderingCommands() const = 0;
 };


### PR DESCRIPTION
Instead of simply calling  the global `FlushRenderingCommands();` to flush all texture reads, add `FlushPendingRenderingCommands` to `TempoSensorInterface` to only wait on what we specifically need in TempoSensorServiceSubsystem.