### PR TITLE
Unreal 5.4 Updates

### DIFF
--- a/ToolChains/TempoLinuxToolChain.cs
+++ b/ToolChains/TempoLinuxToolChain.cs
@@ -24,14 +24,14 @@ namespace UnrealBuildTool
     //    Mac builds as similar as possible.
     class TempoLinuxToolChain : LinuxToolChain
     {
-        public TempoLinuxToolChain(ReadOnlyTargetRules Target)
-            : this(Target.Architecture, UEBuildPlatform.GetSDK(UnrealTargetPlatform.Linux) as LinuxPlatformSDK, TempoLinuxToolChainClangOptions(Target), Log.Logger)
+        public TempoLinuxToolChain(ReadOnlyTargetRules Target, ILogger Logger)
+            : this(Target.Architecture, UEBuildPlatform.GetSDK(UnrealTargetPlatform.Linux) as LinuxPlatformSDK, TempoLinuxToolChainClangOptions(Target), Logger)
         {
             
         }
 
-        private TempoLinuxToolChain(UnrealArch InArchitecture, LinuxPlatformSDK InSDK, ClangToolChainOptions InOptions, ILogger InLogger)
-            : base(InArchitecture, InSDK, InOptions, InLogger)
+        private TempoLinuxToolChain(UnrealArch InArchitecture, LinuxPlatformSDK InSDK, ClangToolChainOptions InOptions, ILogger Logger)
+            : base(InArchitecture, InSDK, InOptions, Logger)
         {
             
         }

--- a/ToolChains/TempoMacToolChain.cs
+++ b/ToolChains/TempoMacToolChain.cs
@@ -23,14 +23,14 @@ namespace UnrealBuildTool
     //    support the --allow-multiple-definition option.
     class TempoMacToolChain : MacToolChain
     {
-        public TempoMacToolChain(ReadOnlyTargetRules Target)
-            : this(Target.ProjectFile, TempoMacToolChainClangOptions(Target), Log.Logger)
+        public TempoMacToolChain(ReadOnlyTargetRules Target, ILogger Logger)
+            : this(Target, TempoMacToolChainClangOptions(Target), Logger)
         {
             
         }
 
-        private TempoMacToolChain(FileReference? InProjectFile, ClangToolChainOptions InOptions, ILogger InLogger)
-            : base(InProjectFile, InOptions, InLogger)
+        private TempoMacToolChain(ReadOnlyTargetRules Target, ClangToolChainOptions InOptions, ILogger Logger)
+            : base(Target, InOptions, Logger)
         {
             
         }

--- a/ToolChains/TempoVCToolChain.cs
+++ b/ToolChains/TempoVCToolChain.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using EpicGames.Core;
+using Microsoft.Extensions.Logging;
 using UnrealBuildBase;
 
 namespace UnrealBuildTool
@@ -26,8 +27,8 @@ namespace UnrealBuildTool
     //    all the libraries (deduplicated, with many exceptions, its complicated) and explicitly export them all.s
     class TempoVCToolChain : VCToolChain
     {
-        public TempoVCToolChain(ReadOnlyTargetRules Target)
-            : base(Target, Log.Logger)
+        public TempoVCToolChain(ReadOnlyTargetRules Target, ILogger Logger)
+            : base(Target, Logger)
         {
             
         }


### PR DESCRIPTION
Two changes for Unreal 5.4 compatibility:
- Interface for custom toolchains changed a little (added logger to constructor), updating the Tempo toolchains to match
- Added a check that `RHICreateTexture` must be called from the render thread, so move it to the render thread.

Also, I got a crash on Windows similar to the one that led me to introduce TextureRHICopy on Linux. 
Using TextureRHICopy there fixed it too. So, even though it works without it on Mac I'd rather just enable it on all platforms to eliminate the divergence.