### PR TITLE
Use More Robust Hashing Algorithm in SyncDeps

### DIFF
--- a/TempoCore/Source/ThirdParty/ttp_manifest.json
+++ b/TempoCore/Source/ThirdParty/ttp_manifest.json
@@ -3,7 +3,7 @@
   "release": "v0.6",
   "md5_hashes": {
     "Linux": "01fbcee1ab08451bc0326ae9331d4210",
-    "Mac": "078d687b57a14f06db9fd74b6c738f24",
+    "Mac": "c99ed4f480079560bc526734ad59ea37",
     "Windows": "348f4dd61dd7cf55b8f55db0be2131bd",
     "Windows+Linux": "1cdc9bbe3411f4e70e1927530d050b1a"
   }

--- a/TempoCore/Source/ThirdParty/ttp_manifest.json
+++ b/TempoCore/Source/ThirdParty/ttp_manifest.json
@@ -4,7 +4,7 @@
   "md5_hashes": {
     "Linux": "01fbcee1ab08451bc0326ae9331d4210",
     "Mac": "c99ed4f480079560bc526734ad59ea37",
-    "Windows": "348f4dd61dd7cf55b8f55db0be2131bd",
-    "Windows+Linux": "1cdc9bbe3411f4e70e1927530d050b1a"
+    "Windows": "7b98aa719a90e16bc692d786e3516805",
+    "Windows+Linux": "ca76569f57f15345fd9003200decf1ad"
   }
 }

--- a/TempoCore/Source/ThirdParty/ttp_manifest.json
+++ b/TempoCore/Source/ThirdParty/ttp_manifest.json
@@ -2,7 +2,7 @@
   "artifact": "gRPC",
   "release": "v0.6",
   "md5_hashes": {
-    "Linux": "01fbcee1ab08451bc0326ae9331d4210",
+    "Linux": "bb031e8c5a8edfb3f716e206180394d8",
     "Mac": "c99ed4f480079560bc526734ad59ea37",
     "Windows": "7b98aa719a90e16bc692d786e3516805",
     "Windows+Linux": "ca76569f57f15345fd9003200decf1ad"


### PR DESCRIPTION
We noticed an unexpected issue with the hashing algorithm used to detect changes in Tempo's third party dependencies and prompt the user to re-download them. On Mac and Windows - but not Linux - the hashes appeared to be changing over time. That was because on those platforms `ls` formats dates differently depending on how far in the past they are. This switches SyncDeps.sh to use a more robust hashing algorithm, based on `stat` instead of `ls` and updates the hashes for all platforms accordingly.