### PR TITLE
Add support for manually placed roads and intersections.

### DIFF
--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficIntersectionSpawnDataGenerator.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficIntersectionSpawnDataGenerator.cpp
@@ -687,36 +687,6 @@ void UMassTrafficIntersectionSpawnDataGenerator::Generate(UObject& QueryOwner, T
 		// trying to cross over them.
 		//
 
-		OutIntersectionsSpawnData.IntersectionFragments.RemoveAll(
-			[&](FMassTrafficIntersectionFragment& IntersectionFragment)->bool
-			{
-				FMassTrafficIntersectionDetail* IntersectionDetail = nullptr;
-				{
-					const int32 IntersectionZoneIndex = IntersectionFragment.ZoneIndex;
-					const int32 IntersectionIndex = IntersectionZoneIndex_To_IntersectionIndex[IntersectionZoneIndex];
-					IntersectionDetail = FindIntersectionDetails(IntersectionDetails, IntersectionIndex, "2-Sided Intersection Remover");
-					if (!IntersectionDetail)
-					{
-						return false; // ..(lambda) don't remove it
-					}
-				}
-				
-				if (IntersectionDetail->Sides.Num() > 2 || IntersectionDetail->HasHiddenSides())
-				{
-					return false; // ..(lambda) don't remove it
-				}
-				
-				for (const FMassTrafficIntersectionSide& Side : IntersectionDetail->Sides)
-				{
-					if (Side.CrosswalkLanes.Num() > 0)
-					{
-						return false; // ..(lambda) don't remove it
-					}
-				}
-				
-				return true; // ..(lambda) remove it
-			}
-		);
 
 		
 		//

--- a/External/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphSubsystem.cpp
+++ b/External/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphSubsystem.cpp
@@ -474,6 +474,23 @@ FName UZoneGraphSubsystem::GetTagName(FZoneGraphTag Tag) const
 	return FName();
 }
 
+TArray<FName> UZoneGraphSubsystem::GetTagNamesFromTagMask(const FZoneGraphTagMask& TagMask) const
+{
+	TArray<FName> TagNames;
+	
+	const TConstArrayView<FZoneGraphTagInfo>& TagInfos = GetTagInfos();
+	for (const FZoneGraphTagInfo& TagInfo : TagInfos)
+	{
+		if (TagMask.Contains(TagInfo.Tag))
+		{
+			const FName& TagName = GetTagName(TagInfo.Tag);
+			TagNames.Add(TagName);
+		}
+	}
+
+	return TagNames;
+}
+
 const FZoneGraphTagInfo* UZoneGraphSubsystem::GetTagInfo(FZoneGraphTag Tag) const
 {
 	if (const UZoneGraphSettings* ZoneGraphSettings = GetDefault<UZoneGraphSettings>())

--- a/External/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphSubsystem.h
+++ b/External/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphSubsystem.h
@@ -122,6 +122,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "ZoneGraphSubsystem|Tags")
 	FName GetTagName(FZoneGraphTag Tag) const;
 
+	// Returns the names of all the tags in a given tag mask.
+	UFUNCTION(BlueprintCallable, Category = "ZoneGraphSubsystem|Tags")
+	TArray<FName> GetTagNamesFromTagMask(const FZoneGraphTagMask& TagMask) const;
+
 	// Returns info about a specific tag.
 	const FZoneGraphTagInfo* GetTagInfo(FZoneGraphTag Tag) const;
 

