### PR TITLE
Fix GenProtos Bug on Windows by Removing Carriage Return Characters

### DIFF
--- a/TempoCore/Scripts/GenProtos.sh
+++ b/TempoCore/Scripts/GenProtos.sh
@@ -276,6 +276,8 @@ GET_MODULE_INCLUDES_PUBLIC_ONLY() {
   
   PUBLIC_DEPENDENCIES=$(echo "$MODULE_INFO" | jq -r --arg module_name "$MODULE_NAME" '.[$module_name] | try .PublicDependencyModules[] // []')
   for PUBLIC_DEPENDENCY in $PUBLIC_DEPENDENCIES; do
+    # Remove any trailing carriage return character
+    PUBLIC_DEPENDENCY="${PUBLIC_DEPENDENCY%$'\r'}"
     if [ -d "$SRC_TEMP_DIR/$PUBLIC_DEPENDENCY" ]; then # Only consider project modules
       if [ -d "$INCLUDES_DIR/$PUBLIC_DEPENDENCY" ]; then
         # We already have this dependency - but still add its public dependencies.
@@ -299,6 +301,8 @@ GET_MODULE_INCLUDES() {
   SYNCPROTOS "$SRC_TEMP_DIR/$MODULE_NAME/Private/" "$INCLUDES_DIR/$MODULE_NAME"
   PUBLIC_DEPENDENCIES=$(echo "$MODULE_INFO" | jq -r --arg module_name "$MODULE_NAME" '.[$module_name] | try .PublicDependencyModules[] // []')
   for PUBLIC_DEPENDENCY in $PUBLIC_DEPENDENCIES; do
+    # Remove any trailing carriage return character
+    PUBLIC_DEPENDENCY="${PUBLIC_DEPENDENCY%$'\r'}"
     if [ -d "$SRC_TEMP_DIR/$PUBLIC_DEPENDENCY" ]; then # Only consider project modules
       if [ -d "$INCLUDES_DIR/$PUBLIC_DEPENDENCY" ]; then
         # We already have this dependency - but still add its public dependencies.
@@ -313,7 +317,9 @@ GET_MODULE_INCLUDES() {
   done
   
   PRIVATE_DEPENDENCIES=$(echo "$MODULE_INFO" | jq -r --arg module_name "$MODULE_NAME" '.[$module_name] | try .PrivateDependencyModules[] // []')
-  for PRIVATE_DEPENDENCY in $PRIVATE_DEPENDENCIES; do   
+  for PRIVATE_DEPENDENCY in $PRIVATE_DEPENDENCIES; do
+    # Remove any trailing carriage return character
+    PRIVATE_DEPENDENCY="${PRIVATE_DEPENDENCY%$'\r'}"
     if [[ -d "$SRC_TEMP_DIR/$PRIVATE_DEPENDENCY" ]]; then # Only consider project modules
       if [[ -d "$INCLUDES_DIR/$PRIVATE_DEPENDENCY" ]]; then
         # We already have this dependency - but still add its public dependencies.


### PR DESCRIPTION
Fixes a Windows-only bug in `GenProtos.sh`, the symptom of which is `EditorProceduralGeneration`'s proto gen step failing because it seems to have a missing dependency on `TempoScripting` (although that dependency does exist). 

The root cause is that on Windows the Public/Private dependency entries in the module info json have a carriage return character at the end, unless they are the last one in their Public/Private section. This carriage return character causes the `GenProtos.sh` script to not find a directory with name corresponding to that dependency. EditorProceduralGeneration simply happens to be the first module we've added which has a dependency on TempoScripting, but does does not list it last in its dependency section and also does not pick up the dependency on TempoScripting via another module's public dependencies.