### PR TITLE
Fix Time Bugs

### DIFF
--- a/TempoCore/Source/TempoCoreShared/Private/TempoCoreSettings.cpp
+++ b/TempoCore/Source/TempoCoreShared/Private/TempoCoreSettings.cpp
@@ -17,20 +17,25 @@ void UTempoCoreSettings::SetTimeMode(ETimeMode TimeModeIn)
 {
 	TimeMode = TimeModeIn;
 
-#if WITH_EDITOR
-	FPropertyChangedEvent PropertyChangedEvent(
-		GetClass()->FindPropertyByName(GET_MEMBER_NAME_CHECKED(UTempoCoreSettings, TimeMode)));
-	OnSettingChanged().Broadcast(this, PropertyChangedEvent);
-#endif
+	TempoCoreTimeSettingsChangedEvent.Broadcast();
 }
 
 void UTempoCoreSettings::SetSimulatedStepsPerSecond(int32 SimulatedStepsPerSecondIn)
 {
 	SimulatedStepsPerSecond = SimulatedStepsPerSecondIn;
 
-#if WITH_EDITOR
-	FPropertyChangedEvent PropertyChangedEvent(
-		GetClass()->FindPropertyByName(GET_MEMBER_NAME_CHECKED(UTempoCoreSettings, SimulatedStepsPerSecond)));
-	OnSettingChanged().Broadcast(this, PropertyChangedEvent);
-#endif
+	TempoCoreTimeSettingsChangedEvent.Broadcast();
 }
+
+#if WITH_EDITOR
+void UTempoCoreSettings::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+	Super::PostEditChangeProperty(PropertyChangedEvent);
+	
+	if (PropertyChangedEvent.Property->GetName() == GET_MEMBER_NAME_CHECKED(UTempoCoreSettings, TimeMode) ||
+		(TimeMode == ETimeMode::FixedStep && PropertyChangedEvent.Property->GetName() == GET_MEMBER_NAME_CHECKED(UTempoCoreSettings, SimulatedStepsPerSecond)))
+	{
+		TempoCoreTimeSettingsChangedEvent.Broadcast();
+	}
+}
+#endif

--- a/TempoCore/Source/TempoCoreShared/Public/TempoCoreSettings.h
+++ b/TempoCore/Source/TempoCoreShared/Public/TempoCoreSettings.h
@@ -9,6 +9,8 @@
 
 #include "TempoCoreSettings.generated.h"
 
+DECLARE_MULTICAST_DELEGATE(FTempoCoreTimeSettingsChanged);
+
 UCLASS(Config=Game)
 class TEMPOCORESHARED_API UTempoCoreSettings : public UDeveloperSettings
 {
@@ -23,6 +25,7 @@ public:
 	void SetSimulatedStepsPerSecond(int32 SimulatedStepsPerSecondIn);
 	ETimeMode GetTimeMode() const { return TimeMode; }
 	int32 GetSimulatedStepsPerSecond() const { return SimulatedStepsPerSecond; }
+	FTempoCoreTimeSettingsChanged TempoCoreTimeSettingsChangedEvent;
 
 	// Scripting Settings.
 	int32 GetScriptingPort() const { return ScriptingPort; }
@@ -30,9 +33,11 @@ public:
 	int32 GetMaxEventProcessingTime() const { return MaxEventProcessingTimeMicroSeconds; }
 	int32 GetMaxEventWaitTime() const { return MaxEventWaitTimeNanoSeconds; }
 
+#if WITH_EDITOR
+	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+#endif
+
 #if WITH_EDITORONLY_DATA
-	static FName GetSimulatedStepsPerSecondMemberName() { return GET_MEMBER_NAME_CHECKED(UTempoCoreSettings, SimulatedStepsPerSecond); }
-	static FName GetTimeModeMemberName() { return GET_MEMBER_NAME_CHECKED(UTempoCoreSettings, TimeMode); }
 	static FName GetScriptingPortMemberName() { return GET_MEMBER_NAME_CHECKED(UTempoCoreSettings, ScriptingPort); }
 	static FName GetScriptingCompressionLevelMemberName() { return GET_MEMBER_NAME_CHECKED(UTempoCoreSettings, ScriptingCompressionLevel); }
 #endif

--- a/TempoCore/Source/TempoTime/Private/TempoTimeWidget.cpp
+++ b/TempoCore/Source/TempoTime/Private/TempoTimeWidget.cpp
@@ -156,7 +156,7 @@ void UTempoTimeWidget::OnPlayPressed()
 	}
 	else
 	{
-		UE_LOG(LogTempoTime, Error, TEXT("Failed to pause (could not find player controller)"));
+		UE_LOG(LogTempoTime, Error, TEXT("Failed to unpause (could not find player controller)"));
 	}
 }
 

--- a/TempoCore/Source/TempoTime/Public/TempoTimeWidget.h
+++ b/TempoCore/Source/TempoTime/Public/TempoTimeWidget.h
@@ -39,11 +39,7 @@ protected:
 	UPROPERTY(meta=(BindWidget))
 	UTextBlock* SimTimeBox;
 
-private:
-#if WITH_EDITOR
-	void OnTempoCoreSettingsChanged(UObject* Object, FPropertyChangedEvent& PropertyChangedEvent) const;
-#endif
-	
+private:	
 	void SyncTimeSettings() const;
 
 	UFUNCTION()

--- a/TempoCore/Source/TempoTime/Public/TempoTimeWorldSettings.h
+++ b/TempoCore/Source/TempoTime/Public/TempoTimeWorldSettings.h
@@ -18,21 +18,21 @@ class TEMPOTIME_API ATempoTimeWorldSettings : public AWorldSettings
 public:
 	void Step(int32 NumSteps=1);
 
-	void SetPaused(bool bPaused);
-	
+	virtual void SetPauserPlayerState(APlayerState* PlayerState) override;
+
 protected:
 	virtual void BeginPlay() override;
 
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
-	
-	virtual float FixupDeltaSeconds(float DeltaSeconds, float RealDeltaSeconds) override;
-	
-private:
-#if WITH_EDITOR
-	void OnTempoCoreSettingsChanged(UObject* Object, FPropertyChangedEvent& PropertyChangedEvent);
-#endif
 
-	void OnTimeSettingsChanged();
+	virtual float FixupDeltaSeconds(float DeltaSeconds, float RealDeltaSeconds) override;
+
+	virtual void SetPaused(bool bPaused);
+
+	virtual void OnUnpaused();
+
+private:
+	void SyncFixedPointTime();
 	
 	UPROPERTY(VisibleAnywhere)
 	uint64 CyclesWhenTimeModeChanged = 0;


### PR DESCRIPTION
Fixes https://github.com/tempo-sim/Tempo/issues/160

The bug was introduced by https://github.com/tempo-sim/Tempo/pull/155, which removed `TempoCoreTimeSettingsChangedEvent` in favor of `UDeveloperSettings::OnSettingChanged`. It is incorrect to use this for the time settings as we support changing these settings in the packaged binary (through UI or scripting) but `OnSettingChanged` is editor only. We do not allow changing scripting settings in the packaged binary so `OnSettingChanged` is fine to use there.

While attempting to fix this bug I made related improvements:
- `TempoTimeWorldSettings` expected users to call its `SetPaused` method to pause and unpause the game. Pausing through other means would cause errors. Now `TempoTimeWorldSettings` overrides `SetPauserPlayerState` instead to detect all pauses.
- `TempoCoreTimeService` does not notify the user when APIs aren't available when `TempoTimeWorldSettings` isn't being used.