### PR TITLE
Fix issues when generating Intersection ZoneShapes for asymmetric roads.

### DIFF
--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
@@ -146,6 +146,9 @@ public:
 	TArray<FName> GetTempoIntersectionTags() const;
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetTempoIntersectionEntranceControlPointIndex(int32 ConnectionIndex) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	FVector GetTempoIntersectionEntranceLocation(int32 ConnectionIndex, ETempoCoordinateSpace CoordinateSpace) const;
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")


### PR DESCRIPTION
Two main issues are addressed, here:

1. ZoneGraph LaneProfiles specify lanes from right to left.
2. Intersection ZoneShapePoints for roads that "leave" intersections (ie. roads that have their starting tangent pointing away from a connected intersection) need to reverse their LaneProfiles to ensure proper lane connectivity.