### PR TITLE
Add mechanism to filter lane change candidates by priority on a per-EntityConfig basis.

### DIFF
--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChangingProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChangingProcessor.cpp
@@ -128,6 +128,7 @@ static void TryStartingNewLaneChange(
 		Lane_Current, AgentRadiusFragment_Current, RandomFractionFragment_Current, VehicleControlFragment_Current,
 		RandomStream,
 		MassTrafficSettings,
+		ZoneGraphStorage,
 		/*out*/LaneChangeRecommendation);
 
 	

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleSimulationTrait.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleSimulationTrait.cpp
@@ -54,6 +54,7 @@ void UMassTrafficVehicleSimulationTrait::BuildTemplate(FMassEntityTemplateBuildC
 	VehicleControlFragment.bAllowLeftTurnsAtIntersections = Params.bAllowLeftTurnsAtIntersections;
 	VehicleControlFragment.bAllowRightTurnsAtIntersections = Params.bAllowRightTurnsAtIntersections;
 	VehicleControlFragment.bAllowGoingStraightAtIntersections = Params.bAllowGoingStraightAtIntersections;
+	VehicleControlFragment.LaneChangePriorityFilters = Params.LaneChangePriorityFilters;
 
 	// Variable tick
 	BuildContext.AddFragment<FMassSimulationVariableTickFragment>();

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
@@ -704,6 +704,8 @@ struct MASSTRAFFIC_API FMassTrafficVehicleControlFragment : public FMassFragment
 	bool bAllowRightTurnsAtIntersections = true;
 	bool bAllowGoingStraightAtIntersections = true;
 
+	TArray<FZoneGraphTagFilter> LaneChangePriorityFilters;
+
 	// Fields used for both pre-emptive and reactive yields.
 	FZoneGraphTrafficLaneData* YieldAtIntersectionLane = nullptr;
 

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
@@ -79,6 +79,11 @@ struct FMassTrafficLaneChangeRecommendation
 	
 bool TrunkVehicleLaneCheck(const FZoneGraphTrafficLaneData* TrafficLaneData, const FMassTrafficVehicleControlFragment& VehicleControlFragment);
 
+int32 GetLaneChangePriority(
+	const FZoneGraphTrafficLaneData* TrafficLaneData,
+	const FMassTrafficVehicleControlFragment& VehicleControlFragment,
+	const FZoneGraphStorage& ZoneGraphStorage);
+
 	
 FORCEINLINE bool AreVehiclesCurrentlyApproachingLaneFromIntersection(const FZoneGraphTrafficLaneData& TrafficLaneData) 
 {
@@ -199,6 +204,7 @@ void ChooseLaneForLaneChange(
 	const FMassTrafficVehicleControlFragment& VehicleControlFragment,
 	const FRandomStream& RandomStream,
 	const UMassTrafficSettings& MassTrafficSettings,
+	const FZoneGraphStorage& ZoneGraphStorage,
 	FMassTrafficLaneChangeRecommendation& OutRecommendation);
 
 bool CheckNextVehicle(const FMassEntityHandle Entity, const FMassEntityHandle NextEntity, const FMassEntityManager& EntityManager);

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
@@ -357,53 +357,53 @@ public:
 	float StopSignPedestrianLaneOpenProbability = 0.2f;
 
 	// Lane change mode.
-	UPROPERTY(EditAnywhere, Category="Lane Changing")
+	UPROPERTY(EditAnywhere, Config, Category="Lane Changing")
 	EMassTrafficLaneChangeMode LaneChangeMode = EMassTrafficLaneChangeMode::On;
 
 	// Min seconds until next lane change attempt.
-	UPROPERTY(EditAnywhere, Category="Lane Changing")
+	UPROPERTY(EditAnywhere, Config, Category="Lane Changing")
 	float MinSecondsUntilLaneChangeDecision = 30.0f;
 
 	// Max seconds until next lane change attempt.
-	UPROPERTY(EditAnywhere, Category="Lane Changing")
+	UPROPERTY(EditAnywhere, Config, Category="Lane Changing")
 	float MaxSecondsUntilLaneChangeDecision = 60.0f;
 
 	// Base seconds taken to execute a lane change.
 	// Number of seconds a particular vehicle takes to execute a lane change is calculated as -
 	// BaseSecondsToExecuteLaneChange + AdditionalSecondsToExecuteLaneChangePerUnitOfVehicleLength * VehicleLengthCM
 	// (VehicleLengthCM is twice the vehicle's radius in CM.)
-	UPROPERTY(EditAnywhere, Category="Lane Changing")
+	UPROPERTY(EditAnywhere, Config, Category="Lane Changing")
 	float BaseSecondsToExecuteLaneChange = 3.0f;
 
 	// Additional seconds taken to execute a lane change - seconds per vehicle length (CM.)
 	// Number of seconds a particular vehicle takes to execute a lane change is calculated as -
 	// BaseSecondsToExecuteLaneChange + AdditionalSecondsToExecuteLaneChangePerUnitOfVehicleLength * VehicleLengthCM
 	// (VehicleLengthCM is twice the vehicle's radius in CM.)
-	UPROPERTY(EditAnywhere, Category="Lane Changing")
+	UPROPERTY(EditAnywhere, Config, Category="Lane Changing")
 	float AdditionalSecondsToExecuteLaneChangePerUnitOfVehicleLength = 0.0015f;
 
 	// How many seconds vehicles should wait before retrying an unsuccessful lane change attempt.
-	UPROPERTY(EditAnywhere, Category="Lane Changing")
+	UPROPERTY(EditAnywhere, Config, Category="Lane Changing")
 	float LaneChangeRetrySeconds = 5.0f;
 
 	// How much lane space a vehicle needs to execute a lane change, as a factor of a vehicle's length.
 	// The longer the vehicle, the more space (and time) it needs to change lanes.
-	UPROPERTY(EditAnywhere, Category="Lane Changing")
+	UPROPERTY(EditAnywhere, Config, Category="Lane Changing")
 	float MinLaneChangeDistanceVehicleLengthScale = 5.0f;
 
 	// How much more to scale search distances for points on adjacent lanes, to help cope with possible issues with 
 	// low lane tessellation and/or higher lane curvature.
-	UPROPERTY(EditAnywhere, Category="Lane Changing")
+	UPROPERTY(EditAnywhere, Config, Category="Lane Changing")
 	float LaneChangeSearchDistanceScale = 1.5f;
 
 	// How much to spread transverse lanes changes, as a fraction of the lane length measured from the
 	// start of the lane.
-	UPROPERTY(EditAnywhere, Category="Lane Changing")
+	UPROPERTY(EditAnywhere, Config, Category="Lane Changing")
 	float LaneChangeTransverseSpreadFromStartOfLaneFraction = 0.4f;
 
 	// Max length of accessories on sides of car - objects like side-mirrors (CM). Helps when trying to pass another
 	// vehicle.
-	UPROPERTY(EditAnywhere, Category="Lane Changing")
+	UPROPERTY(EditAnywhere, Config, Category="Lane Changing")
 	float LaneChangeMaxSideAccessoryLength = 10.0f;
 
 	// Normalized distance *potentially yielding* vehicle is allowed to travel through *left turn* lanes

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficVehicleSimulationTrait.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficVehicleSimulationTrait.h
@@ -53,6 +53,9 @@ struct MASSTRAFFIC_API FMassTrafficVehicleSimulationParameters : public FMassSha
 	UPROPERTY(EditAnywhere, Category = "Restrictions")
 	bool bAllowGoingStraightAtIntersections = true;
 
+	UPROPERTY(EditAnywhere, Category = "Restrictions")
+	TArray<FZoneGraphTagFilter> LaneChangePriorityFilters;
+
 	/** Actor class of this agent when spawned in high resolution */
 	UPROPERTY(EditAnywhere, Category = "Physics")
 	TSubclassOf<AWheeledVehiclePawn> PhysicsVehicleTemplateActor;


### PR DESCRIPTION
The `LaneChangePriorityFilters` array on the `UMassTrafficVehicleSimulationTrait` allows the user to define a set of filters (based on "Any", "All", and "Not" tags) to restrict the lanes onto which each vehicle is allowed to change.  The priority is highest for the filter at index 0 and less for each subsequent index.