--- a/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
+++ b/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
@@ -398,6 +398,15 @@ FZoneLaneProfile UTempoRoadLaneGraphSubsystem::GetLaneProfileByName(FName LanePr
 
 bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForIntersection(AActor& IntersectionQueryActor) const
 {
+	const bool bShouldGenerateZoneShapes = ITempoIntersectionInterface::Execute_ShouldGenerateZoneShapesForTempoIntersection(&IntersectionQueryActor);
+
+	if (!bShouldGenerateZoneShapes)
+	{
+		// Allow the process to continue since we're meant to skip generating ZoneShapeComponents for this IntersectionQueryActor.
+		UE_LOG(LogTempoAgentsEditor, Display, TEXT("Tempo Lane Graph - Skip generating ZoneShapeComponents for Actor: %s."), *IntersectionQueryActor.GetName());
+		return true;
+	}
+	
 	UZoneShapeComponent* ZoneShapeComponent = NewObject<UZoneShapeComponent>(&IntersectionQueryActor, UZoneShapeComponent::StaticClass());
 	if (!ensureMsgf(ZoneShapeComponent != nullptr, TEXT("Failed to create ZoneShapeComponent when building Intersection for Actor: %s."), *IntersectionQueryActor.GetName()))
 	{
@@ -411,7 +420,7 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForI
 	ZoneShapeComponent->SetPolygonRoutingType(EZoneShapePolygonRoutingType::Bezier);
 
 	// Apply intersection tags.
-	TArray<FName> IntersectionTagNames = ITempoIntersectionInterface::Execute_GetTempoIntersectionTags(&IntersectionQueryActor);
+	const TArray<FName> IntersectionTagNames = ITempoIntersectionInterface::Execute_GetTempoIntersectionTags(&IntersectionQueryActor);
 	for (FName IntersectionTagName : IntersectionTagNames)
 	{
 		const FZoneGraphTag IntersectionTag = GetTagByName(IntersectionTagName);

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
@@ -135,6 +135,9 @@ class TEMPOAGENTSSHARED_API ITempoIntersectionInterface
 public:
 
 	// Connected Road Queries
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	bool ShouldGenerateZoneShapesForTempoIntersection() const;
 	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	int32 GetNumTempoConnections() const;
@@ -171,16 +174,22 @@ public:
 	// Traffic Controller Queries
 	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
-	ETempoTrafficControllerType GetTempoTrafficControllerType() const;
+	bool ShouldSetupTempoTrafficControllerPreviewMeshesInEditor() const;
 	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
-	FTempoTrafficControllerMeshInfo GetTempoTrafficControllerMeshInfo(int32 ConnectionIndex, ETempoTrafficControllerType TrafficControllerType) const;
+	ETempoTrafficControllerType GetTempoTrafficControllerType() const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	UStaticMesh* GetTempoTrafficControllerMesh(int32 ConnectionIndex, ETempoTrafficControllerType TrafficControllerType) const;
 	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	FVector GetTempoTrafficControllerLocation(int32 ConnectionIndex, ETempoTrafficControllerType TrafficControllerType, ETempoCoordinateSpace CoordinateSpace) const;
 	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	FRotator GetTempoTrafficControllerRotation(int32 ConnectionIndex, ETempoTrafficControllerType TrafficControllerType, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FVector GetTempoTrafficControllerScale(int32 ConnectionIndex, ETempoTrafficControllerType TrafficControllerType, ETempoCoordinateSpace CoordinateSpace) const;
 
 	// Traffic Controller Commands
 


### PR DESCRIPTION
Users can manually place road actors (of type `TempoRoadSegmentActor`), which allow them to edit a corresponding spline to describe the flow of the road, then add lane properties in the Details Panel.  By default, the ZoneShapes will be centered about the spline, but you can use the road actor's `LateralOffset` to counter this, if the desired lane configuration requires it.

Once users place enough roads, they can place an intersection actor (of type `TempoIntersectionActor`) in the middle of the area where the roads are about to converge.  Then, they can manually place stop signs or traffic lights (under the `TrafficController_Base` hierarchy).  Finally, they can add an entry on the intersection actor (in the `ConnectedRoadInfos` array) for each connected road, where they can pair the connected road with its stop sign or traffic light.

Note:  For now, users will need to make sure they add the connected roads to the intersection's `ConnectedRoadInfos` array in clockwise order, or the intersection won't function correctly.