### PR TITLE
Fix bug in pending writes logic by adding HANDLING state

### DIFF
--- a/Plugins/TempoCore/Source/TempoScripting/Private/TempoScriptingServer.cpp
+++ b/Plugins/TempoCore/Source/TempoScripting/Private/TempoScriptingServer.cpp
@@ -191,6 +191,11 @@ void UTempoScriptingServer::HandleEventForTag(int32 Tag, bool bOk)
 				(*RequestManager)->HandleAndRespond();
 				break;
 			}
+		case FRequestManager::HANDLING: // Shouldn't happen.
+			{
+				checkf(false, TEXT("Got event for request manager while it was handling another request."))
+				break;
+			}
 		case FRequestManager::RESPONDING: // A response has been sent, and there are more to come.
 			{
 				(*RequestManager)->HandleAndRespond();


### PR DESCRIPTION
This fixes a flaw in the logic to determine if a request manager has pending writes: a request manager was in the `RESPONDING` or `FINISHING` state both while handling its request and once the handler had finished and the write had begun. In the former of those two states it does not have a pending write. An additional state, `HANDLING`, is added to tell the difference, and not block on managers that are handling but aren't actually writing.

Tested by confirming the observed symptom is fixed (can freely switch time modes at runtime without hanging) and by confirming the original issue is still fixed (in fixed time mode we block for pending writes, and never miss requests even when the write buffer is overwhelmed) on both Mac and Linux in the editor and packaged binary.