### PR TITLE
Support Labeling Individual StaticMeshComponents Differently from their Owner

### DIFF
--- a/Plugins/TempoSensors/Source/TempoLabels/Private/TempoActorLabeler.cpp
+++ b/Plugins/TempoSensors/Source/TempoLabels/Private/TempoActorLabeler.cpp
@@ -21,11 +21,59 @@ void UTempoActorLabeler::OnWorldBeginPlay(UWorld& InWorld)
 
 	SemanticLabelTable = GetDefault<UTempoSensorsSettings>()->GetSemanticLabelTable();
 
+	// Parse the semantic label table into a more convenient structure.
+	BuildLabelMaps();
+
 	// Label all actors *after* BeginPlay (UWorldSubsystem::OnWorldBeginPlay is called *before* BeginPlay).
 	GetWorld()->OnWorldBeginPlay.AddUObject(this, &UTempoActorLabeler::LabelAllActors);
 	
 	// Label all newly spawned actors.
 	GetWorld()->AddOnActorSpawnedHandler(FOnActorSpawned::FDelegate::CreateUObject(this, &UTempoActorLabeler::LabelActor));
+}
+
+void UTempoActorLabeler::BuildLabelMaps()
+{
+	if (!SemanticLabelTable)
+	{
+		UE_LOG(LogTempoLabels, Error, TEXT("Semantic label table was not set"));
+		return;
+	}
+
+	SemanticLabelTable->ForeachRow<FSemanticLabel>(TEXT(""), [this](const FName& Key, const FSemanticLabel& Value)
+	{
+		const FName& Label = Key;
+		for (const TSubclassOf<AActor>& ActorType : Value.ActorTypes)
+		{
+			if (ActorLabels.Contains(ActorType))
+			{
+				UE_LOG(LogTempoLabels, Error, TEXT("Actor type %s is associated with more than one label (%s and %s)"), *ActorType->GetName(), *ActorLabels[ActorType].ToString(), *Label.ToString());
+				continue;
+			}
+			ActorLabels.Add(ActorType, Label);
+		}
+
+		for (const TSoftObjectPtr<UStaticMesh>& StaticMeshAsset : Value.StaticMeshTypes)
+		{
+			FString MeshId;
+			StaticMeshAsset.LoadSynchronous()->GetMeshId(MeshId);
+			if (StaticMeshLabels.Contains(MeshId))
+			{
+				UE_LOG(LogTempoLabels, Error, TEXT("Static mesh type %s is associated with more than one label (%s and %s)"), *MeshId, *StaticMeshLabels[MeshId].ToString(), *Label.ToString());
+				continue;
+			}
+			StaticMeshLabels.Add(MeshId, Label);
+		}
+
+		const int32 LabelId = Value.Label;
+		if (LabelIds.Contains(Label))
+		{
+			UE_LOG(LogTempoLabels, Error, TEXT("Label name %s is associated with more than one label ID (%d and %d)"), *Label.ToString(), LabelIds[Label], LabelId);
+		}
+		else
+		{
+			LabelIds.Add(Label, LabelId);
+		}
+	});
 }
 
 void UTempoActorLabeler::LabelAllActors() const
@@ -44,29 +92,62 @@ void UTempoActorLabeler::LabelActor(AActor* Actor) const
 		UE_LOG(LogTempoLabels, Error, TEXT("Semantic label table was not set"));
 		return;
 	}
