### PR TITLE
Add Support for Setting Properties Within Structs

### DIFF
--- a/TempoWorld/Source/TempoWorld/Private/TempoActorControlServiceSubsystem.cpp
+++ b/TempoWorld/Source/TempoWorld/Private/TempoActorControlServiceSubsystem.cpp
@@ -406,9 +406,9 @@ void MarkRenderStateDirty(UObject* Object)
 	{
 		Actor->MarkComponentsRenderStateDirty();
 	}
-	else if (UActorComponent* Component = Cast<UActorComponent>(Object))
+	else if (USceneComponent* SceneComponent = Cast<USceneComponent>(Object))
 	{
-		Component->MarkRenderStateDirty();
+		SceneComponent->MarkRenderStateDirty();
 	}
 }
 


### PR DESCRIPTION
Allows the TempoWorld API to get properties within structs and to set them with a `Struct.Property` nomenclature, supporting arbitrarily deep nesting of structs.