### PR TITLE
Workaround for MapStagingSurface Limitation on Vulkan

### DIFF
--- a/Plugins/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
+++ b/Plugins/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
@@ -80,4 +80,17 @@ void UTempoSceneCaptureComponent2D::InitRenderTarget()
 	}
 	
 	TextureTarget = RenderTarget2D;
+
+#if PLATFORM_LINUX
+	// Create the TextureRHICopy, where we will copy our TextureTarget's resource before reading it on the CPU, due to a Vulkan limitation.
+	ETextureCreateFlags TexCreateFlags = ETextureCreateFlags::Shared | ETextureCreateFlags::RenderTargetable | ETextureCreateFlags::ShaderResource | ETextureCreateFlags::CPUReadback;
+	
+	const FRHITextureCreateDesc Desc =
+		FRHITextureCreateDesc::Create2D(*FString::Printf(TEXT("%s TextureRHICopy"), *GetName()))
+		.SetExtent(TextureTarget->SizeX, TextureTarget->SizeY)
+		.SetFormat(TextureTarget->GetFormat())
+		.SetFlags(TexCreateFlags);
+	
+	TextureRHICopy = RHICreateTexture(Desc);
+#endif
 }


### PR DESCRIPTION
On Vulkan only MapStagingSurface checks if the RHI texture has the TexCreate_CPUReadback flag set, which the resource of a TextureRenderTarget2D does not. Thankfully, someone found a clever workaround: Vulkan will let you copy the RHI texture into one that does have the flag set, and then you can MapStaging surface on that. This implements that workaround with a class-member RHI texture (simply to avoid recreating it every frame) on Linux only.