### PR TITLE
Improve Identification of Static Actors

### DIFF
--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionControlComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionControlComponent.cpp
@@ -75,7 +75,6 @@ void UTempoIntersectionControlComponent::SetupTrafficControllerMeshData()
 		MeshComponent->SetWorldScale3D(TrafficControllerMeshInfo.MeshScale);
 
 		MeshComponent->SetStaticMesh(TrafficControllerMeshInfo.TrafficControllerMesh);
-		MeshComponent->SetCollisionObjectType(ECC_WorldStatic);
 		MeshComponent->AttachToComponent(OwnerActor->GetRootComponent(), FAttachmentTransformRules::KeepWorldTransform);
 		MeshComponent->RegisterComponent();
 		

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionControlComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionControlComponent.cpp
@@ -75,6 +75,7 @@ void UTempoIntersectionControlComponent::SetupTrafficControllerMeshData()
 		MeshComponent->SetWorldScale3D(TrafficControllerMeshInfo.MeshScale);
 
 		MeshComponent->SetStaticMesh(TrafficControllerMeshInfo.TrafficControllerMesh);
+		MeshComponent->SetCollisionObjectType(ECC_WorldStatic);
 		MeshComponent->AttachToComponent(OwnerActor->GetRootComponent(), FAttachmentTransformRules::KeepWorldTransform);
 		MeshComponent->RegisterComponent();
 		

--- a/TempoWorld/Source/TempoWorld/Private/TempoWorldStateServiceSubsystem.cpp
+++ b/TempoWorld/Source/TempoWorld/Private/TempoWorldStateServiceSubsystem.cpp
@@ -11,7 +11,10 @@
 #include "TempoWorld.h"
 
 #include "EngineUtils.h"
+#include "MassAgentComponent.h"
+#include "MassTrafficVehicleComponent.h"
 #include "GameFramework/GameMode.h"
+#include "GameFramework/MovementComponent.h"
 #include "Kismet/GameplayStatics.h"
 
 using WorldStateService = TempoWorld::WorldStateService::AsyncService;
@@ -80,14 +83,11 @@ TArray<AActor*> GetMatchingActors(const UWorld* World, const ActorStatesNearRequ
 					continue;
 				}
 				// Skip static actors (unless told to include them).
-				TArray<UPrimitiveComponent*> PrimitiveComponents;
-				ActorIt->GetComponents<UPrimitiveComponent>(PrimitiveComponents);
-				const bool bHasDynamicPrimitiveComponents = PrimitiveComponents.FindByPredicate(
-					[](const UPrimitiveComponent* Component)
-					{
-						return Component->GetCollisionObjectType() != ECollisionChannel::ECC_WorldStatic;
-					});
-				if (!Request.include_static() && !bHasDynamicPrimitiveComponents)
+				const bool bHasMovementComponent = ActorIt->GetComponentByClass<UMovementComponent>();
+				const bool bHasMassTrafficVehicleComponent = ActorIt->GetComponentByClass<UMassTrafficVehicleComponent>();
+				const bool bHasMassAgentComponent = ActorIt->GetComponentByClass<UMassAgentComponent>();
+				const bool bIsStatic = !(bHasMovementComponent || bHasMassTrafficVehicleComponent || bHasMassAgentComponent);
+				if (!Request.include_static() && bIsStatic)
 				{
 					continue;
 				}

