### PR TITLE
Block for Level Streaming Completed on Deferred Level Load

### DIFF
--- a/TempoCore/Source/TempoCore/Private/TempoGameMode.cpp
+++ b/TempoCore/Source/TempoCore/Private/TempoGameMode.cpp
@@ -12,6 +12,8 @@ void ATempoGameMode::StartPlay()
 	UTempoCoreServiceSubsystem* TempoCoreServiceSubsystem = UGameInstance::GetSubsystem<UTempoCoreServiceSubsystem>(GetGameInstance());
 	if (TempoCoreServiceSubsystem)
 	{
+		// Wait until level streaming is up to date (and all streamed actors are loaded)
+		GEngine->BlockTillLevelStreamingCompleted(GetWorld());
 		TempoCoreServiceSubsystem->OnLevelLoaded();
 		if (TempoCoreServiceSubsystem->GetDeferBeginPlay())
 		{


### PR DESCRIPTION
Blocking for level streaming to complete guarantees all actors have been loaded (but BeginPlay has still not been called) while in the deferred level load state.