### PR TITLE
Use Euler Angles not Quats in Geometry Proto

### DIFF
--- a/TempoCore/Source/TempoCoreShared/Public/TempoConversion.h
+++ b/TempoCore/Source/TempoCoreShared/Public/TempoConversion.h
@@ -59,6 +59,11 @@ struct QuantityConverter<UC_NONE, R2L>
     {
         return FQuat(-In.X, In.Y, -In.Z, In.W);
     }
+
+    static FRotator Convert(const FRotator& In)
+    {
+        return FRotator(Convert(In.Quaternion()));
+    }
 };
 
 template<>
@@ -77,6 +82,11 @@ struct QuantityConverter<UC_NONE, L2R>
     static FQuat Convert(const FQuat& In)
     {
         return FQuat(-In.X, In.Y, -In.Z, In.W);
+    }
+
+    static FRotator Convert(const FRotator& In)
+    {
+        return FRotator(Convert(In.Quaternion()));
     }
 };
 

--- a/TempoCore/Source/TempoScripting/Public/Geometry.proto
+++ b/TempoCore/Source/TempoScripting/Public/Geometry.proto
@@ -13,14 +13,13 @@ message Vector {
   double z = 3;
 }
 
-message Quat {
-  double x = 1;
-  double y = 2;
-  double z = 3;
-  double w = 4;
+message Rotation {
+  double r = 1;
+  double p = 2;
+  double y = 3;
 }
 
 message Transform {
   Vector location = 1;
-  Quat rotation = 2;
+  Rotation rotation = 2;
 }


### PR DESCRIPTION
I initially used a quaternion in the geometry transform proto, for the mathematical benefits, but we need a more intuitive angle representation for users writing scripts.