--- a/TempoWorld/Source/TempoWorld/Private/TempoWorldStateServiceSubsystem.cpp
+++ b/TempoWorld/Source/TempoWorld/Private/TempoWorldStateServiceSubsystem.cpp
@@ -82,8 +82,12 @@ TArray<AActor*> GetMatchingActors(const UWorld* World, const ActorStatesNearRequ
 				// Skip static actors (unless told to include them).
 				TArray<UPrimitiveComponent*> PrimitiveComponents;
 				ActorIt->GetComponents<UPrimitiveComponent>(PrimitiveComponents);
-				const int32 DynamicPrimitiveComponents = PrimitiveComponents.FindLastByPredicate([](const UPrimitiveComponent* Component) { return Component->GetCollisionObjectType() != ECollisionChannel::ECC_WorldStatic; });
-				if (!Request.include_static() && DynamicPrimitiveComponents == INDEX_NONE)
+				const bool bHasOnlyStaticPrimitiveComponents = !PrimitiveComponents.FindByPredicate(
+					[](const UPrimitiveComponent* Component)
+					{
+						return Component->GetCollisionObjectType() != ECollisionChannel::ECC_WorldStatic;
+					});
+				if (!Request.include_static() && bHasOnlyStaticPrimitiveComponents)
 				{
 					continue;
 				}

--- a/TempoWorld/Source/TempoWorld/Private/TempoWorldStateServiceSubsystem.cpp
+++ b/TempoWorld/Source/TempoWorld/Private/TempoWorldStateServiceSubsystem.cpp
@@ -82,12 +82,12 @@ TArray<AActor*> GetMatchingActors(const UWorld* World, const ActorStatesNearRequ
 				// Skip static actors (unless told to include them).
 				TArray<UPrimitiveComponent*> PrimitiveComponents;
 				ActorIt->GetComponents<UPrimitiveComponent>(PrimitiveComponents);
-				const bool bHasOnlyStaticPrimitiveComponents = !PrimitiveComponents.FindByPredicate(
+				const bool bHasDynamicPrimitiveComponents = PrimitiveComponents.FindByPredicate(
 					[](const UPrimitiveComponent* Component)
 					{
 						return Component->GetCollisionObjectType() != ECollisionChannel::ECC_WorldStatic;
 					});
-				if (!Request.include_static() && bHasOnlyStaticPrimitiveComponents)
+				if (!Request.include_static() && !bHasDynamicPrimitiveComponents)
 				{
 					continue;
 				}

--- a/TempoWorld/Source/TempoWorld/Private/TempoWorldStateServiceSubsystem.cpp
+++ b/TempoWorld/Source/TempoWorld/Private/TempoWorldStateServiceSubsystem.cpp
@@ -80,7 +80,10 @@ TArray<AActor*> GetMatchingActors(const UWorld* World, const ActorStatesNearRequ
 					continue;
 				}
 				// Skip static actors (unless told to include them).
-				if (!Request.include_static() && ActorIt->GetRootComponent() && ActorIt->GetRootComponent()->GetCollisionObjectType() == ECollisionChannel::ECC_WorldStatic)
+				TArray<UPrimitiveComponent*> PrimitiveComponents;
+				ActorIt->GetComponents<UPrimitiveComponent>(PrimitiveComponents);
+				const int32 DynamicPrimitiveComponents = PrimitiveComponents.FindLastByPredicate([](const UPrimitiveComponent* Component) { return Component->GetCollisionObjectType() != ECollisionChannel::ECC_WorldStatic; });
+				if (!Request.include_static() && DynamicPrimitiveComponents == INDEX_NONE)
 				{
 					continue;
 				}

--- a/TempoWorld/Source/TempoWorld/TempoWorld.Build.cs
+++ b/TempoWorld/Source/TempoWorld/TempoWorld.Build.cs
@@ -22,8 +22,14 @@ public class TempoWorld : TempoModuleRules
         PrivateDependencyModuleNames.AddRange(
             new string[]
             {
+                // Unreal
                 "CoreUObject",
                 "Engine",
+                "MassActors",
+                "MassEntity",
+                "MassTraffic",
+                "StructUtils",
+                // Tempo
                 "TempoCore",
                 "TempoMovementShared",
             }

--- a/TempoWorld/TempoWorld.uplugin
+++ b/TempoWorld/TempoWorld.uplugin
@@ -31,6 +31,10 @@
 			"Enabled": true
 		},
 		{
+			"Name": "MassGameplay",
+			"Enabled": true
+		},
+		{
 			"Name": "TempoCore",
 			"Enabled": true
 		},


### PR DESCRIPTION
This changes the way we identify static actors when gathering actor states to consider non-static actors to be only those that have a MovementComponent, MassAgentComponent, or MassTrafficVehicleComponent.