### PR TITLE
Fix wheel rotations for "medium res" Mass Traffic vehicle representations.

### DIFF
--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleComponent.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleComponent.cpp
@@ -60,7 +60,7 @@ void UMassTrafficVehicleComponent::UpdateWheelComponents(const FMassTrafficSimpl
 		if (WheelComponent)
 		{
 			const FVector& WheelLocalLocation = VehicleSim.WheelLocalLocations[WheelIndex];
-			FRotator WheelRotation(FMath::RadiansToDegrees(VehicleSim.WheelSims[WheelIndex].AngularPosition * FMath::Sign(WheelLocalLocation.Y)), VehicleSim.WheelSims[WheelIndex].SteeringAngle, 0.0f); 
+			FRotator WheelRotation(-FMath::RadiansToDegrees(VehicleSim.WheelSims[WheelIndex].AngularPosition), VehicleSim.WheelSims[WheelIndex].SteeringAngle, 0.0f); 
 			FTransform WheelTransform = WheelOffsets[WheelIndex] * FTransform(WheelRotation, WheelLocalLocation);
 			WheelComponent->SetRelativeTransform(WheelTransform);
 		}


### PR DESCRIPTION
The way this issue manifested is that while the vehicles were driving forward, the wheels on the left side would appear to rotate correctly, but the wheels on the right side would rotate in reverse.

This issue occurred in CitySample as well.