### PR TITLE
Avoid Unnecessary Debris Regenerations

### DIFF
--- a/TempoWorld/Source/TempoDebris/Private/TempoDebrisParameterComponent.cpp
+++ b/TempoWorld/Source/TempoDebris/Private/TempoDebrisParameterComponent.cpp
@@ -8,6 +8,51 @@
 #include "PCGGraph.h"
 #include "TempoConversion.h"
 
+template <typename T>
+bool MaybeSetGraphParameter(UPCGGraphInterface* GraphInterface, const FName& ParameterName, const T& Value)
+{
+	TValueOrError<T, EPropertyBagResult> ValueOrError = GraphInterface->GetGraphParameter<T>(ParameterName);
+	if (!ValueOrError.HasValue())
+	{
+		UE_LOG(LogTempoDebris, Error, TEXT("Error while getting graph property value: %d"), ValueOrError.GetError())
+		return false;
+	}
+	if (ValueOrError.GetValue() == Value)
+	{
+		return false;
+	}
+	EPropertyBagResult SetResult = GraphInterface->SetGraphParameter(ParameterName, Value);
+	if (SetResult != EPropertyBagResult::Success)
+	{
+		UE_LOG(LogTempoDebris, Error, TEXT("Error while setting graph property value: %d"), SetResult)
+		return false;
+	}
+	return true;
+}
+
+// Some of the GetGraphParameter specializations return a T*, others return a T.
+template <typename T>
+bool MaybeSetGraphParameterPtr(UPCGGraphInterface* GraphInterface, const FName& ParameterName, const T& Value)
+{
+	TValueOrError<T*, EPropertyBagResult> ValueOrError = GraphInterface->GetGraphParameter<T*>(ParameterName);
+	if (!ValueOrError.HasValue())
+	{
+		UE_LOG(LogTempoDebris, Error, TEXT("Error while getting graph property value: %d"), ValueOrError.GetError())
+		return false;
+	}
+	if (*ValueOrError.GetValue() == Value)
+	{
+		return false;
+	}
+	EPropertyBagResult SetResult = GraphInterface->SetGraphParameter(ParameterName, Value);
+	if (SetResult != EPropertyBagResult::Success)
+	{
+		UE_LOG(LogTempoDebris, Error, TEXT("Error while setting graph property value: %d"), SetResult)
+		return false;
+	}
+	return true;
+}
+
 void UTempoDebrisParameterComponent::SyncPCGParameters(const FTempoDebrisParameters& Params) const
 {
 	if (!GetOwner())
@@ -30,29 +75,48 @@ void UTempoDebrisParameterComponent::SyncPCGParameters(const FTempoDebrisParamet
 			UE_LOG(LogTempoDebris, Warning, TEXT("No PCG graph instance on PCG component with tag %s in TempoDebrisParameterComponent"), *Params.TargetPCGComponentTag.ToString());
 		}
 
-		TargetedPCGComponent->Seed = Params.Seed;
-		TargetedPCGComponent->bActivated = Params.bEnabled;
+		bool bAnyParametersUpdated = false;
 
-		const float NominalClusterSize = (Params.MaxClusterSize + Params.MinClusterSize) / 2.0;
+		if (TargetedPCGComponent->Seed != Params.Seed)
+		{
+			TargetedPCGComponent->Seed = Params.Seed;
+			bAnyParametersUpdated = true;
+		}
+
+		if (TargetedPCGComponent->bActivated != Params.bEnabled)
+		{
+			TargetedPCGComponent->bActivated = Params.bEnabled;
+			bAnyParametersUpdated = true;
+		}
+
+		const double NominalClusterSize = (Params.MaxClusterSize + Params.MinClusterSize) / 2.0;
 		const FVector NominalClusterOffset(NominalClusterSize / 2.0, NominalClusterSize / 2.0, 0.0);
-		GraphInstance->SetGraphParameter(TEXT("InstanceDensity"), Params.InstanceDensity);
-		GraphInstance->SetGraphParameter(TEXT("MinInstanceScale"), Params.MinInstanceScale);
-		GraphInstance->SetGraphParameter(TEXT("MaxInstanceScale"), Params.MaxInstanceScale);
-		GraphInstance->SetGraphParameter(TEXT("Clustering"), Params.bClusteringEnabled);
-		GraphInstance->SetGraphParameter(TEXT("ClusterDensity"), 1.0 / QuantityConverter<M2CM>::Convert(Params.ClusterSpacing));
-		GraphInstance->SetGraphParameter(TEXT("ClusterSize"), QuantityConverter<M2CM>::Convert(NominalClusterSize));
-		GraphInstance->SetGraphParameter(TEXT("ClusterScaleMin"), Params.MinClusterSize / NominalClusterSize);
-		GraphInstance->SetGraphParameter(TEXT("ClusterScaleMax"), Params.MaxClusterSize / NominalClusterSize);
-		GraphInstance->SetGraphParameter(TEXT("ClusterFalloffNoise"), 1.0 / Params.ClusterFalloff);
-		GraphInstance->SetGraphParameter(TEXT("MinClusterOffset"), -QuantityConverter<M2CM>::Convert(NominalClusterOffset));
-		GraphInstance->SetGraphParameter(TEXT("MaxClusterOffset"), QuantityConverter<M2CM>::Convert(NominalClusterOffset));
-		GraphInstance->SetGraphParameter(TEXT("CenterKeepout"), Params.bCenterKeepoutEnabled);
-		GraphInstance->SetGraphParameter(TEXT("CenterFalloffNoise"), Params.CenterKeepoutFalloff);
-		GraphInstance->SetGraphParameter(TEXT("HalfCenterWidth"), Params.CenterKeepoutPortion * QuantityConverter<M2CM>::Convert(CenterKeepoutWidth / 2.0));
-		GraphInstance->SetGraphParameter(TEXT("MeshDistributionName"), Params.MeshDistribution);
-		GraphInstance->SetGraphParameter(TEXT("MeshDistributionDataTable"), MeshDistributionDataTable.ToSoftObjectPath());
-		GraphInstance->SetGraphParameter(TEXT("CenterSplineTag"), CenterSplineTag);
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("InstanceDensity"), Params.InstanceDensity);
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("MinInstanceScale"), Params.MinInstanceScale);
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("MaxInstanceScale"), Params.MaxInstanceScale);
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("Clustering"), Params.bClusteringEnabled);
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("ClusterDensity"), 1.0 / QuantityConverter<M2CM>::Convert(Params.ClusterSpacing));
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("ClusterSize"), QuantityConverter<M2CM>::Convert(NominalClusterSize));
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("ClusterScaleMin"), Params.MinClusterSize / NominalClusterSize);
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("ClusterScaleMax"), Params.MaxClusterSize / NominalClusterSize);
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("ClusterFalloffNoise"), 1.0 / Params.ClusterFalloff);
+		bAnyParametersUpdated |= MaybeSetGraphParameterPtr(GraphInstance, TEXT("MinClusterOffset"), -QuantityConverter<M2CM>::Convert(NominalClusterOffset));
+		bAnyParametersUpdated |= MaybeSetGraphParameterPtr(GraphInstance, TEXT("MaxClusterOffset"), QuantityConverter<M2CM>::Convert(NominalClusterOffset));
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("CenterKeepout"), Params.bCenterKeepoutEnabled);
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("CenterFalloffNoise"), Params.CenterKeepoutFalloff);
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("HalfCenterWidth"), Params.CenterKeepoutPortion * QuantityConverter<M2CM>::Convert(CenterKeepoutWidth / 2.0));
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("MeshDistributionName"), Params.MeshDistribution);
+		bAnyParametersUpdated |= MaybeSetGraphParameterPtr(GraphInstance, TEXT("MeshDistributionDataTable"), MeshDistributionDataTable.ToSoftObjectPath());
+		bAnyParametersUpdated |= MaybeSetGraphParameter(GraphInstance, TEXT("CenterSplineTag"), CenterSplineTag);
 
-		TargetedPCGComponent->GenerateLocal(true);
+		// In the Editor or PIE this is taken care of for us in the PCGComponent.
+		// In the packaged game we must trigger regeneration ourselves.
+		// But only regenerate if parameters have actually changed, or we've never generated.
+#if !WITH_EDITOR
+		if (bAnyParametersUpdated || !TargetedPCGComponent->bGenerated)
+		{
+			TargetedPCGComponent->GenerateLocal(true);
+		}
+#endif
 	}
 }


### PR DESCRIPTION
We are always calling `TargetedPCGComponent->GenerateLocal(true);` after setting PCG parameters from the `TempoDebrisParameterComponent`. There are two issues with that:
- In Editor or PIE we don't need to call it since it's taken care of in `PCGComponent` already
- In the packaged binary we should only call it when the parameters have actually changed

This resolves both of those. The former with an `#if !WITH_EDITOR` and the latter by replacing calls to `SetPCGParameter` with the new `MaybeSetGraphParameter`, which returns true if the parameter actually changed.