### PR TITLE
Blue and Red Channels are Reversed When Rendering With Depth

### DIFF
--- a/TempoSensors/Source/TempoCamera/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoCamera/Public/TempoCamera.h
@@ -45,9 +45,9 @@ struct FCameraPixelWithDepth
 {
 	static constexpr bool bSupportsDepth = true;
 	
-	uint8 B() const { return U1; }
+	uint8 B() const { return U3; }
 	uint8 G() const { return U2; }
-	uint8 R() const { return U3; }
+	uint8 R() const { return U1; }
 	
 	uint8 Label() const { return U4; }
 	


### PR DESCRIPTION
The `*_WithDepth` post-process material packs the RGB bytes in the opposite order of the `*_NoDepth` one (RGB instead of BGR). This leads to incorrect color rendering when depth is enabled. Changing this in the materials to match would lead to an awkward layout for the `*_WithDepth`, so instead this corrects it in the pixel format.