### PR TITLE
Add TempoIntersectionQueryComponent

### DIFF
--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
@@ -16,6 +16,9 @@ class TEMPOAGENTSSHARED_API UTempoIntersectionQueryComponent : public UActorComp
 	GENERATED_BODY()
 
 public:
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetIntersectionEntranceControlPointIndex(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32& OutIntersectionEntranceControlPointIndex) const;
 	
 	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
 	virtual bool TryGetIntersectionEntranceLocation(const AActor* IntersectionQueryActor, int32 ConnectionIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutIntersectionEntranceLocation) const;
@@ -37,8 +40,7 @@ public:
 	virtual bool IsConnectedRoadActor(const AActor* RoadQueryActor) const;
 	
 protected:
-
-	virtual bool TryGetIntersectionEntranceControlPointIndex(const AActor& IntersectionQueryActor, int32 ConnectionIndex, int32& OutIntersectionEntranceControlPointIndex) const;
+	
 	virtual bool TryGetNearestRoadControlPointIndex(const AActor& IntersectionQueryActor, int32 ConnectionIndex, int32& OutNearestRoadControlPointIndex) const;
 	virtual AActor* GetConnectedRoadActor(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const;
 


### PR DESCRIPTION
Bring the Intersection Query logic into Tempo (up from the project level).  Originally, we added this at the project level because it contained a few assumptions about the project's underlying road and intersection representation.  By making these functions virtual, we've removed these few assumptions, while retaining all the useful general logic for reuse.