-	
-	FName AssignedLabelName = NAME_None;
-	SemanticLabelTable->ForeachRow<FSemanticLabel>(TEXT(""), [&AssignedLabelName, Actor](const FName& Key, const FSemanticLabel& Value)
+
+	FName AssignedLabel = NAME_None;
+	int32 ActorLabelId = 0;
+	for (const auto& Elem : ActorLabels)
 	{
-		const FName& LabelName = Key;
-		for (const TSubclassOf<AActor>& ActorType : Value.ActorTypes)
+		const TSubclassOf<AActor>& ActorType = Elem.Key;
+		const FName& ActorLabel = Elem.Value;
+		if (Actor->GetClass()->IsChildOf(ActorType.Get()))
 		{
-			if (Actor->GetClass()->IsChildOf(ActorType.Get()))
+			if (const int32* LabelId = LabelIds.Find(ActorLabel))
 			{
-				if (AssignedLabelName != NAME_None)
+				if (AssignedLabel != NAME_None)
 				{
-					UE_LOG(LogTempoLabels, Error, TEXT("Labels %s and %s have overlapping actor types"), *LabelName.ToString(), *AssignedLabelName.ToString());
-					return;
+					UE_LOG(LogTempoLabels, Error, TEXT("Labels %s and %s have overlapping actor types"), *ActorLabel.ToString(), *AssignedLabel.ToString());
+					continue;
 				}
-				AssignedLabelName = LabelName;
-			
-				TInlineComponentArray<UPrimitiveComponent*> PrimitiveComponents(Actor);
-				for (UPrimitiveComponent* PrimitiveComponent : PrimitiveComponents)
+				AssignedLabel = ActorLabel;
+				ActorLabelId = *LabelId;
+			}
+			else
+			{
+				UE_LOG(LogTempoLabels, Error, TEXT("Label %s did not have an associated ID"), *ActorLabel.ToString());
+			}
+		}
+	}
+
+	TInlineComponentArray<UPrimitiveComponent*> PrimitiveComponents(Actor);
+	for (UPrimitiveComponent* PrimitiveComponent : PrimitiveComponents)
+	{
+		if (const UStaticMeshComponent* StaticMeshComponent = Cast<UStaticMeshComponent>(PrimitiveComponent))
+		{
+			if (UStaticMesh* StaticMesh = StaticMeshComponent->GetStaticMesh())
+			{
+				FString MeshId;
+				StaticMesh->GetMeshId(MeshId);
+				if (const FName* StaticMeshLabel = StaticMeshLabels.Find(MeshId))
 				{
-					PrimitiveComponent->SetRenderCustomDepth(true);
-					PrimitiveComponent->SetCustomDepthStencilValue(Value.Label);
+					if (const int32* StaticMeshLabelId = LabelIds.Find(*StaticMeshLabel))
+					{
+						PrimitiveComponent->SetRenderCustomDepth(true);
+						PrimitiveComponent->SetCustomDepthStencilValue(*StaticMeshLabelId);
+					}
+					else
+					{
+						UE_LOG(LogTempoLabels, Error, TEXT("Label %s did not have an associated ID"), *StaticMeshLabel->ToString());
+					}
+					// Explicit meshes for static mesh labels take precedence over their owning actor's label.
+					continue;
 				}
 			}
 		}
-	});
+
+		if (AssignedLabel != NAME_None)
+		{
+			PrimitiveComponent->SetRenderCustomDepth(true);
+			PrimitiveComponent->SetCustomDepthStencilValue(ActorLabelId);
+		}
+	}
 }

--- a/Plugins/TempoSensors/Source/TempoLabels/Public/TempoActorLabeler.h
+++ b/Plugins/TempoSensors/Source/TempoLabels/Public/TempoActorLabeler.h
@@ -20,10 +20,21 @@ public:
 	virtual void OnWorldBeginPlay(UWorld& InWorld) override;
 
 private:
+	void BuildLabelMaps();
+	
 	void LabelAllActors() const;
 	
 	void LabelActor(AActor* Actor) const;
 
 	UPROPERTY(VisibleAnywhere)
 	UDataTable* SemanticLabelTable;
+
+	UPROPERTY(VisibleAnywhere)
+	TMap<TSubclassOf<AActor>, FName> ActorLabels;
+
+	UPROPERTY(VisibleAnywhere)
+	TMap<FString, FName> StaticMeshLabels;
+
+	UPROPERTY(VisibleAnywhere)
+	TMap<FName, int32> LabelIds;
 };

--- a/Plugins/TempoSensors/Source/TempoLabels/Public/TempoLabelTypes.h
+++ b/Plugins/TempoSensors/Source/TempoLabels/Public/TempoLabelTypes.h
@@ -14,9 +14,13 @@ struct FSemanticLabel: public FTableRowBase
 
 	// The raw label that will be stored in the stencil buffer.
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	int32 Label;
+	int32 Label = 0;
 
 	// The Actor types which should be tagged with this label.
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	TArray<TSubclassOf<AActor>> ActorTypes;
+	TSet<TSubclassOf<AActor>> ActorTypes;
+
+	// The StaticMesh types which should be tagged with this label (overrides labels at the actor level).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TSet<TSoftObjectPtr<UStaticMesh>> StaticMeshTypes;
 };


### PR DESCRIPTION
Adds support for labeling individual StaticMeshComponents differently from their owning Actor. A row of the label table now can set Static Meshes in addition to Actor types that should receive that label. For every component of every actor in the world if its mesh is associated with a label it will get it, otherwise if the Actor itself is associated with a label it will get that one, otherwise it will get none. To make this logic more convenient and efficient I pre-parse the label table into a few maps.