### PR TITLE
Switch TempoCamera to always CaptureSceneDeferred

### DIFF
--- a/Plugins/TempoCore/Source/TempoScripting/Private/TempoScriptingEngineSubsystem.cpp
+++ b/Plugins/TempoCore/Source/TempoScripting/Private/TempoScriptingEngineSubsystem.cpp
@@ -36,11 +36,25 @@ void UTempoScriptingEngineSubsystem::Initialize(FSubsystemCollectionBase& Collec
 
 	const UTempoCoreSettings* Settings = GetDefault<UTempoCoreSettings>();
 	ScriptingServer->Initialize(Settings->GetEngineScriptingPort());
+
+	bIsInitialized = true;
 }
 
 void UTempoScriptingEngineSubsystem::Deinitialize()
 {
 	Super::Deinitialize();
+
+	bIsInitialized = false;
 	
 	ScriptingServer->Deinitialize();
+}
+
+void UTempoScriptingEngineSubsystem::Tick(float DeltaTime)
+{
+	ScriptingServer->Tick(DeltaTime);
+}
+
+TStatId UTempoScriptingEngineSubsystem::GetStatId() const
+{
+	RETURN_QUICK_DECLARE_CYCLE_STAT(UTempoScriptingEngineSubsystem, STATGROUP_Tickables);
 }

--- a/Plugins/TempoCore/Source/TempoScripting/Private/TempoScriptingWorldSubsystem.cpp
+++ b/Plugins/TempoCore/Source/TempoScripting/Private/TempoScriptingWorldSubsystem.cpp
@@ -33,6 +33,10 @@ void UTempoScriptingWorldSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 	
 	const UTempoCoreSettings* Settings = GetDefault<UTempoCoreSettings>();
 	ScriptingServer->Initialize(Settings->GetWorldScriptingPort());
+
+	// Scripting has nothing to do with movie scene sequences, but this event fires in exactly the right conditions:
+	// After world time has been updated for the current frame, before Actor ticks have begun, and even when paused.
+	InWorld.AddMovieSceneSequenceTickHandler(FOnMovieSceneSequenceTick::FDelegate::CreateUObject(ScriptingServer, &UTempoScriptingServer::Tick));
 }
 
 void UTempoScriptingWorldSubsystem::Deinitialize()

--- a/Plugins/TempoCore/Source/TempoScripting/Public/TempoScriptingEngineSubsystem.h
+++ b/Plugins/TempoCore/Source/TempoScripting/Public/TempoScriptingEngineSubsystem.h
@@ -13,7 +13,7 @@
  * Holds the Engine scripting server.
  */
 UCLASS()
-class TEMPOSCRIPTING_API UTempoScriptingEngineSubsystem : public UEngineSubsystem
+class TEMPOSCRIPTING_API UTempoScriptingEngineSubsystem : public UEngineSubsystem, public FTickableGameObject
 {
 	GENERATED_BODY()
 
@@ -25,7 +25,16 @@ public:
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual void Deinitialize() override;
 
+	virtual bool IsTickable() const override { return bIsInitialized; }
+	virtual bool IsTickableWhenPaused() const override { return true; }
+	virtual bool IsTickableInEditor() const override { return true; }
+	virtual void Tick(float DeltaTime) override;
+	virtual TStatId GetStatId() const override;
+
 private:
 	UPROPERTY()
 	UTempoScriptingServer* ScriptingServer;
+
+	UPROPERTY()
+	bool bIsInitialized = false;
 };

--- a/Plugins/TempoCore/Source/TempoScripting/Public/TempoScriptingServer.h
+++ b/Plugins/TempoCore/Source/TempoScripting/Public/TempoScriptingServer.h
@@ -209,7 +209,7 @@ public:
  * Hosts a gRPC server and supports registering arbitrary gRPC services and handlers.
  */
 UCLASS()
