### PR TITLE
Fix frequent ZoneLaneTest crash when starting the Editor on Linux.

### DIFF
--- a/External/ZoneGraph/ZoneGraph.uplugin
+++ b/External/ZoneGraph/ZoneGraph.uplugin
@@ -20,7 +20,7 @@
 		{
 			"Name" : "ZoneGraph",
 			"Type" : "Runtime",
-			"LoadingPhase" : "Default"
+			"LoadingPhase" : "EarliestPossible"
 		},
 		{
 			"Name" : "ZoneGraphEditor",
@@ -30,12 +30,12 @@
 		{
 			"Name" : "ZoneGraphTestSuite",
 			"Type" : "UncookedOnly",
-			"LoadingPhase" : "Default"
+			"LoadingPhase" : "EarliestPossible"
 		},
 		{
 			"Name": "ZoneGraphDebug",
 			"Type": "Runtime",
-			"LoadingPhase": "Default"
+			"LoadingPhase": "EarliestPossible"
 		}
 	]
 }

--- a/Scripts/InstallToolChain.sh
+++ b/Scripts/InstallToolChain.sh
@@ -119,6 +119,14 @@ else
     exit 1
   fi
   
+  # Disable the ZoneGraph Engine Plugin so it won't conflict with the ZoneGraph Project Plugin.
+  ZONEGRAPH_ENGINE_PLUGIN_DIR="$UNREAL_ENGINE_PATH/Engine/Plugins/Runtime/ZoneGraph"
+  if [[ -d "$ZONEGRAPH_ENGINE_PLUGIN_DIR" ]]; then
+      DISABLED_ZONEGRAPH_ENGINE_PLUGIN_DIR="$ZONEGRAPH_ENGINE_PLUGIN_DIR.disabled"
+      echo "Disabling ZoneGraph Engine Plugin by renaming it (in place) to ${DISABLED_ZONEGRAPH_ENGINE_PLUGIN_DIR}."
+      mv "$ZONEGRAPH_ENGINE_PLUGIN_DIR" "$DISABLED_ZONEGRAPH_ENGINE_PLUGIN_DIR"
+  fi
+  
   if [ "$1" = "-force" ]; then
     NEEDS_REBUILD='Y'
   fi


### PR DESCRIPTION
Disable the ZoneGraph Engine Plugin by renaming it to "ZoneGraph.disabled".

Then, load the ZoneGraph, ZoneGraphTestSuite, and ZoneGraphDebug modules in the ZoneGraph Project Plugin as early as possible.