### PR TITLE
Resolve ensure Condition with Vulkan by Transitioning Texture Before Copying

### DIFF
--- a/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
+++ b/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
@@ -55,7 +55,7 @@ void UTempoSceneCaptureComponent2D::MaybeCapture()
 void UTempoSceneCaptureComponent2D::InitRenderTarget()
 {
 	TextureTarget = NewObject<UTextureRenderTarget2D>(this);
-	
+
 	TextureTarget->TargetGamma = GetDefault<UTempoSensorsSettings>()->GetSceneCaptureGamma();
 	TextureTarget->RenderTargetFormat = RenderTargetFormat;
 	TextureTarget->bGPUSharedFlag = true;
@@ -87,15 +87,15 @@ void UTempoSceneCaptureComponent2D::InitRenderTarget()
 	ENQUEUE_RENDER_COMMAND(InitCommand)(
 		[Context](FRHICommandList& RHICmdList)
 		{
-			// Create the TextureRHICopy, where we will copy our TextureTarget's resource before reading it on the CPU, due to a Vulkan limitation.
+			// Create the TextureRHICopy, where we will copy our TextureTarget's resource before reading it on the CPU.
 			constexpr ETextureCreateFlags TexCreateFlags = ETextureCreateFlags::Shared | ETextureCreateFlags::CPUReadback;
-		
+
 			const FRHITextureCreateDesc Desc =
 				FRHITextureCreateDesc::Create2D(*Context.Name)
 				.SetExtent(Context.SizeX, Context.SizeY)
 				.SetFormat(Context.PixelFormat)
 				.SetFlags(TexCreateFlags);
-		
+
 			*Context.TextureRHICopy = RHICreateTexture(Desc);
 		});
 }


### PR DESCRIPTION
We hit an `ensure` condition on Linux which makes debugging on that platform impossible. This resolves it by explicitly transitioning our source texture, adding `ERHIAccess::CopySrc`, before copying.

Also adds a check that the source and destination of the texture copy have the same format (returning otherwise) which they sometimes don't on the first frame after a format transition (for example, from depth enabled to depth not enabled).

Tested on Windows, Mac, and Linux in debug mode with the editor.