### PR TITLE
Fix TempoActorLabeler Crash

### DIFF
--- a/TempoSensors/Source/TempoLabels/Private/TempoActorLabeler.cpp
+++ b/TempoSensors/Source/TempoLabels/Private/TempoActorLabeler.cpp
@@ -43,6 +43,15 @@ void UTempoActorLabeler::OnWorldBeginPlay(UWorld& InWorld)
 	});
 }
 
+bool UTempoActorLabeler::ShouldCreateSubsystem(UObject* Outer) const
+{
+	if (Outer->GetWorld()->WorldType == EWorldType::Game || Outer->GetWorld()->WorldType == EWorldType::PIE)
+	{
+		return Super::ShouldCreateSubsystem(Outer);
+	}
+	return false;
+}
+
 void UTempoActorLabeler::BuildLabelMaps()
 {
 	if (!SemanticLabelTable)
@@ -174,6 +183,11 @@ void UTempoActorLabeler::LabelAllComponents(const AActor* Actor, int32 ActorLabe
 
 void UTempoActorLabeler::LabelComponent(UActorComponent* Component)
 {
+	if (!Component->GetOwner() || !(Component->GetWorld()->WorldType == EWorldType::Game || Component->GetWorld()->WorldType == EWorldType::PIE))
+	{
+		return;
+	}
+	
 	if (UPrimitiveComponent* PrimitiveComponent = Cast<UPrimitiveComponent>(Component))
 	{
 		if (const int32* ActorLabelId = LabeledActors.Find(PrimitiveComponent->GetOwner()))

--- a/TempoSensors/Source/TempoLabels/Public/TempoActorLabeler.h
+++ b/TempoSensors/Source/TempoLabels/Public/TempoActorLabeler.h
@@ -19,6 +19,8 @@ class TEMPOLABELS_API UTempoActorLabeler : public UWorldSubsystem
 public:
 	virtual void OnWorldBeginPlay(UWorld& InWorld) override;
 
+	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
+
 protected:
 	void BuildLabelMaps();
 	


### PR DESCRIPTION
Fixes https://github.com/tempo-sim/TempoVayuIssues/issues/29

The root cause of this crash is `LabelComponent` getting called in a non-game world, for example the blueprint editor world, where they owning Actor may be null, which is possible due to subscribing to the global events `UActorComponent::MarkRenderStateDirtyEvent` and `UActorComponent::GlobalCreatePhysicsDelegate`. This fixes the bug by exiting `LabelComponent` early in this case, and also overrides `ShouldCreateSubsystem` to not create the `TempoActorLabeler` at all in non-game worlds.