### PR TITLE
Use CPATH to Find Python Include Dir

### DIFF
--- a/TempoCore/Scripts/GenAPI.sh
+++ b/TempoCore/Scripts/GenAPI.sh
@@ -10,12 +10,18 @@ PLUGIN_ROOT="${3//\\//}"
 echo "Generating Python API..."
 
 # Using the Python that comes with Unreal
+# Unreal's Python seems to have it's include directory configured incorrectly (`python3-config --include` returns a
+# path to Engine/Binaries/ThirdParty, but the correct include directory is in Engine/Source/ThirdParty).
+# So, we help pip find it, which it may need to in order to build any dependencies from source, with CPATH
 if [[ "$OSTYPE" = "msys" ]]; then
   PYTHON_DIR="$ENGINE_DIR/Binaries/ThirdParty/Python3/Win64"
+  export CPATH="$CPATH:$UNREAL_ENGINE_PATH/Engine/Source/ThirdParty/Python3/Win64/include"
 elif [[ "$OSTYPE" = "darwin"* ]]; then
   PYTHON_DIR="$ENGINE_DIR/Binaries/ThirdParty/Python3/Mac/bin"
+  export CPATH="$CPATH:$UNREAL_ENGINE_PATH/Engine/Source/ThirdParty/Python3/Mac/include"
 elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
   PYTHON_DIR="$ENGINE_DIR/Binaries/ThirdParty/Python3/Linux/bin"
+  export CPATH="$CPATH:$UNREAL_ENGINE_PATH/Engine/Source/ThirdParty/Python3/Linux/include"
 fi
 
 # Create and activate the virtual environment to generate the API.


### PR DESCRIPTION
Unreal's Python seems to have it's include directory configured incorrectly (`Engine/Binaries/ThirdParty/Python3/Mac/bin/python3-config --include` returns a
path to Engine/**Binaries**/ThirdParty, but the correct include directory is in Engine/**Source**/ThirdParty). Pip may need to build certain dependencies from source, and to do so will need the correct Python include path. If users don't have the python3-dev package installed, pip won't find the required files (namely Python.h). So, we can help pip find the required files by adding the correct include directory to the `CPATH` environment variable.