### PR TITLE
Remove TempoCoreTimeSettingsChanged Subscription in ATempoTimeWorldSettings EndPlay

### DIFF
--- a/TempoCore/Source/TempoTime/Private/TempoTimeWorldSettings.cpp
+++ b/TempoCore/Source/TempoTime/Private/TempoTimeWorldSettings.cpp
@@ -9,8 +9,15 @@ void ATempoTimeWorldSettings::BeginPlay()
 {
 	Super::BeginPlay();
 
-	GetMutableDefault<UTempoCoreSettings>()->TempoCoreTimeSettingsChangedEvent.AddUObject(this, &ATempoTimeWorldSettings::OnTimeSettingsChanged);
+	SettingsChangedHandle = GetMutableDefault<UTempoCoreSettings>()->TempoCoreTimeSettingsChangedEvent.AddUObject(this, &ATempoTimeWorldSettings::OnTimeSettingsChanged);
 	OnTimeSettingsChanged();
+}
+
+void ATempoTimeWorldSettings::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	Super::EndPlay(EndPlayReason);
+
+	GetMutableDefault<UTempoCoreSettings>()->TempoCoreTimeSettingsChangedEvent.Remove(SettingsChangedHandle);
 }
 
 float ATempoTimeWorldSettings::FixupDeltaSeconds(float DeltaSeconds, float RealDeltaSeconds)

--- a/TempoCore/Source/TempoTime/Public/TempoTimeWorldSettings.h
+++ b/TempoCore/Source/TempoTime/Public/TempoTimeWorldSettings.h
@@ -22,6 +22,8 @@ public:
 	
 protected:
 	virtual void BeginPlay() override;
+
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 	
 	virtual float FixupDeltaSeconds(float DeltaSeconds, float RealDeltaSeconds) override;
 	
@@ -39,4 +41,6 @@ private:
 	uint64 FixedStepsCount = 0;
 
 	TOptional<int32> StepsToSimulate;
+
+	FDelegateHandle SettingsChangedHandle;
 };


### PR DESCRIPTION
There is an occasional crash when changing time settings where the TempoTimeWorldSettingsActor gets nullptr from its GetWorld() call. This is related to the world partition system, where apparently one WorldSettings Actor is created per world partition. When the partitions are streamed in and out their EndPlay is called, but they are not destroyed right away, and so still receive events when the time settings are changed, leading to the crash. By removing the subscription to the time settings changed event, we avoid the crash.