### PR TITLE
Set Consistent Locale in SyncDeps

### DIFF
--- a/Scripts/SyncDeps.sh
+++ b/Scripts/SyncDeps.sh
@@ -6,6 +6,10 @@
 
 set -e
 
+# Set a consistent locale to ensure hashes computed below are consistent across environments.
+export LANG=C
+export LC_ALL=C
+
 # Check for jq
 if ! which jq &> /dev/null; then
   echo "Couldn't find jq"

--- a/TempoCore/Source/ThirdParty/ttp_manifest.json
+++ b/TempoCore/Source/ThirdParty/ttp_manifest.json
@@ -2,7 +2,7 @@
   "artifact": "gRPC",
   "release": "v0.6",
   "md5_hashes": {
-    "Linux": "bb031e8c5a8edfb3f716e206180394d8",
+    "Linux": "5fcf2f536662dbc20518278c8a0910f9",
     "Mac": "c99ed4f480079560bc526734ad59ea37",
     "Windows": "7b98aa719a90e16bc692d786e3516805",
     "Windows+Linux": "ca76569f57f15345fd9003200decf1ad"


### PR DESCRIPTION
We observed an issue where the hash computed by SyncDeps was not consistent across environments, and the root cause was an inconsistent locale. This sets the locale consistently before running the SyncDeps script, which makes the hashes consistent.

Also updates the Linux hash, where the new locale results in a new hash. It does not seem to affect the hash on Mac, and the hash on Windows was computed with this locale.