### PR TITLE
Move TempoCore-Specific Scripts into TempoCore

### DIFF
--- a/Scripts/PreBuild.bat
+++ b/Scripts/PreBuild.bat
@@ -1,9 +1,0 @@
-@echo off
-
-REM Simply call the individual scripts from the same directory
-bash %~dp0GenProtos.sh %*
-if %errorlevel% neq 0 exit /b %errorlevel%
-bash %~dp0GenAPI.sh %3 %4
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-exit /b 0

--- a/Scripts/PreBuild.sh
+++ b/Scripts/PreBuild.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-# Simply call the individual scripts from the same directory
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-bash "$SCRIPT_DIR/GenProtos.sh" "$@"
-bash "$SCRIPT_DIR/GenAPI.sh" "$3" "$4"

--- a/Scripts/SyncDeps.sh
+++ b/Scripts/SyncDeps.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright Tempo Simulation, LLC. All Rights Reserved
 
 set -e
 

--- a/TempoCore/Scripts/GenAPI.sh
+++ b/TempoCore/Scripts/GenAPI.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright Tempo Simulation, LLC. All Rights Reserved
 
 set -e
 

--- a/TempoCore/Scripts/PreBuild.bat
+++ b/TempoCore/Scripts/PreBuild.bat
@@ -1,0 +1,19 @@
+@echo off
+REM Copyright Tempo Simulation, LLC. All Rights Reserved
+
+if defined TEMPO_SKIP_PREBUILD (
+    if not "%TEMPO_SKIP_PREBUILD%"=="0" (
+        if not "%TEMPO_SKIP_PREBUILD%"=="" (
+            echo Skipping TempoCore prebuild steps because TEMPO_SKIP_PREBUILD is %TEMPO_SKIP_PREBUILD%
+            exit /b 0
+        )
+    )
+)
+
+REM Simply call the individual scripts from the same directory
+bash %~dp0GenProtos.sh %*
+if %errorlevel% neq 0 exit /b %errorlevel%
+bash %~dp0GenAPI.sh %3 %4
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+exit /b 0

--- a/TempoCore/Scripts/PreBuild.sh
+++ b/TempoCore/Scripts/PreBuild.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright Tempo Simulation, LLC. All Rights Reserved
+
+set -e
+
+if [ -n "${TEMPO_SKIP_PREBUILD}" ] && [ "${TEMPO_SKIP_PREBUILD}" != "0" ] && [ "${TEMPO_SKIP_PREBUILD}" != "" ]; then
+    echo "Skipping TempoCore prebuild steps because TEMPO_SKIP_PREBUILD is $TEMPO_SKIP_PREBUILD"
+    exit 0
+fi
+
+# Simply call the individual scripts from the same directory
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+bash "$SCRIPT_DIR/GenProtos.sh" "$@"
+bash "$SCRIPT_DIR/GenAPI.sh" "$3" "$4"

--- a/TempoCore/TempoCore.uplugin
+++ b/TempoCore/TempoCore.uplugin
@@ -38,13 +38,13 @@
 	],
 	"PreBuildSteps": {
 		"Win64": [
-			"$(PluginDir)\\..\\Scripts\\PreBuild.bat \"$(EngineDir)\" \"$(ProjectFile)\" \"$(ProjectDir)\" \"$(PluginDir)\" \"$(TargetName)\" \"$(TargetConfiguration)\" \"$(TargetPlatform)\" \"$(PluginDir)\\Source\\ThirdParty\\gRPC\\Binaries\\Windows\""
+			"$(PluginDir)\\Scripts\\PreBuild.bat \"$(EngineDir)\" \"$(ProjectFile)\" \"$(ProjectDir)\" \"$(PluginDir)\" \"$(TargetName)\" \"$(TargetConfiguration)\" \"$(TargetPlatform)\" \"$(PluginDir)\\Source\\ThirdParty\\gRPC\\Binaries\\Windows\""
 		],
 		"Mac": [
-			"$(PluginDir)/../Scripts/PreBuild.sh \"$(EngineDir)\" \"$(ProjectFile)\" \"$(ProjectDir)\" \"$(PluginDir)\" \"$(TargetName)\" \"$(TargetConfiguration)\" \"$(TargetPlatform)\" \"$(PluginDir)/Source/ThirdParty/gRPC/Binaries/Mac\"",
+			"$(PluginDir)/Scripts/PreBuild.sh \"$(EngineDir)\" \"$(ProjectFile)\" \"$(ProjectDir)\" \"$(PluginDir)\" \"$(TargetName)\" \"$(TargetConfiguration)\" \"$(TargetPlatform)\" \"$(PluginDir)/Source/ThirdParty/gRPC/Binaries/Mac\"",
 		],
 		"Linux": [
-			"$(PluginDir)/../Scripts/PreBuild.sh \"$(EngineDir)\" \"$(ProjectFile)\" \"$(ProjectDir)\" \"$(PluginDir)\" \"$(TargetName)\" \"$(TargetConfiguration)\" \"$(TargetPlatform)\" \"$(PluginDir)/Source/ThirdParty/gRPC/Binaries/Linux\"",
+			"$(PluginDir)/Scripts/PreBuild.sh \"$(EngineDir)\" \"$(ProjectFile)\" \"$(ProjectDir)\" \"$(PluginDir)\" \"$(TargetName)\" \"$(TargetConfiguration)\" \"$(TargetPlatform)\" \"$(PluginDir)/Source/ThirdParty/gRPC/Binaries/Linux\"",
 		]
 	}
 }


### PR DESCRIPTION
- Moves the TempoCore prebuild step scripts into TempoCore itself
- Adds copyright notices
- Corrects visibility of generated protos (headers generated from private protos go in the private folder)
- More thoroughly cleans up (removes directories within the generated directory that are empty after rebuilding)
- `TEMPO_SKIP_PREBUILD` environment variable can skip prebuild steps