### PR TITLE
gRPC Symbols Export Dynamically from TempoScripting, not from gRPC

### DIFF
--- a/TempoCore/Source/TempoScripting/TempoScripting.Build.cs
+++ b/TempoCore/Source/TempoScripting/TempoScripting.Build.cs
@@ -55,5 +55,19 @@ public class TempoScripting : TempoModuleRules
 			{
 			}
 			);
+		
+		// These definitions are used when building gRPC and must match here so that the headers
+		// we use in the Tempo build match those in the built libraries exactly.
+		// These are here, not in gRPC.Build.cs, because we import the gRPC symbols statically here
+		// but export them dynamically to other modules.
+		PublicDefinitions.Add("ABSL_BUILD_DLL=1");
+		PublicDefinitions.Add("PROTOBUF_USE_DLLS=1");
+		// Defining these privately will cause symbols to be __declspec(dllexport) within TempoScripring
+		// and __declspec(dllimport) from elsewhere.
+		PrivateDefinitions.Add("LIBPROTOBUF_EXPORTS=1");
+		PrivateDefinitions.Add("LIBPROTOC_EXPORTS=1");
+		PrivateDefinitions.Add("GRPC_DLL_EXPORTS=1");
+		PrivateDefinitions.Add("GRPCXX_DLL_EXPORTS=1");
+		PrivateDefinitions.Add("GPR_DLL_EXPORTS=1");
 	}
 }

--- a/TempoCore/Source/ThirdParty/gRPC/gRPC.Build.cs
+++ b/TempoCore/Source/ThirdParty/gRPC/gRPC.Build.cs
@@ -66,16 +66,6 @@ public class gRPC : ModuleRules
         PublicDefinitions.Add("GRPC_ALLOW_EXCEPTIONS=0");
         PublicDefinitions.Add("PROTOBUF_ENABLE_DEBUG_LOGGING_MAY_LEAK_PII=0");
         PublicDefinitions.Add("GOOGLE_PROTOBUF_INTERNAL_DONATE_STEAL_INLINE=0");
-        
-        // These definitions are used when building gRPC and must match here so that the headers
-        // we use in the Tempo build match those in the built libraries exactly.
-        PublicDefinitions.Add("ABSL_BUILD_DLL=1");
-        PublicDefinitions.Add("PROTOBUF_USE_DLLS=1");
-        PublicDefinitions.Add("LIBPROTOBUF_EXPORTS=1");
-        PublicDefinitions.Add("LIBPROTOC_EXPORTS=1");
-        PublicDefinitions.Add("GRPC_DLL_EXPORTS=1");
-        PublicDefinitions.Add("GRPCXX_DLL_EXPORTS=1");
-        PublicDefinitions.Add("GPR_DLL_EXPORTS=1");
 
         ModuleDepPaths moduleDepPaths = GatherDeps();
         PublicIncludePaths.AddRange(moduleDepPaths.HeaderPaths);


### PR DESCRIPTION
A previous attempt to properly export/import gRPC symbols in Tempo was not quite correct, in two ways:
- gRPC symbols are imported statically by TempoScripting, and then re-exported dynamically to the rest of the project. So TempoScripting is the one who should have the preprocessor definitions that create the `__declspec(dllexport/import)` declarations.
- The `*_EXPORTS` definitions should be private to TempoScripting. This will create `__declspec(dllexport)` declarations in the gRPC headers within TempoScripting and `__declspec(dllimport)` declarations elsewhere, as it should be.