### PR TITLE
TempoCore Pre-Build Improvements

### DIFF
--- a/TempoCore/Scripts/GenAPI.sh
+++ b/TempoCore/Scripts/GenAPI.sh
@@ -3,29 +3,30 @@
 
 set -e
 
-PROJECT_ROOT="${1//\\//}"
-PLUGIN_ROOT="${2//\\//}"
+ENGINE_DIR="${1//\\//}"
+PROJECT_ROOT="${2//\\//}"
+PLUGIN_ROOT="${3//\\//}"
 
 echo "Generating Python API..."
 
-# Check for Python
-PYTHON=""
-if ! python3 --version &> /dev/null; then
-  # Maybe it's just called python?
-  if ! python --version &> /dev/null; then
-    echo "Failed to generate Tempo API. Couldn't find python3. Please install (https://www.python.org/downloads/)"
-    exit 1
-  else
-    PYTHON="python"
-  fi
-else
-  PYTHON="python3"
+# Using the Python that comes with Unreal
+if [[ "$OSTYPE" = "msys" ]]; then
+  PYTHON_DIR="$ENGINE_DIR/Binaries/ThirdParty/Python3/Win64"
+elif [[ "$OSTYPE" = "darwin"* ]]; then
+  PYTHON_DIR="$ENGINE_DIR/Binaries/ThirdParty/Python3/Mac/bin"
+elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
+  PYTHON_DIR="$ENGINE_DIR/Binaries/ThirdParty/Python3/Linux/bin"
 fi
 
 # Create and activate the virtual environment to generate the API.
+cd "$PYTHON_DIR"
 VENV_DIR="$PROJECT_ROOT/TempoEnv"
 if [ ! -d "$VENV_DIR" ]; then
-  eval "$PYTHON -m venv $VENV_DIR"
+  if [[ "$OSTYPE" = "msys" ]]; then
+    eval "./python3.exe -m venv $VENV_DIR"
+  else
+    eval "./python3 -m venv $VENV_DIR"
+  fi
 fi
 if [[ "$OSTYPE" = "msys" ]]; then
   source "$VENV_DIR/Scripts/activate"
@@ -38,6 +39,8 @@ set +e # Proceed despite errors from pip. That could just mean the user has no i
 pip install --upgrade pip --quiet --retries 0 # One --quiet to suppress warnings but show errors
 pip install protobuf==4.25.3 --quiet --retries 0 # One --quiet to suppress warnings but show errors
 pip install Jinja2==3.1.3 --quiet --retries 0 # One --quiet to suppress warnings but show errors
+pip install opencv-python==4.10.0.84 --quiet --retries 0 # One --quiet to suppress warnings but show errors
+pip install matplotlib==3.9.2 --quiet --retries 0 # One --quiet to suppress warnings but show errors
 set -e
 
 # Finally build and install the Tempo API (and its dependencies) to the virtual environment.

--- a/TempoCore/Scripts/PreBuild.bat
+++ b/TempoCore/Scripts/PreBuild.bat
@@ -13,7 +13,7 @@ if defined TEMPO_SKIP_PREBUILD (
 REM Simply call the individual scripts from the same directory
 bash %~dp0GenProtos.sh %*
 if %errorlevel% neq 0 exit /b %errorlevel%
-bash %~dp0GenAPI.sh %3 %4
+bash %~dp0GenAPI.sh %1 %3 %4
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 exit /b 0

--- a/TempoCore/Scripts/PreBuild.sh
+++ b/TempoCore/Scripts/PreBuild.sh
@@ -11,4 +11,4 @@ fi
 # Simply call the individual scripts from the same directory
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 bash "$SCRIPT_DIR/GenProtos.sh" "$@"
-bash "$SCRIPT_DIR/GenAPI.sh" "$3" "$4"
+bash "$SCRIPT_DIR/GenAPI.sh" "$1" "$3" "$4"


### PR DESCRIPTION
A few improvements and bug fixes in TempoCore's pre-build steps:
- Fixes a bug where the auto-generated Python wrapper for an RPC would not import all necessary modules
- Change the auto-generated virtual environment to use Unreal's built-in Python
- Add two more packages to the auto-generated virtual environment, opencv and matplotlib
- Speed up GenProtos.sh (from ~10s to ~4s) by making a few changes:
  - Filter the module json to remove non-project and non-c++ modules
  - Store the module json in memory instead of reading it from disk over and over
  - Replace two slow `find` commands with getting the same information from the module json