-class TEMPOSCRIPTING_API UTempoScriptingServer : public UObject, public FTickableGameObject
+class TEMPOSCRIPTING_API UTempoScriptingServer : public UObject
 {
 	GENERATED_BODY()
 public:
@@ -219,12 +219,9 @@ public:
 
 	virtual void Initialize(int32 Port);
 	virtual void Deinitialize();
-	
-	virtual bool IsTickable() const override { return bIsInitialized; }
-	virtual bool IsTickableWhenPaused() const override { return true; }
-	virtual bool IsTickableInEditor() const override { return true; }
-	virtual void Tick(float DeltaTime) override;
-	virtual TStatId GetStatId() const override { return GetStatID(); }
+
+	// The server must be explicitly Ticked. Its owner may choose the most appropriate time within the frame to do so.
+	virtual void Tick(float DeltaTime);
 	
 	template <class ServiceType, class... HandlerTypes>
 	void RegisterService(HandlerTypes... Handlers)

--- a/Plugins/TempoSensors/Source/TempoSensors/Public/TempoSensorServiceSubsystem.h
+++ b/Plugins/TempoSensors/Source/TempoSensors/Public/TempoSensorServiceSubsystem.h
@@ -32,15 +32,16 @@ namespace TempoCamera
 }
 
 UCLASS()
-class TEMPOSENSORS_API UTempoSensorServiceSubsystem : public UTickableWorldSubsystem, public ITempoWorldScriptable
+class TEMPOSENSORS_API UTempoSensorServiceSubsystem : public UWorldSubsystem, public ITempoWorldScriptable
 {
 	GENERATED_BODY()
 	
 public:
 	virtual void RegisterWorldServices(UTempoScriptingServer* ScriptingServer) override;
 
-	virtual void Tick(float DeltaTime) override;
-	virtual TStatId GetStatId() const override;
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+
+	virtual void OnWorldTickStart(UWorld* World, ELevelTick TickType, float DeltaSeconds);
 	
 private:
 	void GetAvailableSensors(const TempoSensors::AvailableSensorsRequest& Request, const TResponseDelegate<TempoSensors::AvailableSensorsResponse>& ResponseContinuation) const;

--- a/Plugins/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
+++ b/Plugins/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
@@ -4,8 +4,6 @@
 
 #include "TempoSensorsSettings.h"
 
-#include "TempoCoreSettings.h"
-
 #include "Engine/TextureRenderTarget2D.h"
 
 UTempoSceneCaptureComponent2D::UTempoSceneCaptureComponent2D()
@@ -51,18 +49,7 @@ void UTempoSceneCaptureComponent2D::MaybeCapture()
 		return;
 	}
 
-	if (GetDefault<UTempoCoreSettings>()->GetTimeMode() == ETimeMode::FixedStep)
-	{
-		// In fixed step mode we block the game thread to render the image immediately.
-		// It will then be read and sent before the end of the current frame.
-		CaptureScene();
-	}
-	else
-	{
-		// Otherwise, we render the frame along with the main render pass.
-		// It will get read and sent one or two frames after this one.
-		CaptureSceneDeferred();
-	}
+	CaptureSceneDeferred();
 }
 
 void UTempoSceneCaptureComponent2D::InitRenderTarget()


### PR DESCRIPTION
Switches TempoCamera to use CaptureSceneDeferred instead of CaptureScene, to always render at the end of the frame. This required changes to the Tick timing of TempoSensorServiceSubsystem and TempoScriptingServer. TempoScriptingServer is no longer a tickable object, it must be ticked by its owner explicitly. Now, the order of events in two subsequent frames is:

Frame n:
...
- Tick Actors
- Tick Timers (Previously CaptureScene, now CaptureSceneDeferred gets called)
- Tick game Objects (Previously TempoSensorServiceSubsystem and TempoScriptingServer ticked here)
- Render

Frame n+1:
- OnWorldTickStart (Before world time has advanced to n+1. Now TempoSensorServiceSubsystem ticks here, blocking on the previous frame's render in FixedStep mode)
- OnMovieSceneSequenceTick (After world time has advanced but before actor tick, even when paused, Now TempoScriptingServer ticks here)
- Tick Actors
...

Lastly, makes TempoEngineScriptingServer a tickable object, so it can tick like it always has.