### PR TITLE
Control Wheeled Vehicle Pawns with TempoMovement

### DIFF
--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficMovement.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficMovement.cpp
@@ -390,7 +390,7 @@ float TimeToCollisionBox2D(
 	const FTransform& ObstacleTransform, const FVector& ObstacleVelocity, const FBox2D& ObstacleBox)
 {
 	const FBox AgentWorldBox = FBox(FVector(AgentBox.Min, 0.0), FVector(AgentBox.Max, 0.0)).TransformBy(AgentTransform);
-	const FBox ObstacleWorldBox = FBox(FVector(ObstacleBox.Min, 0.0), FVector(ObstacleBox.Max, 0.0)).TransformBy(AgentTransform);
+	const FBox ObstacleWorldBox = FBox(FVector(ObstacleBox.Min, 0.0), FVector(ObstacleBox.Max, 0.0)).TransformBy(ObstacleTransform);
 	if (AgentWorldBox.IntersectXY(ObstacleWorldBox))
 	{
 		// Already colliding

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficMovement.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficMovement.cpp
@@ -313,7 +313,7 @@ void UpdateYieldAtIntersectionState(
 	// If we should yield, but we're currently not yielding, ...
 	if (bShouldYieldAtIntersection && !VehicleControlFragment.IsYieldingAtIntersection())
 	{
-		// ensureMsgf(VehicleControlFragment.YieldAtIntersectionLane == nullptr, TEXT("Vehicle is entering \"yield at intersection\" state.  VehicleControlFragment.YieldAtIntersectionLane should be nullptr."));
+		ensureMsgf(VehicleControlFragment.YieldAtIntersectionLane == nullptr, TEXT("Vehicle is entering \"yield at intersection\" state.  VehicleControlFragment.YieldAtIntersectionLane should be nullptr."));
 		
 		// Increase the lane's yield count.
 		if (CurrentLaneData != nullptr)
@@ -328,7 +328,7 @@ void UpdateYieldAtIntersectionState(
 	// Otherwise, if we are currently yielding, ...
 	else if (VehicleControlFragment.IsYieldingAtIntersection())
 	{
-		// ensureMsgf(VehicleControlFragment.YieldAtIntersectionLane != nullptr, TEXT("Vehicle is in \"yield at intersection\" state.  VehicleControlFragment.YieldAtIntersectionLane should not be nullptr."));
+		ensureMsgf(VehicleControlFragment.YieldAtIntersectionLane != nullptr, TEXT("Vehicle is in \"yield at intersection\" state.  VehicleControlFragment.YieldAtIntersectionLane should not be nullptr."));
 
 		// If our current lane is different from the lane we started to yield on, we assume that we moved onto a new lane
 		// as we slowed to a stop for our yield.  So, we transfer "ownership" of our contribution to the yield count
@@ -538,7 +538,7 @@ void MoveVehicleToNextLane(
 	// that was incremented in SetIsVehicleReadyToUseNextIntersectionLane.
 	if (NewCurrentLane.ConstData.bIsIntersectionLane)	// (See all READYLANE.)
 	{
-		// ensureMsgf(&NewCurrentLane == VehicleControlFragment.ReadiedNextIntersectionLane, TEXT("Should be decrementing the \"ready\" count of the same intersection lane that we readied."));
+		ensureMsgf(&NewCurrentLane == VehicleControlFragment.ReadiedNextIntersectionLane, TEXT("Should be decrementing the \"ready\" count of the same intersection lane that we readied."));
 		NewCurrentLane.DecrementNumVehiclesReadyToUseIntersectionLane();
 		
 		// Clear our readied next intersection lane.

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficUpdateDistanceToNearestObstacleProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficUpdateDistanceToNearestObstacleProcessor.cpp
@@ -72,6 +72,7 @@ void UMassTrafficUpdateDistanceToNearestObstacleProcessor::Execute(FMassEntityMa
 				// Debug
 				bool bVisLog = OptionalDebugFragments.IsEmpty() ? false : OptionalDebugFragments[Index].bVisLog > 0;
 
+			
 				auto CanNextVehicleBeForgotten = [&](
 					const FMassTrafficVehicleSimulationParameters& NextSimulationParams,
 					const FTransformFragment& NextTransformFragment,

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficUpdateDistanceToNearestObstacleProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficUpdateDistanceToNearestObstacleProcessor.cpp
@@ -335,8 +335,8 @@ void UMassTrafficUpdateDistanceToNearestObstacleProcessor::Execute(FMassEntityMa
 							float TimeToCollidingObstacle = TNumericLimits<float>::Max();
 							if (OptionalObstacleVehicleSimulationFragment)
 							{
-								const FVector2D AgentExtents(SimulationParams.HalfWidth, SimulationParams.HalfLength);
-								const FVector2D ObstacleExtents(OptionalObstacleVehicleSimulationFragment->HalfWidth, OptionalObstacleVehicleSimulationFragment->HalfLength);
+								const FVector2D AgentExtents(SimulationParams.HalfLength, SimulationParams.HalfWidth);
+								const FVector2D ObstacleExtents(OptionalObstacleVehicleSimulationFragment->HalfLength, OptionalObstacleVehicleSimulationFragment->HalfWidth);
 								TimeToCollidingObstacle = UE::MassTraffic::TimeToCollisionBox2D(
 									TransformFragment.GetTransform(), IdealVelocity, FBox2D(-AgentExtents, AgentExtents),
 									ObstacleTransformFragment.GetTransform(), ObstacleVelocityFragment.Value, FBox2D(-ObstacleExtents, ObstacleExtents));

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficUpdateDistanceToNearestObstacleProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficUpdateDistanceToNearestObstacleProcessor.cpp
@@ -334,13 +334,15 @@ void UMassTrafficUpdateDistanceToNearestObstacleProcessor::Execute(FMassEntityMa
 							float TimeToCollidingObstacle = TNumericLimits<float>::Max();
 							if (OptionalObstacleVehicleSimulationFragment)
 							{
-								TimeToCollidingObstacle = UE::MassTraffic::TimeToCollision2D(
-									TransformFragment.GetTransform(), IdealVelocity, SimulationParams.HalfWidth, SimulationParams.HalfLength,
-									ObstacleTransformFragment.GetTransform(), ObstacleVelocityFragment.Value, OptionalObstacleVehicleSimulationFragment->HalfWidth, OptionalObstacleVehicleSimulationFragment->HalfLength);
+								const FVector2D AgentExtents(SimulationParams.HalfWidth, SimulationParams.HalfLength);
+								const FVector2D ObstacleExtents(OptionalObstacleVehicleSimulationFragment->HalfWidth, OptionalObstacleVehicleSimulationFragment->HalfLength);
+								TimeToCollidingObstacle = UE::MassTraffic::TimeToCollisionBox2D(
+									TransformFragment.GetTransform(), IdealVelocity, FBox2D(-AgentExtents, AgentExtents),
+									ObstacleTransformFragment.GetTransform(), ObstacleVelocityFragment.Value, FBox2D(-ObstacleExtents, ObstacleExtents));
 							}
 							else
 							{
-								TimeToCollidingObstacle = UE::MassTraffic::TimeToCollision(
+								TimeToCollidingObstacle = UE::MassTraffic::TimeToCollisionSphere(
 									TransformFragment.GetTransform().GetLocation(), IdealVelocity, AgentRadiusFragment.Radius,
 									ObstacleTransformFragment.GetTransform().GetLocation(), ObstacleVelocityFragment.Value, ObstacleAgentRadiusFragment.Radius);
 							}

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficMovement.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficMovement.h
@@ -165,8 +165,10 @@ MASSTRAFFIC_API void UpdateYieldAtIntersectionState(
 	const bool bShouldGiveOpportunityForTurningVehiclesToReactivelyYieldAtIntersection);
 
 /** Avoidance */
-	
+
 MASSTRAFFIC_API float TimeToCollision(const FVector& AgentLocation, const FVector& AgentVelocity, float AgentRadius, const FVector& ObstacleLocation, const FVector& ObstacleVelocity, float ObstacleRadius);
+
+MASSTRAFFIC_API float TimeToCollision2D(const FTransform& AgentTransform, const FVector& AgentVelocity, float AgentHalfWidth, float AgentHalfLength, const FTransform& ObstacleTransform, const FVector& ObstacleVelocity, float ObstacleHalfWidth, float ObstacleHalfLength);
 
 /** Lane location eval */
 

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficMovement.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficMovement.h
@@ -166,9 +166,9 @@ MASSTRAFFIC_API void UpdateYieldAtIntersectionState(
 
 /** Avoidance */
 
-MASSTRAFFIC_API float TimeToCollision(const FVector& AgentLocation, const FVector& AgentVelocity, float AgentRadius, const FVector& ObstacleLocation, const FVector& ObstacleVelocity, float ObstacleRadius);
+MASSTRAFFIC_API float TimeToCollisionSphere(const FVector& AgentLocation, const FVector& AgentVelocity, float AgentRadius, const FVector& ObstacleLocation, const FVector& ObstacleVelocity, float ObstacleRadius);
 
-MASSTRAFFIC_API float TimeToCollision2D(const FTransform& AgentTransform, const FVector& AgentVelocity, float AgentHalfWidth, float AgentHalfLength, const FTransform& ObstacleTransform, const FVector& ObstacleVelocity, float ObstacleHalfWidth, float ObstacleHalfLength);
+MASSTRAFFIC_API float TimeToCollisionBox2D(const FTransform& AgentTransform, const FVector& AgentVelocity, const FBox2D& AgentBox, const FTransform& ObstacleTransform, const FVector& ObstacleVelocity, const FBox2D& ObstacleBox);
 
 /** Lane location eval */
 

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficVehicleSimulationTrait.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficVehicleSimulationTrait.h
@@ -55,6 +55,12 @@ struct MASSTRAFFIC_API FMassTrafficVehicleSimulationParameters : public FMassSha
 
 	UPROPERTY(EditAnywhere, Category = "Restrictions")
 	TArray<FZoneGraphTagFilter> LaneChangePriorityFilters;
+};
+
+USTRUCT()
+struct MASSTRAFFIC_API FMassTrafficVehiclePhysicsParameters : public FMassSharedFragment
+{
+	GENERATED_BODY()
 
 	/** Actor class of this agent when spawned in high resolution */
 	UPROPERTY(EditAnywhere, Category = "Physics")
@@ -75,6 +81,21 @@ public:
 
 	UPROPERTY(EditAnywhere, Category = "Variable Tick")
 	FMassSimulationVariableTickParameters VariableTickParams;
+
+	virtual void BuildTemplate(FMassEntityTemplateBuildContext& BuildContext, const UWorld& World) const override;
+};
+
+UCLASS(meta=(DisplayName="Traffic Vehicle Simulation Mass Control"))
+class MASSTRAFFIC_API UMassTrafficVehicleSimulationMassControlTrait : public UMassEntityTraitBase
+{
+	GENERATED_BODY()
+
+public:
+
+	UMassTrafficVehicleSimulationMassControlTrait(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
+
+	UPROPERTY(EditAnywhere, Category = "Mass Traffic")
+	FMassTrafficVehiclePhysicsParameters PhysicsParams;
 
 	virtual void BuildTemplate(FMassEntityTemplateBuildContext& BuildContext, const UWorld& World) const override;
 };

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoMassAgentSyncTraits.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoMassAgentSyncTraits.cpp
@@ -3,6 +3,7 @@
 #include "TempoMassAgentSyncTraits.h"
 
 #include "MassEntityTemplateRegistry.h"
+#include "MassExecutionContext.h"
 #include "MassTrafficFragments.h"
 #include "TempoBrightnessMeter.h"
 #include "TempoBrightnessTranslator.h"
@@ -51,5 +52,110 @@ void UTempoMassAgentBrightnessMeterSyncTrait::BuildTemplate(FMassEntityTemplateB
 	if (EnumHasAnyFlags(SyncDirection, EMassTranslationDirection::MassToActor))
 	{
 		ensureMsgf(false, TEXT("Actor must be the authority.  Entity as the authority is not currently supported."));
+	}
+}
+
+//----------------------------------------------------------------------//
+// UTempoMassSceneComponentTransformToMassTranslator
+//----------------------------------------------------------------------//
+UTempoMassSceneComponentTransformToMassTranslator::UTempoMassSceneComponentTransformToMassTranslator()
+	: EntityQuery(*this)
+{
+	ExecutionFlags = (int32)EProcessorExecutionFlags::AllNetModes;
+	RequiredTags.Add<FTempoMassTransformCopyToMassTag>();
+	ExecutionOrder.ExecuteInGroup = UE::Mass::ProcessorGroupNames::SyncWorldToMass;
+}
+
+void UTempoMassSceneComponentTransformToMassTranslator::ConfigureQueries()
+{
+	AddRequiredTagsToQuery(EntityQuery);
+	EntityQuery.AddRequirement<FSceneComponentWrapperFragment>(EMassFragmentAccess::ReadOnly);
+	EntityQuery.AddRequirement<FTransformFragment>(EMassFragmentAccess::ReadWrite);
+}
+
+void UTempoMassSceneComponentTransformToMassTranslator::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
+{
+	EntityQuery.ForEachEntityChunk(EntityManager, Context, [this](FMassExecutionContext& Context)
+		{
+			const TConstArrayView<FSceneComponentWrapperFragment> CapsuleComponentList = Context.GetFragmentView<FSceneComponentWrapperFragment>();
+			const TArrayView<FTransformFragment> LocationList = Context.GetMutableFragmentView<FTransformFragment>();
+			for (int i = 0; i < CapsuleComponentList.Num(); ++i)
+			{
+				if (const USceneComponent* SceneComp = CapsuleComponentList[i].Component.Get())
+				{
+					LocationList[i].GetMutableTransform() = SceneComp->GetComponentTransform();
+				}
+			}
+		});
+}
+
+//----------------------------------------------------------------------//
+// UTempoMassTransformToSceneComponentTranslator
+//----------------------------------------------------------------------//
+UTempoMassTransformToSceneComponentTranslator::UTempoMassTransformToSceneComponentTranslator()
+	: EntityQuery(*this)
+{
+	ExecutionFlags = (int32)EProcessorExecutionFlags::AllNetModes;
+	RequiredTags.Add<FTempoMassTransformCopyToAgentTag>();
+	ExecutionOrder.ExecuteInGroup = UE::Mass::ProcessorGroupNames::UpdateWorldFromMass;
+	ExecutionOrder.ExecuteAfter.Add(UE::Mass::ProcessorGroupNames::Movement);
+	bRequiresGameThreadExecution = true;
+}
+
+void UTempoMassTransformToSceneComponentTranslator::ConfigureQueries()
+{
+	AddRequiredTagsToQuery(EntityQuery);
+	EntityQuery.AddRequirement<FSceneComponentWrapperFragment>(EMassFragmentAccess::ReadWrite);
+	EntityQuery.AddRequirement<FTransformFragment>(EMassFragmentAccess::ReadOnly);
+	EntityQuery.RequireMutatingWorldAccess(); // due to mutating World by setting component transform
+}
+
+void UTempoMassTransformToSceneComponentTranslator::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
+{
+	EntityQuery.ForEachEntityChunk(EntityManager, Context, [this](FMassExecutionContext& Context)
+		{
+			const TArrayView<FSceneComponentWrapperFragment> SceneComponentList = Context.GetMutableFragmentView<FSceneComponentWrapperFragment>();
+			const TConstArrayView<FTransformFragment> LocationList = Context.GetFragmentView<FTransformFragment>();
+			for (int i = 0; i < SceneComponentList.Num(); ++i)
+			{
+				if (USceneComponent* SceneComp = SceneComponentList[i].Component.Get())
+				{
+					SceneComp->SetWorldTransform(LocationList[i].GetTransform(), /*bSweep=*/false);
+				}
+			}
+		});
+}
+
+//----------------------------------------------------------------------//
+//  UMassAgentTransformSyncTrait
+//----------------------------------------------------------------------//
+void UMassAgentTransformSyncTrait::BuildTemplate(FMassEntityTemplateBuildContext& BuildContext, const UWorld& World) const
+{
+	BuildContext.AddFragment<FSceneComponentWrapperFragment>();
+	BuildContext.RequireFragment<FTransformFragment>();
+
+	BuildContext.GetMutableObjectFragmentInitializers().Add([this](UObject& Owner, FMassEntityView& EntityView, const EMassTranslationDirection CurrentDirection)
+		{
+			if (const AActor* Actor = Cast<AActor>(&Owner))
+			{
+				if (USceneComponent* SceneComponent = Actor->GetRootComponent())
+				{
+					FSceneComponentWrapperFragment& SceneComponentFragment = EntityView.GetFragmentData<FSceneComponentWrapperFragment>();
+					SceneComponentFragment.Component = SceneComponent;
+
+					FTransformFragment& TransformFragment = EntityView.GetFragmentData<FTransformFragment>();
+					TransformFragment.GetMutableTransform() = SceneComponent->GetComponentTransform();
+				}
+			}
+		});
+
+	if (EnumHasAnyFlags(SyncDirection, EMassTranslationDirection::ActorToMass))
+	{
+		BuildContext.AddTranslator<UTempoMassSceneComponentTransformToMassTranslator>();
+	}
+
+	if (EnumHasAnyFlags(SyncDirection, EMassTranslationDirection::MassToActor))
+	{
+		BuildContext.AddTranslator<UTempoMassTransformToSceneComponentTranslator>();
 	}
 }

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoMassAgentSyncTraits.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoMassAgentSyncTraits.h
@@ -4,12 +4,70 @@
 
 #include "CoreMinimal.h"
 #include "MassAgentTraits.h"
+#include "MassCommonFragments.h"
 #include "MassEntityTraitBase.h"
 
 #include "TempoMassAgentSyncTraits.generated.h"
 
 UCLASS(BlueprintType, EditInlineNew, CollapseCategories, meta = (DisplayName = "Agent Brightness Meter Sync"))
 class TEMPOAGENTSSHARED_API UTempoMassAgentBrightnessMeterSyncTrait : public UMassAgentSyncTrait
+{
+	GENERATED_BODY()
+
+protected:
+	virtual void BuildTemplate(FMassEntityTemplateBuildContext& BuildContext, const UWorld& World) const override;
+};
+
+USTRUCT()
+struct FSceneComponentWrapperFragment : public FObjectWrapperFragment
+{
+	GENERATED_BODY()
+	TWeakObjectPtr<USceneComponent> Component;
+};
+
+USTRUCT()
+struct FTempoMassTransformCopyToMassTag : public FMassTag
+{
+	GENERATED_BODY()
+};
+
+UCLASS()
+class MASSACTORS_API UTempoMassSceneComponentTransformToMassTranslator : public UMassTranslator
+{
+	GENERATED_BODY()
+public:
+	UTempoMassSceneComponentTransformToMassTranslator();
+
+protected:
+	virtual void ConfigureQueries() override;
+	virtual void Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context) override;
+
+	FMassEntityQuery EntityQuery;
+};
+
+USTRUCT()
+struct FTempoMassTransformCopyToAgentTag : public FMassTag
+{
+	GENERATED_BODY()
+};
+
+UCLASS()
+class MASSACTORS_API UTempoMassTransformToSceneComponentTranslator : public UMassTranslator
+{
+	GENERATED_BODY()
+public:
+	UTempoMassTransformToSceneComponentTranslator();
+
+protected:
+	virtual void ConfigureQueries() override;
+	virtual void Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context) override;
+
+	FMassEntityQuery EntityQuery;
+};
+
+/** The trait keeps the actor's and entity's transforms in sync. */
+UCLASS(BlueprintType, EditInlineNew, CollapseCategories, meta = (DisplayName = "Agent Transform Sync"))
+class MASSACTORS_API UMassAgentTransformSyncTrait : public UMassAgentSyncTrait
 {
 	GENERATED_BODY()
 

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoMassAgentSyncTraits.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoMassAgentSyncTraits.h
@@ -45,26 +45,6 @@ protected:
 	FMassEntityQuery EntityQuery;
 };
 
-USTRUCT()
-struct FTempoMassTransformCopyToAgentTag : public FMassTag
-{
-	GENERATED_BODY()
-};
-
-UCLASS()
-class MASSACTORS_API UTempoMassTransformToSceneComponentTranslator : public UMassTranslator
-{
-	GENERATED_BODY()
-public:
-	UTempoMassTransformToSceneComponentTranslator();
-
-protected:
-	virtual void ConfigureQueries() override;
-	virtual void Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context) override;
-
-	FMassEntityQuery EntityQuery;
-};
-
 /** The trait keeps the actor's and entity's transforms in sync. */
 UCLASS(BlueprintType, EditInlineNew, CollapseCategories, meta = (DisplayName = "Agent Transform Sync"))
 class MASSACTORS_API UMassAgentTransformSyncTrait : public UMassAgentSyncTrait

--- a/TempoAgents/Source/TempoAgentsShared/TempoAgentsShared.Build.cs
+++ b/TempoAgents/Source/TempoAgentsShared/TempoAgentsShared.Build.cs
@@ -26,6 +26,7 @@ public class TempoAgentsShared : ModuleRules
                 "Slate",
                 "SlateCore",
                 "ZoneGraph",
+                "MassCommon",
                 "MassTraffic",
                 "MassRepresentation",
                 "MassEntity",

--- a/TempoMovement/Source/TempoMovementShared/Public/TempoVehicleControlInterface.h
+++ b/TempoMovement/Source/TempoMovementShared/Public/TempoVehicleControlInterface.h
@@ -34,4 +34,10 @@ public:
 	virtual FString GetVehicleName() = 0;
 	
 	virtual void HandleDrivingInput(const FNormalizedDrivingInput& Input) = 0;
+
+	virtual float GetMaxAcceleration() const = 0;
+
+	virtual float GetMaxDeceleration() const = 0;
+
+	virtual float GetMaxSteerAngle() const = 0;
 };

--- a/TempoMovement/Source/TempoVehicleControl/Public/TempoVehicleController.h
+++ b/TempoMovement/Source/TempoVehicleControl/Public/TempoVehicleController.h
@@ -19,6 +19,12 @@ public:
 	
 	virtual void HandleDrivingInput(const FNormalizedDrivingInput& Input) override;
 
+	virtual float GetMaxAcceleration() const override { return MaxAcceleration; }
+
+	virtual float GetMaxDeceleration() const override { return MaxDeceleration; }
+
+	virtual float GetMaxSteerAngle() const override { return MaxSteerAngle; }
+
 protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	float MaxAcceleration = 200.0; // CM/S/S (~0.2g)

--- a/TempoMovement/Source/TempoVehicleMovement/Private/KinematicBicycleModelMovementComponent.cpp
+++ b/TempoMovement/Source/TempoVehicleMovement/Private/KinematicBicycleModelMovementComponent.cpp
@@ -31,6 +31,10 @@ void UKinematicBicycleModelMovementComponent::TickComponent(float DeltaTime, ELe
 		DeltaVelocity = FMath::Max(-LinearVelocity, DeltaVelocity);
 	}
 	LinearVelocity += DeltaVelocity;
+	if (!bReverseEnabled)
+	{
+		LinearVelocity = FMath::Max(LinearVelocity, 0.0);
+	}
 	const float Beta = FMath::DegreesToRadians(SteeringAngle + HeadingAngle);
 	Velocity = LinearVelocity * FVector(FMath::Cos(Beta), FMath::Sin(Beta), 0.0);
 	AngularVelocity = FMath::RadiansToDegrees(LinearVelocity * FMath::Sin(FMath::DegreesToRadians(SteeringAngle)) / Wheelbase);

--- a/TempoMovement/Source/TempoVehicleMovement/Private/TempoChaosWheeledVehicleMovementComponent.cpp
+++ b/TempoMovement/Source/TempoVehicleMovement/Private/TempoChaosWheeledVehicleMovementComponent.cpp
@@ -17,13 +17,31 @@ void UTempoChaosWheeledVehicleMovementComponent::HandleDrivingCommand(const FDri
 	{
 		if (Input > 0.0)
 		{
-			SetThrottleInput(Input);
-			SetBrakeInput(0.0);
+			if (VehicleState.ForwardSpeed > 0.0)
+			{
+				SetThrottleInput(Input);
+				SetBrakeInput(0.0);
+			}
+			else
+			{
+				SetTargetGear(1, false);
+				SetThrottleInput(0.0);
+				SetBrakeInput(Input);
+			}
 		}
 		else
 		{
-			SetBrakeInput(-Input);
-			SetThrottleInput(0.0);
+			if (VehicleState.ForwardSpeed > 0.0 || !bReverseEnabled)
+			{
+				SetBrakeInput(-Input);
+				SetThrottleInput(0.0);
+			}
+			else
+			{
+				SetTargetGear(-1, false);
+				SetThrottleInput(-Input);
+				SetBrakeInput(0.0);
+			}
 		}
 	};
 	

--- a/TempoMovement/Source/TempoVehicleMovement/Private/TempoChaosWheeledVehicleMovementComponent.cpp
+++ b/TempoMovement/Source/TempoVehicleMovement/Private/TempoChaosWheeledVehicleMovementComponent.cpp
@@ -1,0 +1,52 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#include "TempoChaosWheeledVehicleMovementComponent.h"
+
+#include "TempoVehicleControlInterface.h"
+
+UTempoChaosWheeledVehicleMovementComponent::UTempoChaosWheeledVehicleMovementComponent()
+{
+	bReverseAsBrake = false;
+	bThrottleAsBrake = false;
+}
+
+void UTempoChaosWheeledVehicleMovementComponent::HandleDrivingCommand(const FDrivingCommand& Command)
+{
+	// An extremely rough mapping from normalized acceleration (-1 to 1) to normalized throttle and brakes (each 0 to 1).
+	auto SetAccelInput = [this](float Input)
+	{
+		if (Input > 0.0)
+		{
+			SetThrottleInput(Input);
+			SetBrakeInput(0.0);
+		}
+		else
+		{
+			SetBrakeInput(-Input);
+			SetThrottleInput(0.0);
+		}
+	};
+	
+	if (const APawn* Pawn = Cast<APawn>(GetOwner()))
+	{
+		if (const ITempoVehicleControlInterface* Controller = Cast<ITempoVehicleControlInterface>(Pawn->Controller.Get()))
+		{
+			// The TempoVehicleMovementInterface takes driving commands in real units, but the 
+			// ChaosVehicleMovementComponent expects normalized inputs. So we re-normalize them here.
+			const float MaxAcceleration = Controller->GetMaxAcceleration();
+			const float MaxDeceleration = Controller->GetMaxDeceleration();
+			const float MaxSteerAngle = Controller->GetMaxSteerAngle();
+
+			SetSteeringInput(Command.SteeringAngle / MaxSteerAngle);
+
+			if (VehicleState.ForwardSpeed > 0.0)
+			{
+				SetAccelInput(Command.Acceleration > 0.0 ? Command.Acceleration / MaxAcceleration : Command.Acceleration / MaxDeceleration);
+			}
+			else
+			{
+				SetAccelInput(Command.Acceleration / MaxAcceleration);
+			}
+		}
+	}
+}

--- a/TempoMovement/Source/TempoVehicleMovement/Private/TempoVehicleMovement.cpp
+++ b/TempoMovement/Source/TempoVehicleMovement/Private/TempoVehicleMovement.cpp
@@ -1,4 +1,6 @@
-﻿#include "TempoVehicleMovement.h"
+﻿// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#include "TempoVehicleMovement.h"
 
 #define LOCTEXT_NAMESPACE "FTempoVehicleMovementModule"
 

--- a/TempoMovement/Source/TempoVehicleMovement/Private/TempoWheeledVehiclePawn.cpp
+++ b/TempoMovement/Source/TempoVehicleMovement/Private/TempoWheeledVehiclePawn.cpp
@@ -1,0 +1,10 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#include "TempoWheeledVehiclePawn.h"
+
+#include "TempoChaosWheeledVehicleMovementComponent.h"
+
+ATempoWheeledVehiclePawn::ATempoWheeledVehiclePawn(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer.SetDefaultSubobjectClass<UTempoChaosWheeledVehicleMovementComponent>(VehicleMovementComponentName))
+{
+}

--- a/TempoMovement/Source/TempoVehicleMovement/Public/KinematicBicycleModelMovementComponent.h
+++ b/TempoMovement/Source/TempoVehicleMovement/Public/KinematicBicycleModelMovementComponent.h
@@ -30,6 +30,9 @@ protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	float Wheelbase = 100.0; // CM
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	bool bReverseEnabled = false;
+
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite)
 	float LinearVelocity = 0.0; // CM/S
 

--- a/TempoMovement/Source/TempoVehicleMovement/Public/TempoChaosWheeledVehicleMovementComponent.h
+++ b/TempoMovement/Source/TempoVehicleMovement/Public/TempoChaosWheeledVehicleMovementComponent.h
@@ -1,0 +1,26 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#pragma once
+
+#include "TempoVehicleMovementInterface.h"
+#include "TempoMovementInterface.h"
+
+#include "ChaosWheeledVehicleMovementComponent.h"
+#include "CoreMinimal.h"
+
+#include "TempoChaosWheeledVehicleMovementComponent.generated.h"
+
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class TEMPOVEHICLEMOVEMENT_API UTempoChaosWheeledVehicleMovementComponent : public UChaosWheeledVehicleMovementComponent, public ITempoVehicleMovementInterface, public ITempoMovementInterface
+{
+	GENERATED_BODY()
+
+public:
+	UTempoChaosWheeledVehicleMovementComponent();
+
+	virtual float GetLinearVelocity() override { return VehicleState.ForwardSpeed; }
+
+	virtual FVector GetAngularVelocity() override { return VehicleState.VehicleWorldAngularVelocity; }
+	
+	virtual void HandleDrivingCommand(const FDrivingCommand& Command) override;
+};

--- a/TempoMovement/Source/TempoVehicleMovement/Public/TempoChaosWheeledVehicleMovementComponent.h
+++ b/TempoMovement/Source/TempoVehicleMovement/Public/TempoChaosWheeledVehicleMovementComponent.h
@@ -23,4 +23,8 @@ public:
 	virtual FVector GetAngularVelocity() override { return VehicleState.VehicleWorldAngularVelocity; }
 	
 	virtual void HandleDrivingCommand(const FDrivingCommand& Command) override;
+
+protected:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	bool bReverseEnabled = false;
 };

--- a/TempoMovement/Source/TempoVehicleMovement/Public/TempoVehicleMovement.h
+++ b/TempoMovement/Source/TempoVehicleMovement/Public/TempoVehicleMovement.h
@@ -1,4 +1,6 @@
-﻿#pragma once
+﻿// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#pragma once
 
 #include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"

--- a/TempoMovement/Source/TempoVehicleMovement/Public/TempoWheeledVehiclePawn.h
+++ b/TempoMovement/Source/TempoVehicleMovement/Public/TempoWheeledVehiclePawn.h
@@ -1,0 +1,20 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "WheeledVehiclePawn.h"
+
+#include "TempoWheeledVehiclePawn.generated.h"
+
+/*
+ * A WheeledVehiclePawn that will use the TempoChaosWheeledVehicleMovementComponent.
+ */
+UCLASS()
+class TEMPOVEHICLEMOVEMENT_API ATempoWheeledVehiclePawn : public AWheeledVehiclePawn
+{
+	GENERATED_BODY()
+
+public:
+	ATempoWheeledVehiclePawn(const FObjectInitializer& ObjectInitializer);
+};

--- a/TempoMovement/Source/TempoVehicleMovement/TempoVehicleMovement.Build.cs
+++ b/TempoMovement/Source/TempoVehicleMovement/TempoVehicleMovement.Build.cs
@@ -10,6 +10,7 @@ public class TempoVehicleMovement : ModuleRules
             new string[]
             {
                 "Core",
+                "ChaosVehicles",
             }
         );
 

--- a/TempoMovement/TempoMovement.uplugin
+++ b/TempoMovement/TempoMovement.uplugin
@@ -39,6 +39,10 @@
 		{
 			"Name": "TempoCore",
 			"Enabled": true
+		},
+		{
+			"Name": "ChaosVehiclesPlugin",
+			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
Allows wheeled vehicle pawns to be controlled by the TempoMovement API by adding:
- `TempoChaosWheeledVehicleMovementComponent`, which implements `ITempoVehicleMovementInterface` to map normalized acceleration and steering to `ChaosWheeledVehicleMovementComponent`'s inputs
- `ATempoWheeledVehiclePawn`, which is simply an `AWheeledVehiclePawn` with the above Tempo movement component

Also adds an option to enable or disable reversing (default false) on both the new movement component and the `KinematicBicycleModelMovementComponent`.