### PR TITLE
Allow TempoSensors to FlushMeasurementResponses in parallel

### DIFF
--- a/Plugins/TempoSensors/Source/TempoCamera/Public/TempoCamera.h
+++ b/Plugins/TempoSensors/Source/TempoCamera/Public/TempoCamera.h
@@ -104,7 +104,7 @@ public:
 
 	void RequestMeasurement(const TempoCamera::DepthImageRequest& Request, const TResponseDelegate<TempoCamera::DepthImage>& ResponseContinuation);
 	
-	virtual void FlushMeasurementResponses() override;
+	virtual TOptional<TFuture<void>> FlushMeasurementResponses() override;
 
 	virtual bool HasPendingRenderingCommands() override { return TextureReadQueueNoDepth.HasOutstandingTextureReads() || TextureReadQueueWithDepth.HasOutstandingTextureReads(); }
 
@@ -134,7 +134,7 @@ protected:
 	
 	// Decode the underlying pixel data into responses and send them.
 	template <typename PixelType>
-	void DecodeAndRespond(const TTextureRead<PixelType>* TextureRead);
+	TFuture<void> DecodeAndRespond(TUniquePtr<TTextureRead<PixelType>> TextureRead);
 
 	TArray<FColorImageRequest> PendingColorImageRequests;
 	TArray<FLabelImageRequest> PendingLabelImageRequests;

--- a/Plugins/TempoSensors/Source/TempoSensorsShared/Public/TempoSceneCaptureComponent2D.h
+++ b/Plugins/TempoSensors/Source/TempoSensorsShared/Public/TempoSceneCaptureComponent2D.h
@@ -79,7 +79,7 @@ public:
 	
 	virtual void UpdateSceneCaptureContents(FSceneInterface* Scene) override;
 
-	virtual void FlushMeasurementResponses() override {}
+	virtual TOptional<TFuture<void>> FlushMeasurementResponses() override { return TOptional<TFuture<void>>(); }
 
 	virtual bool HasPendingRenderingCommands() override { return false; }
 

--- a/Plugins/TempoSensors/Source/TempoSensorsShared/Public/TempoSensorInterface.h
+++ b/Plugins/TempoSensors/Source/TempoSensorsShared/Public/TempoSensorInterface.h
@@ -28,7 +28,7 @@ public:
 
 	virtual const TArray<TEnumAsByte<EMeasurementType>>& GetMeasurementTypes() const = 0;
 
-	virtual void FlushMeasurementResponses() = 0;
+	virtual TOptional<TFuture<void>> FlushMeasurementResponses() = 0;
 
 	virtual bool HasPendingRenderingCommands() = 0;
 


### PR DESCRIPTION
TimingInsights revealed that decoding and sending sensor responses serially was a bottleneck. This moves those steps to background tasks. The TempoSensorServiceSubsystem still waits for them all to complete, but they are able to run in parallel.