### PR TITLE
Fix Bug in Engine Mods Plugin Patching

### DIFF
--- a/EngineMods/EngineMods.json
+++ b/EngineMods/EngineMods.json
@@ -10,9 +10,7 @@
         "ToolChain/TempoVCToolChain.cs.2"
       ],
       "Patch": [
-        [
-          "Configuration/UEBuildTarget.cs.patch.2"
-        ]
+        "Configuration/UEBuildTarget.cs.patch.2"
       ],
       "Remove": [
         "Tempo/TempoModuleRules.cs",
@@ -25,9 +23,7 @@
       "Type": "Plugin",
       "Root": "Engine/Plugins/Runtime/ZoneGraph",
       "Patch": [
-        [
           "ZoneGraph.patch.2"
-        ]
       ]
     }
   ],

--- a/EngineMods/README.md
+++ b/EngineMods/README.md
@@ -9,5 +9,9 @@ Different versions of each mod may be necessary for different Major.Minor versio
 It is unlikely but not impossible that an Unreal hotfix release may break one of these mods. We will address that if it happens.
 
 > [!Note]
-> You can generate a new patch with a command like this:
-> `diff -urN <original> <new> > <patch>`
+> To generate a new patch, run a diff command from the unmodified engine folder you want to patch. For example, to generate a patch for the `Source` folder in the `MyPlugin` directory:
+> 
+> ```
+> cd $UNREAL_ENGINE_PATH/Engine/Plugins/MyPlugin
+> diff -urN --strip-trailing-cr Source <modified_plugin_root>/Source > MyPlugin.patch.1
+```


### PR DESCRIPTION
There is a bug in the engine mods script. When I wrote it I think I was trying to treat the `Patch` section as an array of arrays, each of which is an ordered set of patches. So for a given type, say "plugin" you could have one array of patches for each plugin you want to modify. But that wouldn't have worked in practice, because the whole "plugins" type is already associated with only one plugin.

Instead, we can simply allow having more than one mod of each type (two "plugin" mods for example), each with their own root and array of patches.