### PR TITLE
Remove unnecessary RenderTarget2D

### DIFF
--- a/Plugins/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
+++ b/Plugins/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
@@ -54,21 +54,19 @@ void UTempoSceneCaptureComponent2D::MaybeCapture()
 
 void UTempoSceneCaptureComponent2D::InitRenderTarget()
 {
-	UTextureRenderTarget2D* RenderTarget2D = NewObject<UTextureRenderTarget2D>(this);
+	TextureTarget = NewObject<UTextureRenderTarget2D>(this);
 	
-	RenderTarget2D->TargetGamma = GetDefault<UTempoSensorsSettings>()->GetSceneCaptureGamma();
-	RenderTarget2D->RenderTargetFormat = RenderTargetFormat;
-	RenderTarget2D->bGPUSharedFlag = true;
+	TextureTarget->TargetGamma = GetDefault<UTempoSensorsSettings>()->GetSceneCaptureGamma();
+	TextureTarget->RenderTargetFormat = RenderTargetFormat;
+	TextureTarget->bGPUSharedFlag = true;
 	if (PixelFormatOverride == EPixelFormat::PF_Unknown)
 	{
-		RenderTarget2D->InitAutoFormat(SizeXY.X, SizeXY.Y);
+		TextureTarget->InitAutoFormat(SizeXY.X, SizeXY.Y);
 	}
 	else
 	{
-		RenderTarget2D->InitCustomFormat(SizeXY.X, SizeXY.Y, PixelFormatOverride, true);
+		TextureTarget->InitCustomFormat(SizeXY.X, SizeXY.Y, PixelFormatOverride, true);
 	}
-	
-	TextureTarget = RenderTarget2D;
 
 #if PLATFORM_LINUX
 	// Create the TextureRHICopy, where we will copy our TextureTarget's resource before reading it on the CPU, due to a Vulkan limitation.


### PR DESCRIPTION
The temporary RenderTarget2D is not necessary.