### PR TITLE
Add initial procedural crosswalks and related behavior.

### DIFF
--- a/EngineMods/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.2
+++ b/EngineMods/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.2
@@ -1,0 +1,289 @@
+diff -urN --strip-trailing-cr Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp"
+--- Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp	2023-06-01 08:28:46.000000000 -0400
++++ "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp"	2024-12-16 22:10:20.235534200 -0500
+@@ -9,11 +9,14 @@
+ #include "MassEntityManager.h"
+ #include "MassMovementFragments.h"
+ #include "MassCrowdSettings.h"
++#include "MassEntityView.h"
+ #include "ZoneGraphAnnotationSubsystem.h"
+ #include "MassZoneGraphNavigationFragments.h"
+ #include "Annotations/ZoneGraphDisturbanceAnnotation.h"
+ #include "MassSimulationLOD.h"
+ #include "MassSignalSubsystem.h"
++#include "ZoneGraphSubsystem.h"
++#include "MassGameplayExternalTraits.h"
+ 
+ //----------------------------------------------------------------------//
+ // UMassCrowdLaneTrackingSignalProcessor
+@@ -62,6 +65,173 @@
+ }
+ 
+ //----------------------------------------------------------------------//
++// UMassCrowdUpdateTrackingLaneProcessor
++//----------------------------------------------------------------------//
++UMassCrowdUpdateTrackingLaneProcessor::UMassCrowdUpdateTrackingLaneProcessor()
++	: EntityQuery(*this)
++{
++	ExecutionOrder.ExecuteAfter.Add(UE::Mass::ProcessorGroupNames::Tasks);
++}
++
++void UMassCrowdUpdateTrackingLaneProcessor::ConfigureQueries()
++{
++	EntityQuery.AddTagRequirement<FMassCrowdTag>(EMassFragmentPresence::All);
++	
++	ProcessorRequirements.AddSubsystemRequirement<UMassCrowdSubsystem>(EMassFragmentAccess::ReadWrite);
++	ProcessorRequirements.AddSubsystemRequirement<UZoneGraphSubsystem>(EMassFragmentAccess::ReadOnly);
++}
++
++void UMassCrowdUpdateTrackingLaneProcessor::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
++{
++	// Gather all Crowd Entities.
++	TArray<FMassEntityHandle> AllCrowdEntities;
++	EntityQuery.ForEachEntityChunk(EntityManager, Context, [&](const FMassExecutionContext& QueryContext)
++	{
++		const int32 NumEntities = QueryContext.GetNumEntities();
++		for (int32 Index = 0; Index < NumEntities; ++Index)
++		{
++			AllCrowdEntities.Add(QueryContext.GetEntity(Index));
++		}
++	});
++	
++	if (AllCrowdEntities.IsEmpty())
++	{
++		return;
++	}
++	
++	// Sort by ZoneGraphStorage Index, then Lane Index, then *ascending* DistanceAlongLane.
++	AllCrowdEntities.Sort(
++		[&EntityManager](const FMassEntityHandle& EntityA, const FMassEntityHandle& EntityB)
++		{
++			const FMassZoneGraphLaneLocationFragment& A = EntityManager.GetFragmentDataChecked<FMassZoneGraphLaneLocationFragment>(EntityA);
++			const FMassZoneGraphLaneLocationFragment& B = EntityManager.GetFragmentDataChecked<FMassZoneGraphLaneLocationFragment>(EntityB);
++
++			if (A.LaneHandle == B.LaneHandle)
++			{
++				return A.DistanceAlongLane < B.DistanceAlongLane;
++			}
++			else if (A.LaneHandle.DataHandle == B.LaneHandle.DataHandle)
++			{
++				return A.LaneHandle.Index < B.LaneHandle.Index;
++			}
++			else
++			{
++				return A.LaneHandle.DataHandle.Index < B.LaneHandle.DataHandle.Index;
++			}
++		}
++	);
++
++	const TArray<FMassEntityHandle>& AscendingCrowdEntities = AllCrowdEntities;
++	TArray<FMassEntityHandle> DescendingCrowdEntities(AllCrowdEntities);
++	
++	// Sort by ZoneGraphStorage Index, then Lane Index, then *descending* DistanceAlongLane.
++	DescendingCrowdEntities.Sort(
++		[&EntityManager](const FMassEntityHandle& EntityA, const FMassEntityHandle& EntityB)
++		{
++			const FMassZoneGraphLaneLocationFragment& A = EntityManager.GetFragmentDataChecked<FMassZoneGraphLaneLocationFragment>(EntityA);
++			const FMassZoneGraphLaneLocationFragment& B = EntityManager.GetFragmentDataChecked<FMassZoneGraphLaneLocationFragment>(EntityB);
++
++			if (A.LaneHandle == B.LaneHandle)
++			{
++				return A.DistanceAlongLane > B.DistanceAlongLane;
++			}
++			else if (A.LaneHandle.DataHandle == B.LaneHandle.DataHandle)
++			{
++				return A.LaneHandle.Index < B.LaneHandle.Index;
++			}
++			else
++			{
++				return A.LaneHandle.DataHandle.Index < B.LaneHandle.DataHandle.Index;
++			}
++		}
++	);
++
++	UMassCrowdSubsystem& MassCrowdSubsystem = Context.GetMutableSubsystemChecked<UMassCrowdSubsystem>();
++	const UZoneGraphSubsystem& ZoneGraphSubsystem = Context.GetSubsystemChecked<UZoneGraphSubsystem>();
++
++	// First, we need to reset the "distance along lane" fields for the "lead" and "tail" Entities.
++	TConstArrayView<FRegisteredZoneGraphData> RegisteredZoneGraphDatas = ZoneGraphSubsystem.GetRegisteredZoneGraphData();
++	for (const FRegisteredZoneGraphData& RegisteredZoneGraphData : RegisteredZoneGraphDatas)
++	{
++		if (!ensureMsgf(RegisteredZoneGraphData.ZoneGraphData != nullptr, TEXT("Must get valid RegisteredZoneGraphData.ZoneGraphData in UMassCrowdUpdateTrackingLaneProcessor::Execute.")))
++		{
++			continue;
++		}
++		
++		const FZoneGraphStorage& ZoneGraphStorage = RegisteredZoneGraphData.ZoneGraphData->GetStorage();
++		FRegisteredCrowdLaneData* RegisteredCrowdLaneData = MassCrowdSubsystem.GetMutableCrowdData(ZoneGraphStorage.DataHandle);
++
++		if (!ensureMsgf(RegisteredCrowdLaneData != nullptr, TEXT("Must get valid RegisteredCrowdLaneData in UMassCrowdUpdateTrackingLaneProcessor::Execute.")))
++		{
++			continue;
++		}
++
++		for (TTuple<int32, FCrowdTrackingLaneData>& RegisteredCrowdLaneDataPair : RegisteredCrowdLaneData->LaneToTrackingDataLookup)
++		{
++			FCrowdTrackingLaneData& RegisteredCrowdTrackingLaneData = RegisteredCrowdLaneDataPair.Value;
++			RegisteredCrowdTrackingLaneData.LeadEntityNormalizedDistanceAlongLane.Reset();
++			RegisteredCrowdTrackingLaneData.TailEntityNormalizedDistanceAlongLane.Reset();
++		}
++	}
++
++	// Then, update the "distance along lane" fields for the "lead" and "tail" Entities.
++	for (int32 SortedCrowdEntityIndex = 0; SortedCrowdEntityIndex < AscendingCrowdEntities.Num(); ++SortedCrowdEntityIndex)
++	{
++		// First, update the field for the "lead" Entity.
++		const FMassEntityHandle LeadEntityHandle = DescendingCrowdEntities[SortedCrowdEntityIndex];
++			
++		const FMassEntityView LeadEntityView(EntityManager, LeadEntityHandle);
++		const FMassZoneGraphLaneLocationFragment& LeadEntityLaneLocation = LeadEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
++
++		if (LeadEntityLaneLocation.LaneLength > 0.0f)
++		{
++			FCrowdTrackingLaneData* LeadEntityCrowdTrackingLaneData = MassCrowdSubsystem.GetMutableCrowdTrackingLaneData(LeadEntityLaneLocation.LaneHandle);
++			
++			if (LeadEntityCrowdTrackingLaneData == nullptr)
++			{
++				continue;
++			}
++
++			// We only set the LeadEntityNormalizedDistanceAlongLane value for a given lane, if it hasn't already been set.
++			// And, since we're indexing into DescendingCrowdEntities, which has been sorted by descending DistanceAlongLane,
++			// the first Entity to be indexed for a given lane will in fact be the "Lead Entity" for that lane,
++			// and it will have the first (and only) opportunity to set the LeadEntityNormalizedDistanceAlongLane field.
++			if (!LeadEntityCrowdTrackingLaneData->LeadEntityNormalizedDistanceAlongLane.IsSet())
++			{
++				const float NormalizedDistanceAlongLane = LeadEntityLaneLocation.DistanceAlongLane / LeadEntityLaneLocation.LaneLength;
++				LeadEntityCrowdTrackingLaneData->LeadEntityNormalizedDistanceAlongLane = NormalizedDistanceAlongLane;
++			}
++		}
++
++		// Then, update the field for the "tail" Entity.
++		const FMassEntityHandle TailEntityHandle = AscendingCrowdEntities[SortedCrowdEntityIndex];
++			
++		const FMassEntityView TailEntityView(EntityManager, TailEntityHandle);
++		const FMassZoneGraphLaneLocationFragment& TailEntityLaneLocation = TailEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
++
++		if (TailEntityLaneLocation.LaneLength > 0.0f)
++		{
++			FCrowdTrackingLaneData* TailEntityCrowdTrackingLaneData = MassCrowdSubsystem.GetMutableCrowdTrackingLaneData(TailEntityLaneLocation.LaneHandle);
++			
++			if (TailEntityCrowdTrackingLaneData == nullptr)
++			{
++				continue;
++			}
++
++			// We only set the TailEntityNormalizedDistanceAlongLane value for a given lane, if it hasn't already been set.
++			// And, since we're indexing into AscendingCrowdEntities, which has been sorted by ascending DistanceAlongLane,
++			// the first Entity to be indexed for a given lane will in fact be the "Tail Entity" for that lane,
++			// and it will have the first (and only) opportunity to set the TailEntityNormalizedDistanceAlongLane field.
++			if (!TailEntityCrowdTrackingLaneData->TailEntityNormalizedDistanceAlongLane.IsSet())
++			{
++				const float NormalizedDistanceAlongLane = TailEntityLaneLocation.DistanceAlongLane / TailEntityLaneLocation.LaneLength;
++				TailEntityCrowdTrackingLaneData->TailEntityNormalizedDistanceAlongLane = NormalizedDistanceAlongLane;
++			}
++		}
++	}
++}
++
++//----------------------------------------------------------------------//
+ // UMassCrowdLaneTrackingDestructor
+ //----------------------------------------------------------------------//
+ UMassCrowdLaneTrackingDestructor::UMassCrowdLaneTrackingDestructor()
+diff -urN --strip-trailing-cr Source/MassCrowd/Private/MassCrowdSubsystem.cpp "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Private/MassCrowdSubsystem.cpp"
+--- Source/MassCrowd/Private/MassCrowdSubsystem.cpp	2024-03-29 04:15:28.000000000 -0400
++++ "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Private/MassCrowdSubsystem.cpp"	2024-12-16 22:10:20.253042400 -0500
+@@ -261,6 +261,11 @@
+ 	return CrowdLaneData.LaneToTrackingDataLookup.Find(LaneHandle.Index);
+ }
+ 
++FCrowdTrackingLaneData* UMassCrowdSubsystem::GetMutableCrowdTrackingLaneData(const FZoneGraphLaneHandle LaneHandle) const
++{
++	return const_cast<FCrowdTrackingLaneData*>(GetCrowdTrackingLaneData(LaneHandle));
++}
++
+ const FCrowdBranchingLaneData* UMassCrowdSubsystem::GetCrowdBranchingLaneData(const FZoneGraphLaneHandle LaneHandle) const
+ {
+ 	if (!ensureMsgf(LaneHandle.IsValid(), TEXT("Invalid lane handle: returning a null entry.")))
+@@ -363,6 +368,11 @@
+ 	return &LanesData;
+ }
+ 
++FRegisteredCrowdLaneData* UMassCrowdSubsystem::GetMutableCrowdData(const FZoneGraphDataHandle DataHandle) const
++{
++	return const_cast<FRegisteredCrowdLaneData*>(GetCrowdData(DataHandle));
++}
++
+ void UMassCrowdSubsystem::OnEntityLaneChanged(const FMassEntityHandle Entity, const FZoneGraphLaneHandle PreviousLaneHandle, const FZoneGraphLaneHandle CurrentLaneHandle)
+ {
+ 	const bool bPreviousLocationValid = PreviousLaneHandle.IsValid();
+diff -urN --strip-trailing-cr Source/MassCrowd/Public/MassCrowdNavigationProcessor.h "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdNavigationProcessor.h"
+--- Source/MassCrowd/Public/MassCrowdNavigationProcessor.h	2023-06-01 08:28:40.000000000 -0400
++++ "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdNavigationProcessor.h"	2024-12-16 22:10:20.263042700 -0500
+@@ -24,6 +24,21 @@
+ 	virtual void SignalEntities(FMassEntityManager& EntityManager, FMassExecutionContext& Context, FMassSignalNameLookup& EntitySignals) override;
+ };
+ 
++UCLASS()
++class MASSCROWD_API UMassCrowdUpdateTrackingLaneProcessor : public UMassProcessor
++{
++	GENERATED_BODY()
++public:
++	UMassCrowdUpdateTrackingLaneProcessor();
++
++protected:
++	
++	virtual void ConfigureQueries() override;
++	virtual void Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context) override;
++	
++	FMassEntityQuery EntityQuery;
++};
++
+ /** Processors that cleans up the lane tracking on entity destruction. */
+ UCLASS()
+ class MASSCROWD_API UMassCrowdLaneTrackingDestructor : public UMassObserverProcessor
+diff -urN --strip-trailing-cr Source/MassCrowd/Public/MassCrowdSubsystem.h "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdSubsystem.h"
+--- Source/MassCrowd/Public/MassCrowdSubsystem.h	2024-03-29 04:15:26.000000000 -0400
++++ "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdSubsystem.h"	2024-12-16 22:10:20.279076900 -0500
+@@ -84,6 +84,14 @@
+ 	const FRegisteredCrowdLaneData* GetCrowdData(const FZoneGraphDataHandle DataHandle) const;
+ 
+ 	/**
++	 * Returns the readonly runtime data associated to a given zone graph.
++	 * @param DataHandle A valid handle of the zone graph used to retrieve the runtime crowd data
++	 * @return Runtime data associated to the zone graph if available; nullptr otherwise
++	 * @note Method will ensure if DataHandle is invalid or if associated data doesn't exist. Should call HasCrowdDataForZoneGraph first.
++	 */
++	FRegisteredCrowdLaneData* GetMutableCrowdData(const FZoneGraphDataHandle DataHandle) const;
++
++	/**
+ 	 * Returns the readonly runtime data associated to a given zone graph lane.
+ 	 * @param LaneHandle A valid lane handle used to retrieve the runtime data; ensure if handle is invalid
+ 	 * @return Runtime data associated to the lane (if available)
+@@ -98,6 +106,13 @@
+ 	const FCrowdTrackingLaneData* GetCrowdTrackingLaneData(const FZoneGraphLaneHandle LaneHandle) const;
+ 
+ 	/**
++	 * Returns the entity tracking runtime data associated to a given zone graph lane.
++	 * @param LaneHandle A valid lane handle used to retrieve the associated tracking data; ensure if handle is invalid
++	 * @return Runtime data associated to the lane (nullptr if provided handle is invalid or no data is associated to that lane)
++	 */
++	FCrowdTrackingLaneData* GetMutableCrowdTrackingLaneData(const FZoneGraphLaneHandle LaneHandle) const;
++
++	/**
+ 	 * Returns the branching data associated to a given zone graph lane.
+  	 * @param LaneHandle A valid lane handle used to retrieve the associated data; ensure if handle is invalid
+ 	 * @return Branching data associated to the lane (nullptr if provided handle is invalid or no data is associated to that lane)
+diff -urN --strip-trailing-cr Source/MassCrowd/Public/MassCrowdTypes.h "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdTypes.h"
+--- Source/MassCrowd/Public/MassCrowdTypes.h	2023-06-01 08:28:40.000000000 -0400
++++ "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdTypes.h"	2024-12-16 22:10:20.297043300 -0500
+@@ -57,6 +57,9 @@
+ 	int32 WaitAreaIndex = INDEX_NONE;
+ 
+ 	int32 NumEntitiesOnLane = 0;
++	
++	TOptional<float> LeadEntityNormalizedDistanceAlongLane;
++	TOptional<float> TailEntityNormalizedDistanceAlongLane;
+ };
+ 
+ /** Runtime data associated to lane that can be used to wait another one to open. */

--- a/EngineMods/EngineMods.json
+++ b/EngineMods/EngineMods.json
@@ -25,6 +25,13 @@
       "Patch": [
           "ZoneGraph.patch.2"
       ]
+    },
+    {
+      "Type": "Plugin",
+      "Root": "Engine/Plugins/AI/MassCrowd",
+      "Patch": [
+        "MassCrowd.patch.2"
+      ]
     }
   ],
   "5.3": [

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficCrowdYieldProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficCrowdYieldProcessor.cpp
@@ -1,0 +1,160 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+
+#include "MassTrafficCrowdYieldProcessor.h"
+
+#include "MassTraffic.h"
+#include "MassTrafficFragments.h"
+#include "MassCrowdFragments.h"
+#include "MassExecutionContext.h"
+#include "MassZoneGraphNavigationFragments.h"
+#include "ZoneGraphTypes.h"
+#include "MassNavigationFragments.h"
+
+
+UMassTrafficCrowdYieldProcessor::UMassTrafficCrowdYieldProcessor()
+	: EntityQuery(*this)
+{
+	bAutoRegisterWithProcessingPhases = true;
+	ExecutionFlags = int32(EProcessorExecutionFlags::AllNetModes);
+	ExecutionOrder.ExecuteInGroup = UE::MassTraffic::ProcessorGroupNames::CrowdYieldBehavior;
+
+	// IMPORTANT:  We really want to run *just before* UMassSteerToMoveTargetProcessor,
+	// but it doesn't define itself to be in a "Steering" group, in order for us to add it to our ExecuteBefore list.
+	// And, it's in the MassAI Plugin, which we haven't started to modify yet.
+	// So, we'll just set our ExecuteBefore and ExecuteAfter lists to be the same as UMassSteerToMoveTargetProcessor,
+	// which will put us effectively in the same "group" as UMassSteerToMoveTargetProcessor.
+	// And then, in **the project's Mass Entity Settings**, we'll add UMassSteerToMoveTargetProcessor
+	// to a "Steering" group, and add that "Steering" group to our ExecuteBefore list to ensure
+	// UMassTrafficCrowdYieldProcessor runs "just before" UMassSteerToMoveTargetProcessor.
+	ExecutionOrder.ExecuteAfter.Add(UE::Mass::ProcessorGroupNames::Tasks);
+	ExecutionOrder.ExecuteBefore.Add(UE::Mass::ProcessorGroupNames::Avoidance);
+}
+
+void UMassTrafficCrowdYieldProcessor::ConfigureQueries()
+{
+	EntityQuery.AddTagRequirement<FMassCrowdTag>(EMassFragmentPresence::All);
+	EntityQuery.AddRequirement<FMassMoveTargetFragment>(EMassFragmentAccess::ReadWrite);
+	EntityQuery.AddRequirement<FMassZoneGraphLaneLocationFragment>(EMassFragmentAccess::ReadOnly);
+
+	EntityQuery.AddSubsystemRequirement<UMassTrafficSubsystem>(EMassFragmentAccess::ReadWrite);
+}
+
+
+void UMassTrafficCrowdYieldProcessor::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
+{
+	EntityQuery.ForEachEntityChunk(EntityManager, Context, [&](FMassExecutionContext& QueryContext)
+		{
+			UMassTrafficSubsystem& MassTrafficSubsystem = QueryContext.GetMutableSubsystemChecked<UMassTrafficSubsystem>();
+
+			const TArrayView<FMassMoveTargetFragment> MoveTargetFragments = QueryContext.GetMutableFragmentView<FMassMoveTargetFragment>();
+			const TConstArrayView<FMassZoneGraphLaneLocationFragment> LaneLocationFragments = QueryContext.GetFragmentView<FMassZoneGraphLaneLocationFragment>();
+	
+			const int32 NumEntities = Context.GetNumEntities();
+		
+			for (int32 EntityIndex = 0; EntityIndex < NumEntities; ++EntityIndex)
+			{
+				const FMassEntityHandle EntityHandle = QueryContext.GetEntity(EntityIndex);
+				
+				FMassMoveTargetFragment& MoveTargetFragment = MoveTargetFragments[EntityIndex];
+				const FMassZoneGraphLaneLocationFragment& LaneLocationFragment = LaneLocationFragments[EntityIndex];
+
+				if (!ensureMsgf(LaneLocationFragment.LaneLength > 0.0f, TEXT("Must have LaneLocationFragment.LaneLength > 0.0f in UMassTrafficCrowdYieldProcessor::Execute.  LaneLocationFragment.LaneHandle.Index: %d."), LaneLocationFragment.LaneHandle.Index))
+				{
+					return;
+				}
+				
+				FMassTrafficCrosswalkLaneInfo* CrosswalkLaneInfo = MassTrafficSubsystem.GetMutableCrosswalkLaneInfo(LaneLocationFragment.LaneHandle);
+
+				// If this Entity is not on a crosswalk, there's nothing to do here.
+				if (CrosswalkLaneInfo == nullptr)
+				{
+					return;
+				}
+
+				const auto& ShouldYieldToIncomingVehicleLane = [&MassTrafficSubsystem, &LaneLocationFragment, this](const FZoneGraphLaneHandle& IncomingVehicleLane)
+				{
+					const FZoneGraphTrafficLaneData* IncomingTrafficLaneData = MassTrafficSubsystem.GetTrafficLaneData(IncomingVehicleLane);
+					
+					if (!ensureMsgf(IncomingTrafficLaneData != nullptr, TEXT("Must get valid IncomingTrafficLaneData from IncomingVehicleLane in UMassTrafficCrowdYieldProcessor::Execute.  IncomingVehicleLane.Index: %d."), IncomingVehicleLane.Index))
+					{
+						return false;
+					}
+					
+					// If there are no vehicles on this lane, we don't need to worry about yielding to them.
+					// Crowd Entities are only meant to *reactively* yield to vehicles.
+					if (IncomingTrafficLaneData->NumVehiclesOnLane <= 0)
+					{
+						return false;
+					}
+
+					// If this lane already has yielding vehicles, we don't need to yield to them.
+					if (IncomingTrafficLaneData->HasYieldingVehicles())
+					{
+						return false;
+					}
+					
+					const float NormalizedDistanceAlongLane = LaneLocationFragment.DistanceAlongLane / LaneLocationFragment.LaneLength;
+
+					// If we're "too far along the lane", we'll keep going through the intersection.
+					// The expectation is that vehicles should yield to us under these conditions.
+					if (NormalizedDistanceAlongLane > MassTrafficSettings->NormalizedYieldResumeLaneDistance_Crosswalk_AwayFromIntersectionExit)
+					{
+						return false;
+					}
+
+					// If no vehicle on this lane is yielding, but there are vehicles on this lane,
+					// and we're not "too far along the lane", we need to yield to the incoming vehicles.
+					return true;
+				};
+
+				const bool bWasAlreadyYieldingOnCrosswalk = CrosswalkLaneInfo->IsEntityOnCrosswalkYieldingToAnyLane(EntityHandle);
+
+				bool bShouldYieldOnCrosswalk = false;
+				for (const FZoneGraphLaneHandle& IncomingVehicleLane : CrosswalkLaneInfo->IncomingVehicleLanes)
+				{
+					
+					if (ShouldYieldToIncomingVehicleLane(IncomingVehicleLane))
+					{
+						// We should yield to this incoming vehicle lane.
+						// So, start tracking yield state data for the lane.
+						CrosswalkLaneInfo->TrackEntityOnCrosswalkYieldingToLane(EntityHandle, IncomingVehicleLane);
+						bShouldYieldOnCrosswalk = true;
+					}
+					else
+					{
+						// If we're not tracking yield state data for this lane, ignore it.
+						if (!CrosswalkLaneInfo->IsEntityOnCrosswalkYieldingToLane(EntityHandle, IncomingVehicleLane))
+						{
+							continue;
+						}
+
+						// Stop tracking yield state data for this lane.
+						CrosswalkLaneInfo->UnTrackEntityOnCrosswalkYieldingToLane(EntityHandle, IncomingVehicleLane);
+					}
+				}
+
+				// If we should *start* yielding on the crosswalk, ...
+				if (!bWasAlreadyYieldingOnCrosswalk && bShouldYieldOnCrosswalk)
+				{
+					// Let's keep track of our MoveTargetFragment's DesiredSpeed
+					// so that we can resume this DesiredSpeed after we're done yielding.
+					CrosswalkLaneInfo->TrackEntityOnCrosswalkYieldResumeSpeed(EntityHandle, MoveTargetFragment.DesiredSpeed);
+					
+					// Set our MoveTargetFragment's DesiredSpeed to zero.
+					// This is the mechanism we use to yield.
+					MoveTargetFragment.DesiredSpeed = FMassInt16Real(0.0f);
+				}
+				// If we should *stop* yielding on the crosswalk, ...
+				else if (bWasAlreadyYieldingOnCrosswalk && !bShouldYieldOnCrosswalk)
+				{
+					// Restore our MoveTargetFragment's DesiredSpeed to the value before we started yielding.
+					// This will set us in motion again.
+					MoveTargetFragment.DesiredSpeed = CrosswalkLaneInfo->GetEntityYieldResumeSpeed(EntityHandle);
+
+					// Finally, we need to completely untrack all yield state data associated with this Entity.
+					CrosswalkLaneInfo->UnTrackEntityYieldingOnCrosswalk(EntityHandle);
+				}
+			}
+		});
+}

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficInitTrafficVehicleSpeedProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficInitTrafficVehicleSpeedProcessor.cpp
@@ -34,6 +34,8 @@ void UMassTrafficInitTrafficVehicleSpeedProcessor::Execute(FMassEntityManager& E
 		const TConstArrayView<FMassZoneGraphLaneLocationFragment> LaneLocationFragments = QueryContext.GetFragmentView<FMassZoneGraphLaneLocationFragment>();
 		const TArrayView<FMassTrafficVehicleControlFragment> VehicleControlFragments = QueryContext.GetMutableFragmentView<FMassTrafficVehicleControlFragment>();
 
+		const UWorld* World = QueryContext.GetWorld();
+
 		for (int32 Index = 0; Index < NumEntities; ++Index)
 		{
 			const FMassTrafficRandomFractionFragment& RandomFractionFragment = RandomFractionFragments[Index];
@@ -60,6 +62,7 @@ void UMassTrafficInitTrafficVehicleSpeedProcessor::Execute(FMassEntityManager& E
 			bool bIsFrontOfVehicleBeyondEndOfLane = false;
 			bool bNoNext = false;
 			bool bNoRoom = false;
+			bool bShouldProceedAtStopSign = false;
 			const bool bMustStopAtLaneExit = UE::MassTraffic::ShouldStopAtLaneExit(
 				LaneLocationFragment.DistanceAlongLane,
 				VehicleControlFragment.Speed,
@@ -67,14 +70,20 @@ void UMassTrafficInitTrafficVehicleSpeedProcessor::Execute(FMassEntityManager& E
 				RandomFractionFragment.RandomFraction,
 				LaneLocationFragment.LaneLength,
 				VehicleControlFragment.NextLane,
+				VehicleControlFragment.ReadiedNextIntersectionLane,
 				MassTrafficSettings->MinimumDistanceToNextVehicleRange,
+				MassTrafficSettings->StoppingDistanceRange,
 				EntityManager,
 				/*out*/bRequestDifferentNextLane,
 				/*in/out*/bVehicleCantStopAtLaneExit,
 				/*out*/bIsFrontOfVehicleBeyondEndOfLane,
 				/*out*/bNoRoom,
 				/*out*/bNoNext,
-				MassTrafficSettings->StandardTrafficPrepareToStopSeconds
+				/*out*/bShouldProceedAtStopSign,
+				MassTrafficSettings->StandardTrafficPrepareToStopSeconds,
+				VehicleControlFragment.TimeVehicleStopped,
+				VehicleControlFragment.MinVehicleStopSignRestTime,
+				World
 			);
 			
 			// CalculateTargetSpeed has time based variables that use the current speed to convert times

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficIntersectionSpawnDataGenerator.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficIntersectionSpawnDataGenerator.cpp
@@ -535,6 +535,34 @@ void UMassTrafficIntersectionSpawnDataGenerator::Generate(UObject& QueryOwner, T
 
 					// Period -
 					//		Vehicles - bidirectional, this side to opposite/right side, opposite to this/left side
+					//		Pedestrians - bidirectional, across left side and right side
+					{
+						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(
+							IntersectionDetail->bHasTrafficLights ?
+								StandardCrosswalkGoSeconds /*this period is really about the crosswalks*/ :
+								StandardMinimumTrafficGoSeconds);
+
+						Period.VehicleLanes.Append(VehicleTrafficLanes_This_To_OppositeAndRight);
+						Period.VehicleLanes.Append(VehicleTrafficLanes_Opposite_To_ThisAndLeft); // ..left? actually means opposite side's right (our left)
+
+						Period.CrosswalkLanes.Append(LeftSide.CrosswalkLanes.Array());
+						Period.CrosswalkLanes.Append(RightSide.CrosswalkLanes.Array());
+
+						Period.CrosswalkWaitingLanes.Append(LeftSide.CrosswalkWaitingLanes.Array());
+						Period.CrosswalkWaitingLanes.Append(RightSide.CrosswalkWaitingLanes.Array());
+						
+						Period.AddTrafficLightControl(ThisTrafficLightIndex, EMassTrafficLightStateFlags::VehicleGo);
+						Period.AddTrafficLightControl(OppositeTrafficLightIndex, EMassTrafficLightStateFlags::VehicleGo);
+						Period.AddTrafficLightControl(LeftTrafficLightIndex, EMassTrafficLightStateFlags::PedestrianGo_LeftSide);
+						Period.AddTrafficLightControl(RightTrafficLightIndex, EMassTrafficLightStateFlags::PedestrianGo_RightSide);
+
+						// Remember which traffic light controls which lane, for Period::Finalize()
+						LaneToTrafficLightMap.SetTrafficLightForLanes(VehicleTrafficLanes_This_To_OppositeAndRight, ThisTrafficLightIndex);
+						LaneToTrafficLightMap.SetTrafficLightForLanes(VehicleTrafficLanes_Opposite_To_ThisAndLeft, OppositeTrafficLightIndex);
+					}
+
+					// Period -
+					//		Vehicles - bidirectional, this side to opposite/right side, opposite to this/left side
 					//		Pedestrians - none
 					{
 						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficIntersectionSpawnDataGenerator.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficIntersectionSpawnDataGenerator.cpp
@@ -305,7 +305,8 @@ void UMassTrafficIntersectionSpawnDataGenerator::Generate(UObject& QueryOwner, T
 					continue;
 				}
 			}
-			
+
+			IntersectionFragment.NumSides = IntersectionDetail->Sides.Num();
 
 			// Add traffic mass lights to the intersection.
 			// Make a mapping that tells which intersection side is controlled by which of the intersection's mass
@@ -435,28 +436,15 @@ void UMassTrafficIntersectionSpawnDataGenerator::Generate(UObject& QueryOwner, T
 				}
 			}
 
-			// For 4-sided intersections (most of them) - without traffic lights - that can support bi-directional traffic..
+			// For 4-sided intersections (most of them) -
 			// NOTE - Period times depend on whether or not there are traffic lights.
 			// NOTE - The intersection processor treats these intersections differently depending on if they have traffic lights.
 			
 			else if (IntersectionDetail->Sides.Num() == 4 &&
-				
-				// 4WAYSTOPSIGN - Adding a check for bHasTrafficLights will make it so stop-sign intersections do NOT have
-				// cross-traffic. If you want them to, then simply remove this check. The problem with cross-traffic stop
-				// signs is that since two sides of the bi-directional periods are both open at the same time, one side
-				// allows cars to run the stop sign. I don't think we have a way to create a period that will allow 4-way
-				// stop-sign cross-traffic without significant changes to the way periods and intersections work. Aside from
-				// that, there have been comments that 4-way stop-sign cross-traffic looks unnatural and confusing. And since
-				// addressing the time-delay issues with intersections, it doesn't actually seem we need to / should do this.
-				// It's actually against the law -
-				IntersectionDetail->bHasTrafficLights && // (See all 4WAYSTOPSIGN.)
-				
 				IntersectionDetail->IsMostlySquare() &&
 				!IntersectionDetail->HasHiddenSides() &&
 				!IntersectionDetail->HasSideWithInboundLanesFromFreeway())
 			{
-				// Make several periods from each side..
-				
 				for (int32 S = 0; S < 4; S++)
 				{
 					// NOTE - The (SideIndex+N)%4 assumptions work because of the clockwise ordering of the sides.
@@ -469,121 +457,337 @@ void UMassTrafficIntersectionSpawnDataGenerator::Generate(UObject& QueryOwner, T
 					const FMassTrafficIntersectionSide& OppositeSide = IntersectionDetail->Sides[SOpposite];
 					const FMassTrafficIntersectionSide& RightSide = IntersectionDetail->Sides[SRight];
 
-					const int8 ThisTrafficLightIndex = IntersectionSide_To_TrafficLightIndex[S];
-					const int8 LeftTrafficLightIndex = IntersectionSide_To_TrafficLightIndex[SLeft];
-					const int8 OppositeTrafficLightIndex = IntersectionSide_To_TrafficLightIndex[SOpposite];
-					const int8 RightTrafficLightIndex = IntersectionSide_To_TrafficLightIndex[SRight];
-					
-					// Vehicle fragment lists we'll need.
-					
-					TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_This_To_Opposite;
+					if (IntersectionDetail->bHasTrafficLights)
 					{
-						IntersectionDetail->GetTrafficLanesConnectingSides(
-							S, SOpposite, *ZoneGraphStorage, VehicleTrafficLanes_This_To_Opposite);
-					}
+						TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_This_To_Opposite;
+						{
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								S, SOpposite, *ZoneGraphStorage, VehicleTrafficLanes_This_To_Opposite);
+						}
 						
-					TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_Opposite_To_This;
-					{
-						IntersectionDetail->GetTrafficLanesConnectingSides(
-							SOpposite, S, *ZoneGraphStorage, VehicleTrafficLanes_Opposite_To_This);
-					}
+						TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_Opposite_To_This;
+						{
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								SOpposite, S, *ZoneGraphStorage, VehicleTrafficLanes_Opposite_To_This);
+						}
 
-					TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_This_To_OppositeAndRight;
-					{
-						IntersectionDetail->GetTrafficLanesConnectingSides(
-							S, SOpposite, *ZoneGraphStorage, VehicleTrafficLanes_This_To_OppositeAndRight);
-						IntersectionDetail->GetTrafficLanesConnectingSides(
-							S, SRight, *ZoneGraphStorage, VehicleTrafficLanes_This_To_OppositeAndRight);
-					}
+						TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_This_To_OppositeAndRight;
+						{
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								S, SOpposite, *ZoneGraphStorage, VehicleTrafficLanes_This_To_OppositeAndRight);
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								S, SRight, *ZoneGraphStorage, VehicleTrafficLanes_This_To_OppositeAndRight);
+						}
 
-					TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_Opposite_To_ThisAndLeft;
-					{
-						IntersectionDetail->GetTrafficLanesConnectingSides(
-							SOpposite, S, *ZoneGraphStorage, VehicleTrafficLanes_Opposite_To_ThisAndLeft);
-						IntersectionDetail->GetTrafficLanesConnectingSides(
-							SOpposite, SLeft, *ZoneGraphStorage, VehicleTrafficLanes_Opposite_To_ThisAndLeft);
-					}
+						TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_Opposite_To_ThisAndLeft;
+						{
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								SOpposite, S, *ZoneGraphStorage, VehicleTrafficLanes_Opposite_To_ThisAndLeft);
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								SOpposite, SLeft, *ZoneGraphStorage, VehicleTrafficLanes_Opposite_To_ThisAndLeft);
+						}
 
-					TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_This_To_AllOther;
-					{
-						IntersectionDetail->GetTrafficLanesConnectingSides(
-							S, SOpposite, *ZoneGraphStorage, VehicleTrafficLanes_This_To_AllOther);
-						IntersectionDetail->GetTrafficLanesConnectingSides(
-							S, SLeft, *ZoneGraphStorage, VehicleTrafficLanes_This_To_AllOther);
-						IntersectionDetail->GetTrafficLanesConnectingSides(
-							S, SRight, *ZoneGraphStorage, VehicleTrafficLanes_This_To_AllOther);
-					}
-
-
-					// Period -
-					//		Vehicles - this side to all sides
-					//		Pedestrians - none
-					{
-						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(
-							IntersectionDetail->bHasTrafficLights ?
+						TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_This_To_AllOther;
+						{
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								S, SOpposite, *ZoneGraphStorage, VehicleTrafficLanes_This_To_AllOther);
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								S, SLeft, *ZoneGraphStorage, VehicleTrafficLanes_This_To_AllOther);
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								S, SRight, *ZoneGraphStorage, VehicleTrafficLanes_This_To_AllOther);
+						}
+						
+						const int8 ThisTrafficLightIndex = IntersectionSide_To_TrafficLightIndex[S];
+						const int8 LeftTrafficLightIndex = IntersectionSide_To_TrafficLightIndex[SLeft];
+						const int8 OppositeTrafficLightIndex = IntersectionSide_To_TrafficLightIndex[SOpposite];
+						const int8 RightTrafficLightIndex = IntersectionSide_To_TrafficLightIndex[SRight];
+						
+						// Period -
+						//		Vehicles - this side to all sides
+						//		Pedestrians - none
+						{
+							FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(
 								UnidirectionalTrafficStraightRightLeftGoSeconds *
-								(ThisSide.bHasInboundLanesFromFreeway ? FreewayIncomingTrafficGoDurationScale : 1.0f) :
-								StandardMinimumTrafficGoSeconds);
+								(ThisSide.bHasInboundLanesFromFreeway ? FreewayIncomingTrafficGoDurationScale : 1.0f));
 
-						Period.VehicleLanes.Append(VehicleTrafficLanes_This_To_AllOther);
-						
-						Period.AddTrafficLightControl(ThisTrafficLightIndex, EMassTrafficLightStateFlags::VehicleGo | EMassTrafficLightStateFlags::VehicleGoProtectedLeft);
+							Period.VehicleLanes.Append(VehicleTrafficLanes_This_To_AllOther);
+							
+							Period.AddTrafficLightControl(ThisTrafficLightIndex, EMassTrafficLightStateFlags::VehicleGo | EMassTrafficLightStateFlags::VehicleGoProtectedLeft);
 
-						// Remember which traffic light controls which lane, for Period::Finalize()
-						LaneToTrafficLightMap.SetTrafficLightForLanes(VehicleTrafficLanes_This_To_AllOther, ThisTrafficLightIndex);
+							// Remember which traffic light controls which lane, for Period::Finalize()
+							LaneToTrafficLightMap.SetTrafficLightForLanes(VehicleTrafficLanes_This_To_AllOther, ThisTrafficLightIndex);
+						}
+
+						// Period -
+						//		Vehicles - bidirectional, this side to opposite/right side, opposite to this/left side
+						//		Pedestrians - bidirectional, across left side and right side
+						{
+							FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(StandardTrafficGoSeconds);
+
+							Period.VehicleLanes.Append(VehicleTrafficLanes_This_To_OppositeAndRight);
+							Period.VehicleLanes.Append(VehicleTrafficLanes_Opposite_To_ThisAndLeft); // ..left? actually means opposite side's right (our left)
+
+							Period.CrosswalkLanes.Append(LeftSide.CrosswalkLanes.Array());
+							Period.CrosswalkLanes.Append(RightSide.CrosswalkLanes.Array());
+
+							Period.CrosswalkWaitingLanes.Append(LeftSide.CrosswalkWaitingLanes.Array());
+							Period.CrosswalkWaitingLanes.Append(RightSide.CrosswalkWaitingLanes.Array());
+							
+							Period.AddTrafficLightControl(ThisTrafficLightIndex, EMassTrafficLightStateFlags::VehicleGo | EMassTrafficLightStateFlags::PedestrianGo);
+							Period.AddTrafficLightControl(OppositeTrafficLightIndex, EMassTrafficLightStateFlags::VehicleGo | EMassTrafficLightStateFlags::PedestrianGo);
+
+							// Remember which traffic light controls which lane, for Period::Finalize()
+							LaneToTrafficLightMap.SetTrafficLightForLanes(VehicleTrafficLanes_This_To_OppositeAndRight, ThisTrafficLightIndex);
+							LaneToTrafficLightMap.SetTrafficLightForLanes(VehicleTrafficLanes_Opposite_To_ThisAndLeft, OppositeTrafficLightIndex);
+						}
 					}
+					// Special handling for 4-way intersections with stop-signs.
+					else
+					{
+						TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_Left_To_OppositeAndRight;
+						{
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								SLeft, SRight, *ZoneGraphStorage, VehicleTrafficLanes_Left_To_OppositeAndRight);
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								SLeft, S, *ZoneGraphStorage, VehicleTrafficLanes_Left_To_OppositeAndRight);
+						}
+
+						TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_Right_To_OppositeAndRight;
+						{
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								SRight, SLeft, *ZoneGraphStorage, VehicleTrafficLanes_Right_To_OppositeAndRight);
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								SRight, SOpposite, *ZoneGraphStorage, VehicleTrafficLanes_Right_To_OppositeAndRight);
+						}
+						
+						TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_Opposite_To_OppositeAndRight;
+						{
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								SOpposite, S, *ZoneGraphStorage, VehicleTrafficLanes_Opposite_To_OppositeAndRight);
+							IntersectionDetail->GetTrafficLanesConnectingSides(
+								SOpposite, SLeft, *ZoneGraphStorage, VehicleTrafficLanes_Opposite_To_OppositeAndRight);
+						}
+						
+						// Period -
+						//		Vehicles - This side to all sides
+						//		Pedestrians - None
+						{
+							FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(StandardMinimumTrafficGoSeconds);
+
+							Period.VehicleLanes.Append(ThisSide.VehicleIntersectionLanes);
+						}
+						
+						// Period -
+						//		Vehicles - Left to opposite side and its right.  Right to opposite side and its right.
+						//		Pedestrians - None
+						{
+							FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(StandardMinimumTrafficGoSeconds);
+
+							Period.VehicleLanes.Append(VehicleTrafficLanes_Left_To_OppositeAndRight);
+							Period.VehicleLanes.Append(VehicleTrafficLanes_Right_To_OppositeAndRight);
+						}
+						
+						// Period -
+						//		Vehicles - This side to opposite side and its right.  Opposite side to this side and its right.
+						//		Pedestrians - None
+						{
+							FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(StandardMinimumTrafficGoSeconds);
+
+							Period.VehicleLanes.Append(VehicleTrafficLanes_Left_To_OppositeAndRight);
+							Period.VehicleLanes.Append(VehicleTrafficLanes_Right_To_OppositeAndRight);
+						}
+					}
+				}
+			}
+
+			// Special handling for T-intersections.
+			else if (IntersectionDetail->Sides.Num() == 3)
+			{
+				const auto GetBaseOfTSideIndex = [&IntersectionDetail]()
+				{
+					float MinDotProduct = TNumericLimits<float>::Max();
+					int32 BaseOfTSideIndex = INDEX_NONE;
+					
+					for (int32 S = 0; S < IntersectionDetail->Sides.Num(); S++)
+					{
+						// Sides are sorted in clockwise order.
+						const uint32 SNext = (S + 1) % 3;
+						const uint32 SNextNext = (S + 2) % 3;
+						
+						FMassTrafficIntersectionSide& SideNext = IntersectionDetail->Sides[SNext];
+						FMassTrafficIntersectionSide& SideNextNext = IntersectionDetail->Sides[SNextNext];
+
+						const float DotProduct = FVector::DotProduct(SideNext.DirectionIntoIntersection, SideNextNext.DirectionIntoIntersection);
+						if (DotProduct < MinDotProduct)
+						{
+							MinDotProduct = DotProduct;
+							BaseOfTSideIndex = S;
+						}
+					}
+					
+					return BaseOfTSideIndex;
+				};
+
+				const uint32 SBaseOfT = GetBaseOfTSideIndex();
+				const uint32 SLeft = (SBaseOfT + 1) % 3;
+				const uint32 SRight = (SBaseOfT + 2) % 3;
+				
+				FMassTrafficIntersectionSide& BaseOfTSide = IntersectionDetail->Sides[SBaseOfT];
+				FMassTrafficIntersectionSide& LeftSide = IntersectionDetail->Sides[SLeft];
+				FMassTrafficIntersectionSide& RightSide = IntersectionDetail->Sides[SRight];
+				
+				TArray<FZoneGraphTrafficLaneData*> VehicleTrafficLanes_Right_To_Opposite;
+                {
+                	IntersectionDetail->GetTrafficLanesConnectingSides(
+                		SRight, SLeft, *ZoneGraphStorage, VehicleTrafficLanes_Right_To_Opposite);
+                }
+
+				// Special handling for T-intersections with traffic lights.
+				// When vehicles go for the base of the T, pedestrian go on each side.
+				// When vehicles go for the "through" road, pedestrians go for the "through" road.
+				if (IntersectionDetail->bHasTrafficLights)
+				{
+					const int8 TrafficLightIndex_BaseOfT = IntersectionSide_To_TrafficLightIndex[SBaseOfT];
+					const int8 TrafficLightIndex_Left = IntersectionSide_To_TrafficLightIndex[SLeft];
+					const int8 TrafficLightIndex_Right = IntersectionSide_To_TrafficLightIndex[SRight];
+					// ..NOTE - Can end up being INDEX_NONE if there is no traffic light.
 
 					// Period -
-					//		Vehicles - bidirectional, this side to opposite/right side, opposite to this/left side
-					//		Pedestrians - bidirectional, across left side and right side
+					//		Vehicles - None
+					//		Pedestrians - Left and Right Side
 					{
-						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(
-							IntersectionDetail->bHasTrafficLights ?
-								StandardCrosswalkGoSeconds /*this period is really about the crosswalks*/ :
-								StandardMinimumTrafficGoSeconds);
-
-						Period.VehicleLanes.Append(VehicleTrafficLanes_This_To_OppositeAndRight);
-						Period.VehicleLanes.Append(VehicleTrafficLanes_Opposite_To_ThisAndLeft); // ..left? actually means opposite side's right (our left)
-
+						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(StandardCrosswalkGoHeadStartSeconds);
+						
 						Period.CrosswalkLanes.Append(LeftSide.CrosswalkLanes.Array());
 						Period.CrosswalkLanes.Append(RightSide.CrosswalkLanes.Array());
 
 						Period.CrosswalkWaitingLanes.Append(LeftSide.CrosswalkWaitingLanes.Array());
 						Period.CrosswalkWaitingLanes.Append(RightSide.CrosswalkWaitingLanes.Array());
 						
-						Period.AddTrafficLightControl(ThisTrafficLightIndex, EMassTrafficLightStateFlags::VehicleGo);
-						Period.AddTrafficLightControl(OppositeTrafficLightIndex, EMassTrafficLightStateFlags::VehicleGo);
-						Period.AddTrafficLightControl(LeftTrafficLightIndex, EMassTrafficLightStateFlags::PedestrianGo_LeftSide);
-						Period.AddTrafficLightControl(RightTrafficLightIndex, EMassTrafficLightStateFlags::PedestrianGo_RightSide);
-
-						// Remember which traffic light controls which lane, for Period::Finalize()
-						LaneToTrafficLightMap.SetTrafficLightForLanes(VehicleTrafficLanes_This_To_OppositeAndRight, ThisTrafficLightIndex);
-						LaneToTrafficLightMap.SetTrafficLightForLanes(VehicleTrafficLanes_Opposite_To_ThisAndLeft, OppositeTrafficLightIndex);
+						Period.AddTrafficLightControl(TrafficLightIndex_BaseOfT, EMassTrafficLightStateFlags::PedestrianGo);
 					}
 
 					// Period -
-					//		Vehicles - bidirectional, this side to opposite/right side, opposite to this/left side
-					//		Pedestrians - none
+					//		Vehicles - Base of T to Left and Right Side
+					//		Pedestrians - Left and Right Side
 					{
-						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(
-							IntersectionDetail->bHasTrafficLights ?
-								BidirectionalTrafficStraightRightGoSeconds *
-								((ThisSide.bHasInboundLanesFromFreeway || OppositeSide.bHasInboundLanesFromFreeway) ? FreewayIncomingTrafficGoDurationScale : 1.0f) :
-								StandardMinimumTrafficGoSeconds);
+						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(StandardTrafficGoSeconds);
 
-						Period.VehicleLanes.Append(VehicleTrafficLanes_This_To_OppositeAndRight);
-						Period.VehicleLanes.Append(VehicleTrafficLanes_Opposite_To_ThisAndLeft); // ..left? actually means opposite side's right (our left)
+						Period.VehicleLanes.Append(BaseOfTSide.VehicleIntersectionLanes);
 						
-						Period.AddTrafficLightControl(ThisTrafficLightIndex, EMassTrafficLightStateFlags::VehicleGo);
-						Period.AddTrafficLightControl(OppositeTrafficLightIndex, EMassTrafficLightStateFlags::VehicleGo);
+						Period.CrosswalkLanes.Append(LeftSide.CrosswalkLanes.Array());
+						Period.CrosswalkLanes.Append(RightSide.CrosswalkLanes.Array());
 
+						Period.CrosswalkWaitingLanes.Append(LeftSide.CrosswalkWaitingLanes.Array());
+						Period.CrosswalkWaitingLanes.Append(RightSide.CrosswalkWaitingLanes.Array());
+							
+						Period.AddTrafficLightControl(TrafficLightIndex_BaseOfT, EMassTrafficLightStateFlags::VehicleGo | EMassTrafficLightStateFlags::PedestrianGo);
+						
 						// Remember which traffic light controls which lane, for Period::Finalize()
-						LaneToTrafficLightMap.SetTrafficLightForLanes(VehicleTrafficLanes_This_To_OppositeAndRight, ThisTrafficLightIndex);
-						LaneToTrafficLightMap.SetTrafficLightForLanes(VehicleTrafficLanes_Opposite_To_ThisAndLeft, OppositeTrafficLightIndex);
+						LaneToTrafficLightMap.SetTrafficLightForLanes(BaseOfTSide.VehicleIntersectionLanes, TrafficLightIndex_BaseOfT);
+					}
+					
+					// Period -
+					//		Vehicles - None
+					//		Pedestrians - Base of T
+					{
+						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(StandardCrosswalkGoHeadStartSeconds);
+						
+						Period.CrosswalkLanes.Append(BaseOfTSide.CrosswalkLanes.Array());
+
+						Period.CrosswalkWaitingLanes.Append(BaseOfTSide.CrosswalkWaitingLanes.Array());
+						
+						Period.AddTrafficLightControl(TrafficLightIndex_Left, EMassTrafficLightStateFlags::PedestrianGo);
+						Period.AddTrafficLightControl(TrafficLightIndex_Right, EMassTrafficLightStateFlags::PedestrianGo);
+					}
+
+					// Period -
+					//		Vehicles - Right to other two sides.  (We need this period since the vehicles don't know how to perform unprotected lefts.)
+					//		Pedestrians - Base of T
+					{
+						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(UnidirectionalTrafficStraightRightLeftGoSeconds);
+						
+						Period.VehicleLanes.Append(RightSide.VehicleIntersectionLanes);
+						
+						Period.CrosswalkLanes.Append(BaseOfTSide.CrosswalkLanes.Array());
+
+						Period.CrosswalkWaitingLanes.Append(BaseOfTSide.CrosswalkWaitingLanes.Array());
+						
+						Period.AddTrafficLightControl(TrafficLightIndex_Left, EMassTrafficLightStateFlags::PedestrianGo);
+						Period.AddTrafficLightControl(TrafficLightIndex_Right, EMassTrafficLightStateFlags::VehicleGo | EMassTrafficLightStateFlags::VehicleGoProtectedLeft | EMassTrafficLightStateFlags::PedestrianGo);
+						
+						// Remember which traffic light controls which lane, for Period::Finalize()
+						LaneToTrafficLightMap.SetTrafficLightForLanes(RightSide.VehicleIntersectionLanes, TrafficLightIndex_Right);
+					}
+					
+					// Period -
+					//		Vehicles - Left to other two sides.  Right to Left side (ie. "through" traffic only).
+					//		Pedestrians - Base of T
+					{
+						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(StandardTrafficGoSeconds);
+
+						Period.VehicleLanes.Append(LeftSide.VehicleIntersectionLanes);
+						Period.VehicleLanes.Append(VehicleTrafficLanes_Right_To_Opposite);
+						
+						Period.CrosswalkLanes.Append(BaseOfTSide.CrosswalkLanes.Array());
+
+						Period.CrosswalkWaitingLanes.Append(BaseOfTSide.CrosswalkWaitingLanes.Array());
+						
+						Period.AddTrafficLightControl(TrafficLightIndex_Left, EMassTrafficLightStateFlags::VehicleGo | EMassTrafficLightStateFlags::PedestrianGo);
+						Period.AddTrafficLightControl(TrafficLightIndex_Right, EMassTrafficLightStateFlags::VehicleGo | EMassTrafficLightStateFlags::PedestrianGo);
+						
+						// Remember which traffic light controls which lane, for Period::Finalize()
+						LaneToTrafficLightMap.SetTrafficLightForLanes(LeftSide.VehicleIntersectionLanes, TrafficLightIndex_Left);
+						LaneToTrafficLightMap.SetTrafficLightForLanes(VehicleTrafficLanes_Right_To_Opposite, TrafficLightIndex_Right);
+					}
+				}
+				// Special handling for T-intersections with stop signs.
+				else
+				{
+					// Period -
+					//		Vehicles - Base of T to Left and Right Side
+					//		Pedestrians - Left and Right Side
+					{
+						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(StandardMinimumTrafficGoSeconds);
+
+						Period.VehicleLanes.Append(BaseOfTSide.VehicleIntersectionLanes);
+						
+						Period.CrosswalkLanes.Append(LeftSide.CrosswalkLanes.Array());
+						Period.CrosswalkLanes.Append(RightSide.CrosswalkLanes.Array());
+
+						Period.CrosswalkWaitingLanes.Append(LeftSide.CrosswalkWaitingLanes.Array());
+						Period.CrosswalkWaitingLanes.Append(RightSide.CrosswalkWaitingLanes.Array());
+					}
+
+					// Period -
+					//		Vehicles - Right to other two sides.  (Period to allow protected left.)
+					//		Pedestrians - Base of T
+					{
+						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(StandardMinimumTrafficGoSeconds);
+						
+						Period.VehicleLanes.Append(RightSide.VehicleIntersectionLanes);
+						
+						Period.CrosswalkLanes.Append(BaseOfTSide.CrosswalkLanes.Array());
+
+						Period.CrosswalkWaitingLanes.Append(BaseOfTSide.CrosswalkWaitingLanes.Array());
+					}
+					
+					// Period -
+					//		Vehicles - Left to other two sides.  Right to opposite side (ie. "through" traffic only).
+					//		Pedestrians - Base of T
+					{
+						FMassTrafficPeriod& Period = IntersectionFragment.AddPeriod(StandardMinimumTrafficGoSeconds);
+
+						Period.VehicleLanes.Append(LeftSide.VehicleIntersectionLanes);
+						Period.VehicleLanes.Append(VehicleTrafficLanes_Right_To_Opposite);
+						
+						Period.CrosswalkLanes.Append(BaseOfTSide.CrosswalkLanes.Array());
+
+						Period.CrosswalkWaitingLanes.Append(BaseOfTSide.CrosswalkWaitingLanes.Array());
 					}
 				}
 			}
-		
+			
 			// General intersections with traffic lights.
 			// (Each period for vehicles go, and then there is one period for just pedestrians.)
 

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
@@ -1238,6 +1238,14 @@ bool ShouldPerformReactiveYieldAtIntersection(
 				return false;
 			}
 
+			if (!ensureMsgf(CrowdTrackingLaneData->LeadEntityNormalizedDistanceAlongLane.IsSet(), TEXT("CrowdTrackingLaneData has Entities on the lane, but no LeadEntityNormalizedDistanceAlongLane value in IsDownstreamCrosswalkLaneClear.  TestDownstreamCrosswalkLane.Index: %d."), TestDownstreamCrosswalkLane.Index))
+			{
+				// Since there are Entities on the test lane, but we can't determine where the tail Entity is,
+				// we just wait until all Entities fully clear the test lane before allowing vehicles to resume
+				// from yielding.
+				return false;
+			}
+
 			const auto& GetLaneStartDirection = [&ZoneGraphStorage](const FZoneGraphLaneHandle& LaneHandle)
 			{
 				const FZoneLaneData& ZoneLaneData = ZoneGraphStorage.Lanes[LaneHandle.Index];

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
@@ -790,6 +790,8 @@ bool CheckNextVehicle(const FMassEntityHandle Entity, const FMassEntityHandle Ne
 bool ShouldYieldAtIntersection_Internal(
 	const FZoneGraphTrafficLaneData& CurrentLaneData,
 	const FZoneGraphTrafficLaneData& PrevLaneData,
+	const TFunction<bool(const FZoneGraphLaneHandle&)>& IsDownstreamCrosswalkLaneClearFunc,
+	const TFunction<bool(const FZoneGraphLaneHandle&)>& DownstreamCrosswalkLaneHasYieldingEntitiesFunc,
 	const TFunction<bool(const FZoneGraphTrafficLaneData&)>& IsTestLaneClearFunc,
 	const bool bConsiderYieldForGoingStraight = true,
 	const bool bConsiderYieldForLeftTurns = true,
@@ -799,6 +801,28 @@ bool ShouldYieldAtIntersection_Internal(
 	if (!CurrentLaneData.ConstData.bIsIntersectionLane)
 	{
 		return false;
+	}
+
+	// If we're turning, check all the downstream crosswalk lanes for our current lane.
+	//
+	// We assume that the Intersection "Periods" should not give any "through" lane a green light
+	// while there are still pedestrians in the crosswalk downstream of the "through" lane.
+	if (CurrentLaneData.bTurnsLeft || CurrentLaneData.bTurnsRight)
+	{
+		for (const FZoneGraphLaneHandle& DownstreamCrosswalkLane : CurrentLaneData.DownstreamCrosswalkLanes)
+		{
+			// And, we skip over any crosswalk lanes, which already have yielding Entities.
+			if (DownstreamCrosswalkLaneHasYieldingEntitiesFunc(DownstreamCrosswalkLane))
+			{
+				continue;
+			}
+		
+			// We should yield, if any of our downstream crosswalk lanes are not clear.
+			if (!IsDownstreamCrosswalkLaneClearFunc(DownstreamCrosswalkLane))
+			{
+				return true;
+			}
+		}
 	}
 
 	// If we're turning left at an intersection, ...
@@ -932,10 +956,12 @@ bool ShouldYieldAtIntersection_Internal(
 
 bool ShouldPerformPreemptiveYieldAtIntersection(
 	const UMassTrafficSubsystem& MassTrafficSubsystem,
+	const UMassCrowdSubsystem& MassCrowdSubsystem,
 	const FMassEntityManager& EntityManager,
 	const FMassTrafficVehicleControlFragment& VehicleControlFragment,
 	const FMassZoneGraphLaneLocationFragment& LaneLocationFragment,
 	const FAgentRadiusFragment& RadiusFragment,
+	const FZoneGraphStorage& ZoneGraphStorage,
 	bool& OutHasAnotherVehicleEnteredRelevantLaneAfterPreemptiveYieldRollOut)
 {
 	const UMassTrafficSettings* MassTrafficSettings = GetDefault<UMassTrafficSettings>();
@@ -1023,11 +1049,26 @@ bool ShouldPerformPreemptiveYieldAtIntersection(
 			return false;
 		}
 	}
+	
+	const auto& DownstreamCrosswalkLaneHasYieldingEntities = [&MassTrafficSubsystem](const FZoneGraphLaneHandle& TestDownstreamCrosswalkLane)
+	{
+		// Currently, pre-emptively yielding to crosswalk lanes is not implemented.
+		return false;
+	};
+	
+	const auto& IsDownstreamCrosswalkLaneClear = [&MassCrowdSubsystem, &CurrentLaneData, &LaneLocationFragment, &RadiusFragment, &ZoneGraphStorage, MassTrafficSettings](const FZoneGraphLaneHandle& TestDownstreamCrosswalkLane)
+	{
+		// Currently, pre-emptively yielding to crosswalk lanes is not implemented.
+		// So, we just say the crosswalk lanes are always clear from a pre-emptive yield perspective.
+		return true;
+	};
 
 	const auto& IsTestLaneClear = [&EntityManager, &VehicleControlFragment, &CurrentLaneData, &LaneDataBeforeIntersection, MassTrafficSettings](const FZoneGraphTrafficLaneData& TestLane)
 	{
 		if (!VehicleControlFragment.IsPreemptivelyYieldingAtIntersection())
 		{
+			// TODO:  Allow Crowd characters to "ready" their intersection lanes so that vehicles will pre-emptively yield to them.
+			
 			// A pre-emptive yield starts when a vehicle is ready to use the test lane before we are in the intersection.
 			return !(CurrentLaneData == LaneDataBeforeIntersection && TestLane.HasVehiclesReadyToUseIntersectionLane());	// (See all READYLANE.)
 		}
@@ -1085,7 +1126,7 @@ bool ShouldPerformPreemptiveYieldAtIntersection(
 	// So, we don't consider pre-emptively yielding when going straight.
 	// However, vehicles going straight can reactively yield
 	// after an opportunity is given for turning vehicles to reactively yield first.
-	const bool bShouldYieldAtIntersection = ShouldYieldAtIntersection_Internal(*IntersectionLaneData, *LaneDataBeforeIntersection, IsTestLaneClear, false);
+	const bool bShouldYieldAtIntersection = ShouldYieldAtIntersection_Internal(*IntersectionLaneData, *LaneDataBeforeIntersection, IsDownstreamCrosswalkLaneClear, DownstreamCrosswalkLaneHasYieldingEntities, IsTestLaneClear, false);
 
 	// If we are pre-emptively yielding, ...
 	if (VehicleControlFragment.IsPreemptivelyYieldingAtIntersection())
@@ -1123,10 +1164,12 @@ bool ShouldPerformPreemptiveYieldAtIntersection(
 
 bool ShouldPerformReactiveYieldAtIntersection(
 	const UMassTrafficSubsystem& MassTrafficSubsystem,
+	const UMassCrowdSubsystem& MassCrowdSubsystem,
 	const FMassEntityManager& EntityManager,
 	const FMassTrafficVehicleControlFragment& VehicleControlFragment,
 	const FMassZoneGraphLaneLocationFragment& LaneLocationFragment,
 	const FAgentRadiusFragment& RadiusFragment,
+	const FZoneGraphStorage& ZoneGraphStorage,
 	bool& OutShouldGiveOpportunityForTurningVehiclesToReactivelyYieldAtIntersection)
 {
 	const UMassTrafficSettings* MassTrafficSettings = GetDefault<UMassTrafficSettings>();
@@ -1151,6 +1194,109 @@ bool ShouldPerformReactiveYieldAtIntersection(
 	{
 		return false;
 	}
+	
+	const auto& DownstreamCrosswalkLaneHasYieldingEntities = [&MassTrafficSubsystem, &CurrentLaneData](const FZoneGraphLaneHandle& TestDownstreamCrosswalkLane)
+	{
+		const FMassTrafficCrosswalkLaneInfo* CrosswalkLaneInfo = MassTrafficSubsystem.GetCrosswalkLaneInfo(TestDownstreamCrosswalkLane);
+
+		if (!ensureMsgf(CrosswalkLaneInfo != nullptr, TEXT("Must get valid CrosswalkLaneInfo in DownstreamCrosswalkLaneHasYieldingEntities.  TestDownstreamCrosswalkLane.Index: %d."), TestDownstreamCrosswalkLane.Index))
+		{
+			return false;
+		}
+
+		// Are there any Entities on the crosswalk lane that are yielding to our current lane?
+		return CrosswalkLaneInfo->IsAnyEntityOnCrosswalkYieldingToLane(CurrentLaneData->LaneHandle);
+	};
+	
+	const auto& IsDownstreamCrosswalkLaneClear = [&MassCrowdSubsystem, &CurrentLaneData, &LaneLocationFragment, &RadiusFragment, &ZoneGraphStorage, MassTrafficSettings](const FZoneGraphLaneHandle& TestDownstreamCrosswalkLane)
+	{
+		if (!ensureMsgf(CurrentLaneData->bTurnsLeft || CurrentLaneData->bTurnsRight, TEXT("IsDownstreamCrosswalkLaneClear expects CurrentLaneData to be a *turn* lane, not a \"through\" lane.  CurrentLaneData->LaneHandle.Index: %d."), CurrentLaneData->LaneHandle.Index))
+		{
+			// Since we're in an error state, assume it's clear to keep traffic flowing.
+			return true;
+		}
+		
+		if (!ensureMsgf(CurrentLaneData->Length > 0.0f && LaneLocationFragment.LaneLength > 0.0f, TEXT("CurrentLane should have a length greater than zero.")))
+		{
+			// If we have errant lane data, just say it's clear to attempt to keep traffic flowing.
+			return true;
+		}
+		
+		const FCrowdTrackingLaneData* CrowdTrackingLaneData = MassCrowdSubsystem.GetCrowdTrackingLaneData(TestDownstreamCrosswalkLane);
+		
+		if (!ensureMsgf(CrowdTrackingLaneData != nullptr, TEXT("Must get valid CrowdTrackingLaneData in IsDownstreamCrosswalkLaneClear.  TestDownstreamCrosswalkLane.Index: %d."), TestDownstreamCrosswalkLane.Index))
+		{
+			// Since we're in an error state, assume it's clear to keep traffic flowing.
+			return true;
+		}
+
+		if (CrowdTrackingLaneData->NumEntitiesOnLane > 0)
+		{
+			if (!ensureMsgf(CrowdTrackingLaneData->TailEntityNormalizedDistanceAlongLane.IsSet(), TEXT("CrowdTrackingLaneData has Entities on the lane, but no TailEntityNormalizedDistanceAlongLane value in IsDownstreamCrosswalkLaneClear.  TestDownstreamCrosswalkLane.Index: %d."), TestDownstreamCrosswalkLane.Index))
+			{
+				// Since there are Entities on the test lane, but we can't determine where the tail Entity is,
+				// we just wait until all Entities fully clear the test lane before allowing vehicles to resume
+				// from yielding.
+				return false;
+			}
+
+			const auto& GetLaneStartDirection = [&ZoneGraphStorage](const FZoneGraphLaneHandle& LaneHandle)
+			{
+				const FZoneLaneData& ZoneLaneData = ZoneGraphStorage.Lanes[LaneHandle.Index];
+				
+				if (!ensureMsgf(ZoneLaneData.GetNumPoints() >= 2, TEXT("Expected ZoneLaneData.GetNumPoints() >= 2 in IsDownstreamCrosswalkLaneClear.")))
+				{
+					return FVector::ZeroVector;
+				}
+				
+				const int32 LanePointsStartIndex = ZoneLaneData.PointsBegin;
+				const int32 LanePointsEndIndex = LanePointsStartIndex + 1;
+
+				const FVector LaneStartLocation = ZoneGraphStorage.LanePoints[LanePointsStartIndex];
+				const FVector LaneEndLocation = ZoneGraphStorage.LanePoints[LanePointsEndIndex];
+
+				const FVector LaneDirection = (LaneEndLocation - LaneStartLocation).GetSafeNormal();
+
+				return LaneDirection;
+			};
+			
+			const float NormalizedDistanceAlongCurrentLane = (LaneLocationFragment.DistanceAlongLane - RadiusFragment.Radius) / LaneLocationFragment.LaneLength;
+			const float NormalizedYieldCutoffLaneDistance = MassTrafficSettings->NormalizedYieldCutoffLaneDistance_Crosswalk;
+
+			const FVector CurrentLaneStartDirection = GetLaneStartDirection(CurrentLaneData->LaneHandle);
+			const FVector CrosswalkLaneStartDirection = GetLaneStartDirection(TestDownstreamCrosswalkLane);
+
+			const bool bIsCrosswalkLaneGoingSameDirection = FVector::DotProduct(CurrentLaneStartDirection, CrosswalkLaneStartDirection) >= 0.0f;
+
+			// We need to know whether the Entities on the crosswalk lanes will be heading "away" or "towards" our Intersection "exit" lane.
+			const bool bOtherEntityHeadingAwayFromIntersectionExitLane = CurrentLaneData->bTurnsRight ? bIsCrosswalkLaneGoingSameDirection : !bIsCrosswalkLaneGoingSameDirection;
+
+			// If the Entities will be heading *away* from our exit lane, we care about the
+			// *Tail* Entity's distance along the crosswalk lane.  Whereas, if the Entities will be heading *towards*
+			// our exit lane, then we care about the *Lead* Entity's distance along the crosswalk lane.
+			const float NormalizedDistanceAlongTestLane = bOtherEntityHeadingAwayFromIntersectionExitLane
+				? CrowdTrackingLaneData->TailEntityNormalizedDistanceAlongLane.GetValue()
+				: CrowdTrackingLaneData->LeadEntityNormalizedDistanceAlongLane.GetValue();
+
+			// When the Entities are heading *away* from our exit lane,
+			// they are considered "out of the way" when the *Tail* Entity is essentially past
+			// the double-yellow center line (or "effectively" past such a boundary).
+			//
+			// When the Entities are heading *towards* our exit lane,
+			// they are considered "out of the way" when the *Lead* Entity is far enough back
+			// *before* the double-yellow center line (or "effectively" *before* such a boundary).
+			const bool bOtherEntityOutOfTheWay = bOtherEntityHeadingAwayFromIntersectionExitLane
+				? NormalizedDistanceAlongTestLane > MassTrafficSettings->NormalizedYieldResumeLaneDistance_Crosswalk_AwayFromIntersectionExit
+				: NormalizedDistanceAlongTestLane < MassTrafficSettings->NormalizedYieldResumeLaneDistance_Crosswalk_TowardsIntersectionExit;
+
+			if (NormalizedDistanceAlongCurrentLane < NormalizedYieldCutoffLaneDistance && !bOtherEntityOutOfTheWay)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	};
 
 	const auto& IsTestLaneClear = [&EntityManager, &CurrentLaneData, &LaneLocationFragment, &RadiusFragment, MassTrafficSettings](const FZoneGraphTrafficLaneData& TestLane)
 	{
@@ -1194,6 +1340,7 @@ bool ShouldPerformReactiveYieldAtIntersection(
 				return true;
 			}
 
+			// TODO:  Is this a bug where we determine NormalizedYieldCutoffLaneDistance based on TestLane, rather than CurrentLaneData?  Seems like it.
 			const float NormalizedYieldCutoffLaneDistance =
 				TestLane.bTurnsLeft ? MassTrafficSettings->NormalizedYieldCutoffLaneDistance_Left :
 				TestLane.bTurnsRight ? MassTrafficSettings->NormalizedYieldCutoffLaneDistance_Right :
@@ -1213,7 +1360,7 @@ bool ShouldPerformReactiveYieldAtIntersection(
 		return true;
 	};
 
-	const bool bShouldReactivelyYieldAtIntersection = ShouldYieldAtIntersection_Internal(*CurrentLaneData, *PrevLaneData, IsTestLaneClear);
+	const bool bShouldReactivelyYieldAtIntersection = ShouldYieldAtIntersection_Internal(*CurrentLaneData, *PrevLaneData, IsDownstreamCrosswalkLaneClear, DownstreamCrosswalkLaneHasYieldingEntities, IsTestLaneClear);
 
 	// If we haven't started reactively yielding, ...
 	if (!VehicleControlFragment.IsReactivelyYieldingAtIntersection())

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
@@ -1067,8 +1067,6 @@ bool ShouldPerformPreemptiveYieldAtIntersection(
 	{
 		if (!VehicleControlFragment.IsPreemptivelyYieldingAtIntersection())
 		{
-			// TODO:  Allow Crowd characters to "ready" their intersection lanes so that vehicles will pre-emptively yield to them.
-			
 			// A pre-emptive yield starts when a vehicle is ready to use the test lane before we are in the intersection.
 			return !(CurrentLaneData == LaneDataBeforeIntersection && TestLane.HasVehiclesReadyToUseIntersectionLane());	// (See all READYLANE.)
 		}
@@ -1287,7 +1285,7 @@ bool ShouldPerformReactiveYieldAtIntersection(
 			// *before* the double-yellow center line (or "effectively" *before* such a boundary).
 			const bool bOtherEntityOutOfTheWay = bOtherEntityHeadingAwayFromIntersectionExitLane
 				? NormalizedDistanceAlongTestLane > MassTrafficSettings->NormalizedYieldResumeLaneDistance_Crosswalk_AwayFromIntersectionExit
-				: NormalizedDistanceAlongTestLane < MassTrafficSettings->NormalizedYieldResumeLaneDistance_Crosswalk_TowardsIntersectionExit;
+				: NormalizedDistanceAlongTestLane < MassTrafficSettings->NormalizedYieldPedestrianCutoffLaneDistance_Crosswalk_TowardsIntersectionExit;
 
 			if (NormalizedDistanceAlongCurrentLane < NormalizedYieldCutoffLaneDistance && !bOtherEntityOutOfTheWay)
 			{
@@ -1340,7 +1338,6 @@ bool ShouldPerformReactiveYieldAtIntersection(
 				return true;
 			}
 
-			// TODO:  Is this a bug where we determine NormalizedYieldCutoffLaneDistance based on TestLane, rather than CurrentLaneData?  Seems like it.
 			const float NormalizedYieldCutoffLaneDistance =
 				TestLane.bTurnsLeft ? MassTrafficSettings->NormalizedYieldCutoffLaneDistance_Left :
 				TestLane.bTurnsRight ? MassTrafficSettings->NormalizedYieldCutoffLaneDistance_Right :

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficUpdateIntersectionsProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficUpdateIntersectionsProcessor.cpp
@@ -269,7 +269,7 @@ namespace
 	FORCEINLINE bool IsIntersectionEffectivelyClearToAdvanceToNextPeriod(FMassTrafficIntersectionFragment& IntersectionFragment, const EMassTrafficIntersectionVehicleLaneType ClearTest, const FZoneGraphStorage& ZoneGraphStorage, const UMassCrowdSubsystem* MassCrowdSubsystem, const bool bIncludeReservedVehicles = true)
 	{
 		if (AreVehiclesClearOfIntersection(IntersectionFragment, ClearTest, bIncludeReservedVehicles) &&
-			(AreAnyCrosswalkLanesOpenInCurrentPeriod(IntersectionFragment, MassCrowdSubsystem) && AreAllCurrentCrosswalkLanesOpenNextPeriod(IntersectionFragment) ||
+			((AreAnyCrosswalkLanesOpenInCurrentPeriod(IntersectionFragment, MassCrowdSubsystem) && AreAllCurrentCrosswalkLanesOpenNextPeriod(IntersectionFragment)) ||
 			ArePedestriansClearOfIntersection(IntersectionFragment, ZoneGraphStorage, MassCrowdSubsystem)))
 		{
 			return true;
@@ -869,7 +869,7 @@ void UMassTrafficUpdateIntersectionsProcessor::Execute(FMassEntityManager& Entit
 						RandomStream.FRand() <= MassTrafficSettings->StopSignPedestrianLaneOpenProbability;
 					
 					const EMassTrafficPeriodLanesAction PedestrianLanesAction =
-							bPeriodHasAnyOpenCrosswalkLanes && bAreAllCurrentCrosswalkLanesOpenNextPeriod ||
+							(bPeriodHasAnyOpenCrosswalkLanes && bAreAllCurrentCrosswalkLanesOpenNextPeriod) ||
 							(bCanOpenPedestrianLanesByProbability &&
 							NumPedestriansWaitingForIntersection(IntersectionFragment, *ZoneGraphStorage, &MassCrowdSubsystem) >= MinPedestrians &&
 							// WARNING - If there are no pedestrians in the level, this will never end up being executed, so the value will never be cleared -

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleControlProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleControlProcessor.cpp
@@ -72,7 +72,8 @@ namespace
 		const FMassZoneGraphLaneLocationFragment& LaneLocationFragment,
 		const FAgentRadiusFragment& RadiusFragment,
 		const FMassTrafficRandomFractionFragment& RandomFractionFragment,
-		UMassTrafficSubsystem& MassTrafficSubsystem,
+		const FRandomStream& RandomStream,
+		const UMassTrafficSubsystem& MassTrafficSubsystem,
 		const UMassTrafficSettings& MassTrafficSettings)
 	{
 		// If we *just* stopped, ...
@@ -91,7 +92,7 @@ namespace
 			// If we just stopped at a stop sign, choose a minimum time to remain stopped at the stop sign.
 			if (!VehicleControlFragment.NextLane->ConstData.bIsTrafficLightControlled)
 			{
-				VehicleControlFragment.MinVehicleStopSignRestTime = FMath::FRandRange(MassTrafficSettings.LowerMinStopSignRestTime, MassTrafficSettings.UpperMinStopSignRestTime);
+				VehicleControlFragment.MinVehicleStopSignRestTime = RandomStream.FRandRange(MassTrafficSettings.LowerMinStopSignRestTime, MassTrafficSettings.UpperMinStopSignRestTime);
 			}
 		}
 		// If we *just* ceased being stopped, ...
@@ -411,7 +412,7 @@ void UMassTrafficVehicleControlProcessor::SimpleVehicleControl(
 
 	// We need to update our stop state before calling ShouldStopAtLaneExit.
 	// Basically, we need to update our stop state based on what we *are* doing this update cycle to inform what we *should* be doing.
-	UpdateVehicleStopState(VehicleControlFragment, LaneLocationFragment, AgentRadiusFragment, RandomFractionFragment, MassTrafficSubsystem, *MassTrafficSettings);
+	UpdateVehicleStopState(VehicleControlFragment, LaneLocationFragment, AgentRadiusFragment, RandomFractionFragment, RandomStream, MassTrafficSubsystem, *MassTrafficSettings);
 	
 	// Should stop?
 	bool bRequestDifferentNextLane = false;
@@ -758,7 +759,7 @@ void UMassTrafficVehicleControlProcessor::PIDVehicleControl(
 
 	// We need to update our stop state before calling ShouldStopAtLaneExit.
 	// Basically, we need to update our stop state based on what we *are* doing this update cycle to inform what we *should* be doing.
-	UpdateVehicleStopState(VehicleControlFragment, LaneLocationFragment, AgentRadiusFragment, RandomFractionFragment, MassTrafficSubsystem, *MassTrafficSettings);
+	UpdateVehicleStopState(VehicleControlFragment, LaneLocationFragment, AgentRadiusFragment, RandomFractionFragment, RandomStream, MassTrafficSubsystem, *MassTrafficSettings);
 
 	// Should stop?
 	bool bRequestDifferentNextLane = false;

--- a/External/Traffic/Source/MassTraffic/Public/MassTraffic.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTraffic.h
@@ -93,6 +93,8 @@ namespace UE::MassTraffic::ProcessorGroupNames
 	const FName PostPhysicsDriverVisualization = FName(TEXT("TrafficPostPhysics.DriverVisualization"));
 	const FName PostPhysicsUpdateDistanceToNearestObstacle = FName(TEXT("TrafficPostPhysics.UpdateDistanceToNearestObstacle"));
 	const FName PostPhysicsUpdateTrafficVehicles = FName(TEXT("TrafficPostPhysics.UpdateTrafficVehicles"));
+
+	const FName CrowdYieldBehavior = FName(TEXT("Traffic.CrowdYieldBehavior"));
 }
 
 class FMassTrafficModule : public IModuleInterface

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficCrowdYieldProcessor.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficCrowdYieldProcessor.h
@@ -1,0 +1,22 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "MassTrafficProcessorBase.h"
+#include "MassTrafficCrowdYieldProcessor.generated.h"
+
+
+UCLASS()
+class MASSTRAFFIC_API UMassTrafficCrowdYieldProcessor : public UMassTrafficProcessorBase
+{
+	GENERATED_BODY()
+
+public:
+	UMassTrafficCrowdYieldProcessor();
+
+protected:
+	virtual void ConfigureQueries() override;
+	virtual void Execute(FMassEntityManager& EntitySubSystem, FMassExecutionContext& Context) override;
+
+	FMassEntityQuery EntityQuery;
+};

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
@@ -721,6 +721,9 @@ struct MASSTRAFFIC_API FMassTrafficVehicleControlFragment : public FMassFragment
 	// Fields used for reactive yields.
 	bool bHasGivenOpportunityForTurningVehiclesToReactivelyYieldAtIntersection = false;
 
+	// Crosswalk lanes that this vehicle is actively yielding to.
+	TArray<FZoneGraphLaneHandle> ActiveYieldCrosswalkLanes;
+
 	// Inline copy of CurrentTrafficLaneData->ConstData constant lane data, copied on lane entry
 	FZoneGraphTrafficLaneConstData CurrentLaneConstData;
 

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
@@ -406,6 +406,8 @@ struct MASSTRAFFIC_API FMassTrafficIntersectionFragment : public FMassFragment
 	// Zone Graph zone index
 	// @see FZoneGraphStorage::Zones
 	int32 ZoneIndex = INDEX_NONE;
+
+	int32 NumSides = 0;
 	
 	FFloat16 PeriodTimeRemaining = 0.0f;
 
@@ -746,6 +748,17 @@ struct MASSTRAFFIC_API FMassTrafficVehicleControlFragment : public FMassFragment
 	int32 PreviousLaneIndex = INDEX_NONE;
 	
 	float PreviousLaneLength = 0.0f;
+
+	// The world time (in seconds) at which the vehicle stopped.
+	float TimeVehicleStopped = -1.0f;
+
+	// The chosen minimum delta time (in seconds) to remain at rest at the current stop sign.
+	float MinVehicleStopSignRestTime = 0.0f;
+
+	// Functions used for the stopped state.
+	bool IsVehicleCurrentlyStopped() const { return FMath::IsNearlyZero(Speed, 0.1f); }
+	bool WasVehiclePreviouslyStopped() const { return TimeVehicleStopped >= 0.0f; }
+	void ClearVehicleStoppedState() { TimeVehicleStopped = -1.0f; MinVehicleStopSignRestTime = 0.0f; }
 
 	// Functions used for both pre-emptive and reactive yields.
 	bool IsYieldingAtIntersection() const { return YieldAtIntersectionLane != nullptr; }

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficIntersectionSpawnDataGenerator.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficIntersectionSpawnDataGenerator.h
@@ -43,10 +43,14 @@ public:
 	UPROPERTY(EditAnywhere, Category="Durations|Standard")
 	float StandardMinimumTrafficGoSeconds = 5.0f;
 
+	/** How many seconds pedestrians go before vehicles go in 4-way and T-intersections. */
+	UPROPERTY(EditAnywhere, Category="Durations|Standard")
+	float StandardCrosswalkGoHeadStartSeconds = 4.0f;
+	
 	/** How many seconds pedestrians go (how long crosswalks are open for arriving pedestrians)- in most cases. */
 	UPROPERTY(EditAnywhere, Category="Durations|Standard")
 	float StandardCrosswalkGoSeconds = 10.0f;
-
+	
 	/** In cross-traffic intersections only - how many seconds for vehicles to go (how long a green light lasts) - when coming from one side, and can go straight, right or left. */
 	UPROPERTY(EditAnywhere, Category="Durations|FourWay")
 	float UnidirectionalTrafficStraightRightLeftGoSeconds = StandardTrafficGoSeconds / 2.0f;

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
@@ -211,18 +211,22 @@ bool CheckNextVehicle(const FMassEntityHandle Entity, const FMassEntityHandle Ne
 
 bool ShouldPerformPreemptiveYieldAtIntersection(
 	const UMassTrafficSubsystem& MassTrafficSubsystem,
+	const UMassCrowdSubsystem& MassCrowdSubsystem,
 	const FMassEntityManager& EntityManager,
 	const FMassTrafficVehicleControlFragment& VehicleControlFragment,
 	const FMassZoneGraphLaneLocationFragment& LaneLocationFragment,
 	const FAgentRadiusFragment& RadiusFragment,
+	const FZoneGraphStorage& ZoneGraphStorage,
 	bool& OutHasAnotherVehicleEnteredRelevantLaneAfterPreemptiveYieldRollOut);
 	
 bool ShouldPerformReactiveYieldAtIntersection(
 	const UMassTrafficSubsystem& MassTrafficSubsystem,
+	const UMassCrowdSubsystem& MassCrowdSubsystem,
 	const FMassEntityManager& EntityManager,
 	const FMassTrafficVehicleControlFragment& VehicleControlFragment,
 	const FMassZoneGraphLaneLocationFragment& LaneLocationFragment,
 	const FAgentRadiusFragment& RadiusFragment,
+	const FZoneGraphStorage& ZoneGraphStorage,
 	bool& OutShouldGiveOpportunityForTurningVehiclesToReactivelyYieldAtIntersection);
 
 };

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficMovement.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficMovement.h
@@ -137,22 +137,35 @@ MASSTRAFFIC_API bool ShouldStopAtLaneExit(
 	float RandomFraction,
 	float LaneLength,
 	FZoneGraphTrafficLaneData* NextTrafficLaneData,
+	const FZoneGraphTrafficLaneData* ReadiedNextIntersectionLane,
 	const FVector2D& MinimumDistanceToNextVehicleRange,
+	const FVector2D& StoppingDistanceRange,
 	const FMassEntityManager& EntityManager, 
 	bool& bOut_RequestDifferentNextLane,
 	bool& bInOut_CantStopAtLaneExit,
 	bool& bOut_IsFrontOfVehicleBeyondLaneExit,
 	bool& bOut_VehicleHasNoNextLane,
 	bool& bOut_VehicleHasNoRoom,
-	const float StandardTrafficPrepareToStopSeconds
+	bool& bOut_ShouldProceedAtStopSign,
+	const float StandardTrafficPrepareToStopSeconds,
+	const float TimeVehicleStopped,
+	const float MinVehicleStopSignRestTime,
+	const UWorld* World
 #if WITH_MASSTRAFFIC_DEBUG
 	, bool bVisLog = false
 	, const UObject* VisLogOwner = nullptr
 	, const FTransform* VisLogTransform = nullptr
 #endif
-	, const UWorld* World = nullptr // ..for debugging
 	, const FVector* VehicleLocation = nullptr // ..for debuging
 );
+	
+bool IsVehicleNearStopLineAtIntersection(
+	const FZoneGraphTrafficLaneData* NextLane,
+	const float DistanceAlongCurrentLane,
+	const float CurrentLaneLength,
+	const float AgentRadius,
+	const float RandomFraction,
+	const FVector2D& StoppingDistanceRange);
 
 MASSTRAFFIC_API void UpdateYieldAtIntersectionState(
 	UMassTrafficSubsystem& MassTrafficSubsystem,

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
@@ -191,6 +191,18 @@ public:
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Config, Category="Speed|Stopping")
 	float StopSignBrakingTime = 4.0f;
 
+	// Min time (in seconds) for vehicles to remain stationary at stop signs.
+	// It is a "lower" minimum time since we'll be selecting a value between this
+	// and UpperMinStopSignRestTime.
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Config, Category="Speed|Stopping")
+	float LowerMinStopSignRestTime = 2.0f;
+
+	// Max time (in seconds) for vehicles to remain stationary at stop signs,
+	// given the intersection "period" logic allows them to proceed.
+	// Therefore, it is an "upper" minimum time.
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Config, Category="Speed|Stopping")
+	float UpperMinStopSignRestTime = 4.0f;
+
 	/**
 	 * Target speed along the CurrentLane is determined by looking at the curvature ahead of the 
 	 * current closest point on the spline, and slowing to turn. The distance ahead is determined by 

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
@@ -458,14 +458,12 @@ public:
 	// in order for yielding vehicle to resume motion after yielding.
 	UPROPERTY(EditAnywhere, Config, Category="Yield Behavior")
 	float NormalizedYieldResumeLaneDistance_Crosswalk_AwayFromIntersectionExit = 0.6f;
-
-	// TODO:  Fix-up name for "NormalizedYieldResumeLaneDistance_Crosswalk_TowardsIntersectionExit".  It's not a "resume" distance.
 	
 	// Normalized distance "Lead" *pedestrian* may travel through *crosswalk* lanes
 	// going *towards* the current Intersection "exit" lanes
 	// before vehicles must yield to the crosswalk lane.
 	UPROPERTY(EditAnywhere, Config, Category="Yield Behavior")
-	float NormalizedYieldResumeLaneDistance_Crosswalk_TowardsIntersectionExit = 0.2f;
+	float NormalizedYieldPedestrianCutoffLaneDistance_Crosswalk_TowardsIntersectionExit = 0.2f;
 
 	// Max distance from the end of the lane (leading up to an intersection)
 	// within which a vehicle is allowed to start a pre-emptive yield if other conditions apply.

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
@@ -420,6 +420,11 @@ public:
 	// before it is no longer required to *start* yielding.
 	UPROPERTY(EditAnywhere, Config, Category="Yield Behavior")
 	float NormalizedYieldCutoffLaneDistance_Straight = 0.2f;
+
+	// Normalized distance *potentially yielding* vehicle is allowed to travel through *any* intersection lanes
+	// before it is no longer required to *start* yielding to a pedestrian in a crosswalk.
+	UPROPERTY(EditAnywhere, Config, Category="Yield Behavior")
+	float NormalizedYieldCutoffLaneDistance_Crosswalk = 0.6f;
 	
 	// Normalized distance *other* vehicle needs to travel through *left turn* lanes
 	// in order to resume motion after yielding.
@@ -435,6 +440,20 @@ public:
 	// in order to resume motion after yielding.
 	UPROPERTY(EditAnywhere, Config, Category="Yield Behavior")
 	float NormalizedYieldResumeLaneDistance_Straight = 0.4f;
+
+	// Normalized distance "Tail" *pedestrian* needs to travel through *crosswalk* lanes
+	// going *away* from the current Intersection "exit" lanes
+	// in order for yielding vehicle to resume motion after yielding.
+	UPROPERTY(EditAnywhere, Config, Category="Yield Behavior")
+	float NormalizedYieldResumeLaneDistance_Crosswalk_AwayFromIntersectionExit = 0.6f;
+
+	// TODO:  Fix-up name for "NormalizedYieldResumeLaneDistance_Crosswalk_TowardsIntersectionExit".  It's not a "resume" distance.
+	
+	// Normalized distance "Lead" *pedestrian* may travel through *crosswalk* lanes
+	// going *towards* the current Intersection "exit" lanes
+	// before vehicles must yield to the crosswalk lane.
+	UPROPERTY(EditAnywhere, Config, Category="Yield Behavior")
+	float NormalizedYieldResumeLaneDistance_Crosswalk_TowardsIntersectionExit = 0.2f;
 
 	// Max distance from the end of the lane (leading up to an intersection)
 	// within which a vehicle is allowed to start a pre-emptive yield if other conditions apply.

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficTypes.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficTypes.h
@@ -9,11 +9,14 @@
 #include "HierarchicalHashGrid2D.h"
 #include "MassEntityView.h"
 
+#include "Containers/Set.h"
+
 #include "MassTrafficTypes.generated.h"
 
 #define MASSTRAFFIC_NUM_INLINE_VEHICLE_NEXT_LANES 2 // ..determined to be ~1.4 on average for this game
 #define MASSTRAFFIC_NUM_INLINE_VEHICLE_MERGING_LANES 2 // ..determined to be ~1.3 on average for this game
 #define MASSTRAFFIC_NUM_INLINE_VEHICLE_SPLITTING_LANES 2 // ..determined to be ~1.7 on average for this game
+#define MASSTRAFFIC_NUM_INLINE_VEHICLE_CROSSWALK_LANES 2 // Each lane should only run through (at most) one crosswalk (which will have just 2 lanes).
 
 
 
@@ -502,6 +505,11 @@ struct MASSTRAFFIC_API FZoneGraphTrafficLaneData
 	TArray<FZoneGraphTrafficLaneData*, TInlineAllocator<MASSTRAFFIC_NUM_INLINE_VEHICLE_NEXT_LANES>> NextLanes;
 	TArray<FZoneGraphTrafficLaneData*, TInlineAllocator<MASSTRAFFIC_NUM_INLINE_VEHICLE_MERGING_LANES>> MergingLanes;
 	TArray<FZoneGraphTrafficLaneData*, TInlineAllocator<MASSTRAFFIC_NUM_INLINE_VEHICLE_SPLITTING_LANES>> SplittingLanes;
+
+	// Lanes which are not drivable will not have an associated FZoneGraphTrafficLaneData.
+	// So, we just store FZoneGraphLaneHandles for crosswalk lanes with "right of way" over this lane,
+	// which we call "downstream crosswalk lanes".
+	TArray<FZoneGraphLaneHandle, TInlineAllocator<MASSTRAFFIC_NUM_INLINE_VEHICLE_CROSSWALK_LANES>> DownstreamCrosswalkLanes;
 
 	/**
 	 * NOTE - If these take up too much memory, we can instead make a single 1-bit flag to cover both of these, that simply

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficVehicleControlProcessor.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficVehicleControlProcessor.h
@@ -23,8 +23,10 @@ protected:
 	void SimpleVehicleControl(
 		FMassEntityManager& EntityManager,
 		UMassTrafficSubsystem& MassTrafficSubsystem,
+		const UMassCrowdSubsystem& MassCrowdSubsystem,
 		FMassExecutionContext& Context,
 		const int32 EntityIndex,
+		const FZoneGraphStorage& ZoneGraphStorage,
 		const FAgentRadiusFragment& AgentRadiusFragment,
 		const FMassTrafficRandomFractionFragment& RandomFractionFragment,
 		const FTransformFragment& TransformFragment,
@@ -40,6 +42,7 @@ protected:
 	void PIDVehicleControl(
 		const FMassEntityManager& EntityManager,
 		UMassTrafficSubsystem& MassTrafficSubsystem,
+		const UMassCrowdSubsystem& MassCrowdSubsystem,
 		const FMassExecutionContext& Context,
 		const int32 EntityIndex,
 		const FZoneGraphStorage& ZoneGraphStorage,

--- a/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
+++ b/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
@@ -606,9 +606,13 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForC
 		ZoneShapeComponent->GetMutablePoints().Empty();
 		ZoneShapeComponent->SetCommonLaneProfile(LaneProfileRef);
 
-		// TODO:  Get this via the interface.
-		const FZoneGraphTag IntersectionTag = GetTagByName(TEXT("Crosswalk"));
-		ZoneShapeComponent->GetMutableTags().Add(IntersectionTag);
+		// Apply crosswalk tags.
+		TArray<FName> CrosswalkTagNames = ITempoIntersectionInterface::Execute_GetTempoCrosswalkTags(&IntersectionQueryActor, ConnectionIndex);
+		for (const FName& CrosswalkTagName : CrosswalkTagNames)
+		{
+			const FZoneGraphTag CrosswalkTag = GetTagByName(CrosswalkTagName);
+			ZoneShapeComponent->GetMutableTags().Add(CrosswalkTag);
+		}
 
 		const int32 CrosswalkControlPointStartIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(&IntersectionQueryActor, ConnectionIndex);
 		const int32 CrosswalkControlPointEndIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(&IntersectionQueryActor, ConnectionIndex);

--- a/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
+++ b/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
@@ -748,8 +748,6 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForC
 
 bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersections(AActor& IntersectionQueryActor) const
 {
-	// FEditorScriptExecutionGuard ScriptGuard;
-	
 	const int32 NumCrosswalkIntersections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersections(&IntersectionQueryActor);
 
 	for (int32 CrosswalkIntersectionIndex = 0; CrosswalkIntersectionIndex < NumCrosswalkIntersections; ++CrosswalkIntersectionIndex)

--- a/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
+++ b/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
@@ -61,12 +61,23 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateZoneShapeComponents() const
 		else if (Actor->Implements<UTempoRoadModuleInterface>())
 		{
 			DestroyZoneShapeComponents(*Actor);
-
-			// Then, try to generate ZoneShapeComponents for road modules (ex. sidewalks, walkable bridges, etc.).
-			if (!TryGenerateAndRegisterZoneShapeComponentsForRoad(*Actor, true))
+			
+			const AActor* RoadModuleParentActor = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleParentActor(Actor);
+			if (RoadModuleParentActor == nullptr)
 			{
-				UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Road Module ZoneShapeComponents for Actor: %s."), *Actor->GetName());
+				UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Road Module ZoneShapeComponents for Actor: %s.  It must have a valid parent."), *Actor->GetName());
 				return false;
+			}
+
+			// Build ZoneShapes for RoadModules differently, based on whether its parent is a Road or an Intersection.
+			if (!RoadModuleParentActor->Implements<UTempoIntersectionInterface>())
+			{
+				// Then, try to generate ZoneShapeComponents for road modules (ex. sidewalks, walkable bridges, etc.).
+				if (!TryGenerateAndRegisterZoneShapeComponentsForRoad(*Actor, true))
+				{
+					UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Road Module ZoneShapeComponents for Actor: %s."), *Actor->GetName());
+					return false;
+				}
 			}
 		}
 		else if (Actor->Implements<UTempoIntersectionInterface>())
@@ -78,6 +89,24 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateZoneShapeComponents() const
 				UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Intersection ZoneShapeComponents for Actor: %s."), *Actor->GetName());
 				return false;
 			}
+
+			if (!TryGenerateAndRegisterZoneShapeComponentsForCrosswalksAtIntersections(*Actor))
+			{
+				UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Crosswalk ZoneShapeComponents for Actor: %s."), *Actor->GetName());
+				return false;
+			}
+
+			if (!TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersectionConnectorSegments(*Actor))
+			{
+				UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Crosswalk Intersection Connector Segment ZoneShapeComponents for Actor: %s."), *Actor->GetName());
+				return false;
+			}
+			
+			if (!TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersections(*Actor))
+            {
+            	UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Crosswalk Intersection ZoneShapeComponents for Actor: %s."), *Actor->GetName());
+            	return false;
+            }
 		}
 	}
 
@@ -212,6 +241,33 @@ FZoneShapePoint UTempoRoadLaneGraphSubsystem::CreateZoneShapePointForRoadControl
 	ZoneShapePoint.Type = FZoneShapePointType::Bezier;
 	
 	ZoneShapePoint.TangentLength = ControlPointTangent.Size();
+
+	return ZoneShapePoint;
+}
+
+FZoneShapePoint UTempoRoadLaneGraphSubsystem::CreateZoneShapePointAtDistanceAlongRoad(const AActor& RoadQueryActor, float DistanceAlongRoad, bool bQueryActorIsRoadModule) const
+{
+	FZoneShapePoint ZoneShapePoint;
+	
+	const FVector ZoneShapePointLocation = bQueryActorIsRoadModule
+		? ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule(&RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::Local)
+		: ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad(&RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::Local);
+
+	const FRotator ZoneShapePointRotation = bQueryActorIsRoadModule
+		? ITempoRoadModuleInterface::Execute_GetRotationAtDistanceAlongTempoRoadModule(&RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::Local)
+		: ITempoRoadInterface::Execute_GetRotationAtDistanceAlongTempoRoad(&RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::Local);
+	
+	const FVector ZoneShapePointTangent = bQueryActorIsRoadModule
+		? ITempoRoadModuleInterface::Execute_GetTangentAtDistanceAlongTempoRoadModule(&RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::Local)
+		: ITempoRoadInterface::Execute_GetTangentAtDistanceAlongTempoRoad(&RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::Local);
+
+	DrawDebugSphere(GetWorld(), RoadQueryActor.GetActorTransform().TransformPosition(ZoneShapePointLocation), 25.0f, 16, FColor::Purple, false, 5.0f);
+
+	ZoneShapePoint.Position = ZoneShapePointLocation;
+	ZoneShapePoint.Rotation = ZoneShapePointRotation;
+	ZoneShapePoint.Type = FZoneShapePointType::Bezier;
+	
+	ZoneShapePoint.TangentLength = ZoneShapePointTangent.Size();
 
 	return ZoneShapePoint;
 }
@@ -504,13 +560,344 @@ AActor* UTempoRoadLaneGraphSubsystem::GetConnectedRoadActor(const AActor& Inters
 	{
 		return nullptr;
 	}
-			
+
 	if (!RoadActor->Implements<UTempoRoadInterface>())
 	{
 		return nullptr;
 	}
 
 	return RoadActor;
+}
+
+//
+// Crosswalk functions
+//
+
+bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForCrosswalksAtIntersections(AActor& IntersectionQueryActor) const
+{
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(&IntersectionQueryActor);
+	
+	for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
+	{
+		const bool bShouldGenerateZoneShapesForCrosswalk = ITempoIntersectionInterface::Execute_ShouldGenerateZoneShapesForTempoCrosswalk(&IntersectionQueryActor, ConnectionIndex);
+
+		if (!bShouldGenerateZoneShapesForCrosswalk)
+		{
+			UE_LOG(LogTempoAgentsEditor, Display, TEXT("Tempo Lane Graph - Skip generating Crosswalk ZoneShapeComponents for Actor: %s at ConnectionIndex: %d."), *IntersectionQueryActor.GetName(), ConnectionIndex);
+			continue;
+		}
+		
+		const FZoneLaneProfile LaneProfile = GetLaneProfileForCrosswalk(IntersectionQueryActor, ConnectionIndex);
+		if (!LaneProfile.IsValid())
+		{
+			UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Crosswalk ZoneShapeComponent - Couldn't get valid LaneProfile for Actor: %s at ConnectionIndex: %d."), *IntersectionQueryActor.GetName(), ConnectionIndex);
+			return false;
+		}
+	
+		const FZoneLaneProfileRef LaneProfileRef(LaneProfile);
+		
+		UZoneShapeComponent* ZoneShapeComponent = NewObject<UZoneShapeComponent>(&IntersectionQueryActor, UZoneShapeComponent::StaticClass());
+		if (!ensureMsgf(ZoneShapeComponent != nullptr, TEXT("Failed to create Crosswalk ZoneShapeComponent when building Lane Graph for Actor: %s at ConnectionIndex: %d."), *IntersectionQueryActor.GetName(), ConnectionIndex))
+		{
+			return false;
+		}
+
+		// Remove default points.
+		ZoneShapeComponent->GetMutablePoints().Empty();
+		ZoneShapeComponent->SetCommonLaneProfile(LaneProfileRef);
+
+		// TODO:  Get this via the interface.
+		const FZoneGraphTag IntersectionTag = GetTagByName(TEXT("Crosswalk"));
+		ZoneShapeComponent->GetMutableTags().Add(IntersectionTag);
+
+		const int32 CrosswalkControlPointStartIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(&IntersectionQueryActor, ConnectionIndex);
+		const int32 CrosswalkControlPointEndIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(&IntersectionQueryActor, ConnectionIndex);
+		
+		for (int32 CrosswalkControlPointIndex = CrosswalkControlPointStartIndex; CrosswalkControlPointIndex <= CrosswalkControlPointEndIndex; ++CrosswalkControlPointIndex)
+		{
+			FZoneShapePoint ZoneShapePoint;
+			if (!TryCreateZoneShapePointForCrosswalkControlPoint(IntersectionQueryActor, ConnectionIndex, CrosswalkControlPointIndex, ZoneShapePoint))
+			{
+				return false;
+			}
+			
+			ZoneShapeComponent->GetMutablePoints().Add(ZoneShapePoint);
+		}
+
+		// Register ZoneShapeComponent.
+		if (!TryRegisterZoneShapeComponentWithActor(IntersectionQueryActor, *ZoneShapeComponent))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersectionConnectorSegments(AActor& IntersectionQueryActor) const
+{
+	const auto& GetNumControlPointsBetweenDistancesAlongRoadModule = [](const AActor& RoadModuleQueryActor, float StartDistance, float EndDistance)
+	{
+		TArray<int32> RoadModuleControlPointIndexes;
+
+		if (StartDistance > EndDistance)
+		{
+			return 0;
+		}
+
+		const float RoadModuleLength = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLength(&RoadModuleQueryActor);
+
+		StartDistance = FMath::Clamp(StartDistance, 0.0f, RoadModuleLength);
+		EndDistance = FMath::Clamp(EndDistance, 0.0f, RoadModuleLength);
+
+		const int32 NumRoadModuleControlPoints = ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleControlPoints(&RoadModuleQueryActor);
+
+		for (int32 RoadModuleControlPointIndex = 0; RoadModuleControlPointIndex < NumRoadModuleControlPoints; ++RoadModuleControlPointIndex)
+		{
+			const float DistanceAlongRoadModule = ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleAtControlPoint(&RoadModuleQueryActor, RoadModuleControlPointIndex);
+
+			if (DistanceAlongRoadModule >= StartDistance && DistanceAlongRoadModule <= EndDistance)
+			{
+				RoadModuleControlPointIndexes.Add(RoadModuleControlPointIndex);
+			}
+		}
+
+		return RoadModuleControlPointIndexes.Num();
+	};
+	
+	const int32 NumCrosswalkRoadModules = ITempoIntersectionInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(&IntersectionQueryActor);
+
+	for (int32 CrosswalkRoadModuleIndex = 0; CrosswalkRoadModuleIndex < NumCrosswalkRoadModules; ++CrosswalkRoadModuleIndex)
+	{
+		const FCrosswalkIntersectionConnectorInfo& CrosswalkIntersectionConnectorInfo = ITempoIntersectionInterface::Execute_GetTempoCrosswalkIntersectionConnectorInfo(&IntersectionQueryActor, CrosswalkRoadModuleIndex);
+		
+		const FZoneLaneProfile LaneProfile = GetLaneProfile(*CrosswalkIntersectionConnectorInfo.CrosswalkRoadModule, true);
+		
+		if (!LaneProfile.IsValid())
+		{
+			UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Crosswalk Intersection Connector ZoneShapeComponent - Couldn't get valid LaneProfile for Actor: %s."), *CrosswalkIntersectionConnectorInfo.CrosswalkRoadModule->GetName());
+			return false;
+		}
+
+		const FZoneLaneProfileRef LaneProfileRef(LaneProfile);
+
+		for (const FCrosswalkIntersectionConnectorSegmentInfo& CrosswalkIntersectionConnectorSegmentInfo : CrosswalkIntersectionConnectorInfo.CrosswalkIntersectionConnectorSegmentInfos)
+		{
+			UZoneShapeComponent* ZoneShapeComponent = NewObject<UZoneShapeComponent>(&IntersectionQueryActor, UZoneShapeComponent::StaticClass());
+			if (!ensureMsgf(ZoneShapeComponent != nullptr, TEXT("Failed to create Crosswalk Intersection Connector Segment ZoneShapeComponent when building Lane Graph for Actor: %s at CrosswalkRoadModuleIndex: %d."), *IntersectionQueryActor.GetName(), CrosswalkRoadModuleIndex))
+			{
+				return false;
+			}
+
+			// Remove default points.
+			ZoneShapeComponent->GetMutablePoints().Empty();
+			ZoneShapeComponent->SetCommonLaneProfile(LaneProfileRef);
+
+			const int32 NumRoadModuleControlPointIndexesForSegment = GetNumControlPointsBetweenDistancesAlongRoadModule(
+				*CrosswalkIntersectionConnectorInfo.CrosswalkRoadModule,
+				CrosswalkIntersectionConnectorSegmentInfo.CrosswalkIntersectionConnectorStartDistance,
+				CrosswalkIntersectionConnectorSegmentInfo.CrosswalkIntersectionConnectorEndDistance);
+
+			const int32 NumSegmentControlPoints = FMath::Max(NumRoadModuleControlPointIndexesForSegment, 2);
+			const float SegmentLength = CrosswalkIntersectionConnectorSegmentInfo.CrosswalkIntersectionConnectorEndDistance - CrosswalkIntersectionConnectorSegmentInfo.CrosswalkIntersectionConnectorStartDistance;
+
+			const float SegmentStep = SegmentLength / NumSegmentControlPoints;
+
+			for (int32 SegmentControlPointIndex = 0; SegmentControlPointIndex <= NumSegmentControlPoints; ++SegmentControlPointIndex)
+			{
+				const float SegmentDistance = SegmentStep * SegmentControlPointIndex + CrosswalkIntersectionConnectorSegmentInfo.CrosswalkIntersectionConnectorStartDistance;
+				
+				FZoneShapePoint ZoneShapePoint = CreateZoneShapePointAtDistanceAlongRoad(*CrosswalkIntersectionConnectorInfo.CrosswalkRoadModule, SegmentDistance, true);
+				ZoneShapeComponent->GetMutablePoints().Add(ZoneShapePoint);
+			}
+
+			// Register ZoneShapeComponent.
+			if (!TryRegisterZoneShapeComponentWithActor(IntersectionQueryActor, *ZoneShapeComponent))
+			{
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersections(AActor& IntersectionQueryActor) const
+{
+	const int32 NumCrosswalkIntersections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersections(&IntersectionQueryActor);
+
+	for (int32 CrosswalkIntersectionIndex = 0; CrosswalkIntersectionIndex < NumCrosswalkIntersections; ++CrosswalkIntersectionIndex)
+	{
+		UZoneShapeComponent* ZoneShapeComponent = NewObject<UZoneShapeComponent>(&IntersectionQueryActor, UZoneShapeComponent::StaticClass());
+
+		if (!ensureMsgf(ZoneShapeComponent != nullptr, TEXT("Failed to create Crosswalk Intersection ZoneShapeComponent when building Lane Graph for Actor: %s at CrosswalkIntersectionIndex: %d."), *IntersectionQueryActor.GetName(), CrosswalkIntersectionIndex))
+		{
+			return false;
+		}
+
+		// Remove default points.
+		ZoneShapeComponent->GetMutablePoints().Empty();
+	
+		ZoneShapeComponent->SetShapeType(FZoneShapeType::Polygon);
+		ZoneShapeComponent->SetPolygonRoutingType(EZoneShapePolygonRoutingType::Bezier);
+
+		// Apply crosswalk intersection tags.
+		TArray<FName> IntersectionTagNames = ITempoIntersectionInterface::Execute_GetTempoCrosswalkIntersectionTags(&IntersectionQueryActor, CrosswalkIntersectionIndex);
+		for (FName IntersectionTagName : IntersectionTagNames)
+		{
+			const FZoneGraphTag IntersectionTag = GetTagByName(IntersectionTagName);
+			ZoneShapeComponent->GetMutableTags().Add(IntersectionTag);
+		}
+	
+		const int32 NumCrosswalkIntersectionConnections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(&IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+		// Create and Setup Points.
+		for (int32 CrosswalkIntersectionConnectionIndex = 0; CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections; ++CrosswalkIntersectionConnectionIndex)
+		{
+			FZoneShapePoint ZoneShapePoint;
+			if (!TryCreateZoneShapePointForCrosswalkIntersectionEntranceLocation(IntersectionQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, *ZoneShapeComponent, ZoneShapePoint))
+			{
+				return false;
+			}
+
+			ZoneShapeComponent->GetMutablePoints().Add(ZoneShapePoint);
+		}
+
+		// Register ZoneShapeComponent.
+		if (!TryRegisterZoneShapeComponentWithActor(IntersectionQueryActor, *ZoneShapeComponent))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoRoadLaneGraphSubsystem::TryCreateZoneShapePointForCrosswalkIntersectionEntranceLocation(const AActor& IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, UZoneShapeComponent& ZoneShapeComponent, FZoneShapePoint& OutZoneShapePoint) const
+{
+	const FVector CrosswalkIntersectionEntranceLocationInWorldFrame = ITempoIntersectionInterface::Execute_GetTempoCrosswalkIntersectionEntranceLocation(&IntersectionQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace::World);
+	
+	DrawDebugSphere(GetWorld(), CrosswalkIntersectionEntranceLocationInWorldFrame, 25.0f, 16, FColor::Green, false, 5.0f);
+
+	// TODO:  Resolve this more transparently via interface functions.
+	const int32 CrosswalkRoadModuleIndex = CrosswalkIntersectionIndex / 2;
+
+	AActor* CrosswalkRoadModuleQueryActor = ITempoIntersectionInterface::Execute_GetConnectedTempoCrosswalkRoadModuleActor(&IntersectionQueryActor, CrosswalkRoadModuleIndex);
+
+	if (CrosswalkRoadModuleQueryActor == nullptr)
+	{
+		UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Crosswalk Intersection Zone Shape Point - Failed to get Connected Road Actor for Actor: %s at CrosswalkRoadModuleIndex: %d."), *IntersectionQueryActor.GetName(), CrosswalkRoadModuleIndex);
+		return false;
+	}
+
+	// TODO:  Query through the interface to get the lane profile, which indexes each side of the crosswalk intersection (ie. like when getting the crosswalk intersection entrance location).
+	const FZoneLaneProfile LaneProfile = GetLaneProfileForCrosswalk(IntersectionQueryActor, CrosswalkRoadModuleIndex);
+	if (!LaneProfile.IsValid())
+	{
+		UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Crosswalk Intersection Zone Shape Point - Couldn't get valid LaneProfile for Actor: %s at CrosswalkRoadModuleIndex: %d."), *IntersectionQueryActor.GetName(), CrosswalkRoadModuleIndex);
+		return false;
+	}
+	
+	const FZoneLaneProfileRef LaneProfileRef(LaneProfile);
+
+	const uint8 PerPointLaneProfileIndex = ZoneShapeComponent.AddUniquePerPointLaneProfile(LaneProfileRef);
+
+	FZoneShapePoint ZoneShapePoint;
+	
+	ZoneShapePoint.Position = IntersectionQueryActor.ActorToWorld().InverseTransformPosition(CrosswalkIntersectionEntranceLocationInWorldFrame);
+	ZoneShapePoint.Type = FZoneShapePointType::LaneProfile;
+	ZoneShapePoint.LaneProfile = PerPointLaneProfileIndex;
+	ZoneShapePoint.TangentLength = LaneProfile.GetLanesTotalWidth() * 0.5f;
+
+	const FVector CrosswalkIntersectionEntranceTangentInWorldFrame = ITempoIntersectionInterface::Execute_GetTempoCrosswalkIntersectionEntranceTangent(&IntersectionQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace::World);
+	const FVector CrosswalkIntersectionEntranceUpVectorInWorldFrame = ITempoIntersectionInterface::Execute_GetTempoCrosswalkIntersectionEntranceUpVector(&IntersectionQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace::World);
+
+	ZoneShapePoint.SetRotationFromForwardAndUp(ZoneShapeComponent.GetComponentToWorld().InverseTransformPosition(CrosswalkIntersectionEntranceTangentInWorldFrame),
+		ZoneShapeComponent.GetComponentToWorld().InverseTransformPosition(CrosswalkIntersectionEntranceUpVectorInWorldFrame));
+
+	DrawDebugDirectionalArrow(GetWorld(), IntersectionQueryActor.ActorToWorld().TransformPosition(ZoneShapePoint.GetInControlPoint()), IntersectionQueryActor.ActorToWorld().TransformPosition(ZoneShapePoint.Position), 10000.0f, FColor::Blue, false, 10.0f, 0, 10.0f);
+	DrawDebugDirectionalArrow(GetWorld(), IntersectionQueryActor.ActorToWorld().TransformPosition(ZoneShapePoint.Position), IntersectionQueryActor.ActorToWorld().TransformPosition(ZoneShapePoint.GetOutControlPoint()), 10000.0f, FColor::Red, false, 10.0f, 0, 10.0f);
+
+	OutZoneShapePoint = ZoneShapePoint;
+
+	return true;
+}
+
+bool UTempoRoadLaneGraphSubsystem::TryCreateZoneShapePointForCrosswalkControlPoint(const AActor& IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, FZoneShapePoint& OutZoneShapePoint) const
+{
+	FZoneShapePoint ZoneShapePoint;
+	
+	const FVector CrosswalkControlPointLocation = ITempoIntersectionInterface::Execute_GetTempoCrosswalkControlPointLocation(&IntersectionQueryActor, ConnectionIndex, CrosswalkControlPointIndex, ETempoCoordinateSpace::World);
+	const FVector CrosswalkControlPointTangent = ITempoIntersectionInterface::Execute_GetTempoCrosswalkControlPointTangent(&IntersectionQueryActor, ConnectionIndex, CrosswalkControlPointIndex, ETempoCoordinateSpace::World);
+
+	const FVector CrosswalkControlPointForwardVector = CrosswalkControlPointTangent.GetSafeNormal();
+	const FVector CrosswalkControlPointUpVector = ITempoIntersectionInterface::Execute_GetTempoCrosswalkControlPointUpVector(&IntersectionQueryActor, ConnectionIndex, CrosswalkControlPointIndex, ETempoCoordinateSpace::World);
+
+	ZoneShapePoint.Position = IntersectionQueryActor.GetTransform().InverseTransformPosition(CrosswalkControlPointLocation);
+	ZoneShapePoint.Type = FZoneShapePointType::Bezier;
+	ZoneShapePoint.TangentLength = CrosswalkControlPointTangent.Size();
+	
+	ZoneShapePoint.SetRotationFromForwardAndUp(IntersectionQueryActor.GetTransform().InverseTransformVector(CrosswalkControlPointForwardVector),
+		IntersectionQueryActor.GetTransform().InverseTransformVector(CrosswalkControlPointUpVector));
+
+	OutZoneShapePoint = ZoneShapePoint;
+	
+	return true;
+}
+
+FZoneLaneProfile UTempoRoadLaneGraphSubsystem::CreateDynamicLaneProfileForCrosswalk(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const
+{
+	FZoneLaneProfile LaneProfile;
+	
+	const int32 NumLanes = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkLanes(&IntersectionQueryActor);
+
+	for (int32 LaneIndex = 0; LaneIndex < NumLanes; ++LaneIndex)
+	{
+		// ZoneGraph's LaneProfiles specify lanes from right to left.
+		const int32 LaneProfileLaneIndex = NumLanes - 1 - LaneIndex;
+		
+		const float LaneWidth = ITempoIntersectionInterface::Execute_GetTempoCrosswalkLaneWidth(&IntersectionQueryActor, ConnectionIndex, LaneProfileLaneIndex);
+		const EZoneLaneDirection LaneDirection = ITempoIntersectionInterface::Execute_GetTempoCrosswalkLaneDirection(&IntersectionQueryActor, ConnectionIndex, LaneProfileLaneIndex);
+		const TArray<FName> LaneTags = ITempoIntersectionInterface::Execute_GetTempoCrosswalkLaneTags(&IntersectionQueryActor, ConnectionIndex, LaneProfileLaneIndex);
+
+		FZoneLaneDesc LaneDesc = CreateZoneLaneDesc(LaneWidth, LaneDirection, LaneTags);
+		LaneProfile.Lanes.Add(LaneDesc);
+	}
+
+	LaneProfile.Name = GenerateDynamicLaneProfileName(LaneProfile);
+
+	return LaneProfile;
+}
+
+FZoneLaneProfile UTempoRoadLaneGraphSubsystem::GetLaneProfileForCrosswalk(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const
+{
+	const FName LaneProfileOverrideName = ITempoIntersectionInterface::Execute_GetLaneProfileOverrideNameForTempoCrosswalk(&IntersectionQueryActor, ConnectionIndex);
+
+	if (LaneProfileOverrideName != NAME_None)
+	{
+		const FZoneLaneProfile OverrideLaneProfile = GetLaneProfileByName(LaneProfileOverrideName);
+		return OverrideLaneProfile;
+	}
+
+	const FZoneLaneProfile DynamicLaneProfile = CreateDynamicLaneProfileForCrosswalk(IntersectionQueryActor, ConnectionIndex);
+	
+	FZoneLaneProfile DynamicLaneProfileFromSettings;
+	if (TryGetDynamicLaneProfileFromSettings(DynamicLaneProfile, DynamicLaneProfileFromSettings))
+	{
+		// The Lane Profile stored in the settings will have a unique ID (ie. Guid).
+		// So, we always want to reference that one, if it exists.
+		return DynamicLaneProfileFromSettings;
+	}
+	else
+	{
+		if (!TryWriteDynamicLaneProfile(DynamicLaneProfile))
+		{
+			UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to write Dynamic Lane Profile for Crosswalk for Actor: %s.  Returning default constructed profile."), *IntersectionQueryActor.GetName());
+			return FZoneLaneProfile();
+		}
+	}
+	
+	return DynamicLaneProfile;
 }
 
 //

--- a/TempoAgents/Source/TempoAgentsEditor/Public/TempoRoadLaneGraphSubsystem.h
+++ b/TempoAgents/Source/TempoAgentsEditor/Public/TempoRoadLaneGraphSubsystem.h
@@ -31,6 +31,7 @@ protected:
 	// Road functions
 	bool TryGenerateAndRegisterZoneShapeComponentsForRoad(AActor& RoadQueryActor, bool bQueryActorIsRoadModule = false) const;
 	FZoneShapePoint CreateZoneShapePointForRoadControlPoint(const AActor& RoadQueryActor, int32 ControlPointIndex, bool bQueryActorIsRoadModule) const;
+	FZoneShapePoint CreateZoneShapePointAtDistanceAlongRoad(const AActor& RoadQueryActor, float DistanceAlongRoad, bool bQueryActorIsRoadModule) const;
 	FZoneLaneProfile CreateDynamicLaneProfile(const AActor& RoadQueryActor, bool bQueryActorIsRoadModule) const;
 	FZoneLaneDesc CreateZoneLaneDesc(const float LaneWidth, const EZoneLaneDirection LaneDirection, const TArray<FName>& LaneTagNames) const;
 	FName GenerateDynamicLaneProfileName(const FZoneLaneProfile& LaneProfile) const;
@@ -43,6 +44,15 @@ protected:
 	bool TryGenerateAndRegisterZoneShapeComponentsForIntersection(AActor& IntersectionQueryActor) const;
 	bool TryCreateZoneShapePointForIntersectionEntranceLocation(const AActor& IntersectionQueryActor, int32 ConnectionIndex, UZoneShapeComponent& ZoneShapeComponent, FZoneShapePoint& OutZoneShapePoint) const;
 	AActor* GetConnectedRoadActor(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const;
+	
+	// Crosswalk functions
+	bool TryGenerateAndRegisterZoneShapeComponentsForCrosswalksAtIntersections(AActor& IntersectionQueryActor) const;
+	bool TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersectionConnectorSegments(AActor& IntersectionQueryActor) const;
+	bool TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersections(AActor& IntersectionQueryActor) const;
+	bool TryCreateZoneShapePointForCrosswalkIntersectionEntranceLocation(const AActor& IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, UZoneShapeComponent& ZoneShapeComponent, FZoneShapePoint& OutZoneShapePoint) const;
+	bool TryCreateZoneShapePointForCrosswalkControlPoint(const AActor& IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, FZoneShapePoint& OutZoneShapePoint) const;
+	FZoneLaneProfile CreateDynamicLaneProfileForCrosswalk(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const;
+	FZoneLaneProfile GetLaneProfileForCrosswalk(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const;
 
 	// Shared functions
 	bool TryRegisterZoneShapeComponentWithActor(AActor& Actor, UZoneShapeComponent& ZoneShapeComponent) const;

--- a/TempoAgents/Source/TempoAgentsEditor/Public/TempoRoadLaneGraphSubsystem.h
+++ b/TempoAgents/Source/TempoAgentsEditor/Public/TempoRoadLaneGraphSubsystem.h
@@ -51,8 +51,15 @@ protected:
 	bool TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersections(AActor& IntersectionQueryActor) const;
 	bool TryCreateZoneShapePointForCrosswalkIntersectionEntranceLocation(const AActor& IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, UZoneShapeComponent& ZoneShapeComponent, FZoneShapePoint& OutZoneShapePoint) const;
 	bool TryCreateZoneShapePointForCrosswalkControlPoint(const AActor& IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, FZoneShapePoint& OutZoneShapePoint) const;
+
 	FZoneLaneProfile CreateDynamicLaneProfileForCrosswalk(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const;
 	FZoneLaneProfile GetLaneProfileForCrosswalk(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const;
+	
+	FZoneLaneProfile CreateCrosswalkIntersectionConnectorDynamicLaneProfile(const AActor& IntersectionQueryActor, int32 CrosswalkRoadModuleIndex) const;
+	FZoneLaneProfile GetCrosswalkIntersectionConnectorLaneProfile(const AActor& IntersectionQueryActor, int32 CrosswalkRoadModuleIndex) const;
+	
+	FZoneLaneProfile CreateCrosswalkIntersectionEntranceDynamicLaneProfile(const AActor& IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex) const;
+	FZoneLaneProfile GetCrosswalkIntersectionEntranceLaneProfile(const AActor& IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex) const;
 
 	// Shared functions
 	bool TryRegisterZoneShapeComponentWithActor(AActor& Actor, UZoneShapeComponent& ZoneShapeComponent) const;

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoAgentsWorldSubsystem.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoAgentsWorldSubsystem.cpp
@@ -4,11 +4,14 @@
 
 #include "EngineUtils.h"
 #include "MassTrafficLightRegistrySubsystem.h"
+#include "MassTrafficSubsystem.h"
 #include "TempoAgentsShared.h"
 #include "TempoBrightnessMeter.h"
 #include "TempoBrightnessMeterComponent.h"
 #include "TempoIntersectionInterface.h"
 #include "TempoRoadInterface.h"
+#include "TempoRoadModuleInterface.h"
+#include "ZoneGraphQuery.h"
 #include "Kismet/GameplayStatics.h"
 
 void UTempoAgentsWorldSubsystem::SetupTrafficControllers()
@@ -106,6 +109,203 @@ void UTempoAgentsWorldSubsystem::SetupBrightnessMeter()
 	ensureMsgf(BrightnessMeterActor != nullptr, TEXT("Must spawn valid BrightnessMeterActor in UTempoAgentsWorldSubsystem::SetupBrightnessMeter."));
 }
 
+void UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap()
+{
+	const UWorld& World = GetWorldRef();
+
+	const UZoneGraphSubsystem* ZoneGraphSubsystem = UWorld::GetSubsystem<UZoneGraphSubsystem>(&World);
+
+	if (!ensureMsgf(ZoneGraphSubsystem != nullptr, TEXT("ZoneGraphSubsystem must be valid in UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap.")))
+	{
+		return;
+	}
+
+	UMassTrafficSubsystem* MassTrafficSubsystem = UWorld::GetSubsystem<UMassTrafficSubsystem>(&World);
+
+	if (!ensureMsgf(MassTrafficSubsystem != nullptr, TEXT("MassTrafficSubsystem must be valid in UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap.")))
+	{
+		return;
+	}
+
+	const auto& GetRoadLaneTags = [](const AActor& RoadQueryActor)
+	{
+		TArray<FName> AggregateRoadLaneTags;
+		
+		const int32 NumLanes = ITempoRoadInterface::Execute_GetNumTempoLanes(&RoadQueryActor);
+
+		for (int32 LaneIndex = 0; LaneIndex < NumLanes; ++LaneIndex)
+		{
+			const TArray<FName> RoadLaneTags = ITempoRoadInterface::Execute_GetTempoLaneTags(&RoadQueryActor, LaneIndex);
+
+			for (const FName& RoadLaneTag : RoadLaneTags)
+			{
+				AggregateRoadLaneTags.AddUnique(RoadLaneTag);
+			}
+		}
+
+		return AggregateRoadLaneTags;
+	};
+
+	const auto& GenerateTagMaskFromTagNames = [&ZoneGraphSubsystem](const TArray<FName>& TagNames)
+	{
+		FZoneGraphTagMask ZoneGraphTagMask;
+	
+		for (const auto& TagName : TagNames)
+		{
+			FZoneGraphTag Tag = ZoneGraphSubsystem->GetTagByName(TagName);
+			ZoneGraphTagMask.Add(Tag);
+		}
+
+		return ZoneGraphTagMask;
+	};
+	
+	for (AActor* Actor : TActorRange<AActor>(&World))
+	{
+		if (!IsValid(Actor))
+		{
+			continue;
+		}
+
+		if (!Actor->Implements<UTempoIntersectionInterface>())
+		{
+			continue;
+		}
+
+		const AActor& IntersectionQueryActor = *Actor;
+
+		const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(&IntersectionQueryActor);
+		
+		for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
+		{
+			const AActor* RoadQueryActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(&IntersectionQueryActor, ConnectionIndex);
+			if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("Couldn't get valid Connected Road Actor for Actor: %s at ConnectionIndex: %d in UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap."), *IntersectionQueryActor.GetName(), ConnectionIndex))
+			{
+				return;
+			}
+			
+			const int32 CrosswalkStartControlPointIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(&IntersectionQueryActor, ConnectionIndex);
+			const int32 CrosswalkEndControlPointIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(&IntersectionQueryActor, ConnectionIndex);
+			
+			const FVector CrosswalkStartControlPointLocation = ITempoIntersectionInterface::Execute_GetTempoCrosswalkControlPointLocation(&IntersectionQueryActor, ConnectionIndex, CrosswalkStartControlPointIndex, ETempoCoordinateSpace::World);
+			const FVector CrosswalkEndControlPointLocation = ITempoIntersectionInterface::Execute_GetTempoCrosswalkControlPointLocation(&IntersectionQueryActor, ConnectionIndex, CrosswalkEndControlPointIndex, ETempoCoordinateSpace::World);
+
+			const FVector IntersectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(&IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+			const FVector IntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(&IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+
+			const float RoadWidth = ITempoRoadInterface::Execute_GetTempoRoadWidth(RoadQueryActor);
+			const float LateralDistanceToIntersectionExitCenter = RoadWidth / 4.0f;
+
+			const FVector IntersectionQueryLocation = IntersectionEntranceLocation - IntersectionEntranceRightVector * LateralDistanceToIntersectionExitCenter;
+
+			// TODO:  Remove this debug sphere.
+			DrawDebugSphere(IntersectionQueryActor.GetWorld(), IntersectionQueryLocation, 25.0f, 16, FColor::Red, false, 10.0f);
+
+			const float DistanceToCrosswalkCenter = FMath::PointDistToSegment(IntersectionQueryLocation, CrosswalkStartControlPointLocation, CrosswalkEndControlPointLocation);
+			const float QueryRadius = FMath::Max(LateralDistanceToIntersectionExitCenter, DistanceToCrosswalkCenter);
+
+			// TODO:  Remove this debug sphere.
+			DrawDebugSphere(IntersectionQueryActor.GetWorld(), IntersectionQueryLocation, QueryRadius, 16, FColor::Purple, false, 10.0f);
+
+			const TArray<FName> RoadLaneTags = GetRoadLaneTags(*RoadQueryActor);
+			const TArray<FName> CrosswalkTags = ITempoIntersectionInterface::Execute_GetTempoCrosswalkTags(&IntersectionQueryActor, ConnectionIndex);
+
+			const FZoneGraphTagMask RoadLaneAnyTagMask = GenerateTagMaskFromTagNames(RoadLaneTags);
+			const FZoneGraphTagMask CrosswalkAllTagMask = GenerateTagMaskFromTagNames(CrosswalkTags);
+
+			constexpr FZoneGraphTagMask EmptyTagMask;
+
+			const FZoneGraphTagFilter RoadLaneTagFilter(RoadLaneAnyTagMask, EmptyTagMask, EmptyTagMask);
+			const FZoneGraphTagFilter CrosswalkTagFilter(EmptyTagMask, CrosswalkAllTagMask, EmptyTagMask);
+
+			const TIndirectArray<FMassTrafficZoneGraphData>& MassTrafficZoneGraphDatas = MassTrafficSubsystem->GetTrafficZoneGraphData();
+			
+			for (const FMassTrafficZoneGraphData& MassTrafficZoneGraphData : MassTrafficZoneGraphDatas)
+			{
+				const FZoneGraphStorage* ZoneGraphStorage = ZoneGraphSubsystem->GetZoneGraphStorage(MassTrafficZoneGraphData.DataHandle);
+
+				if (!ensureMsgf(ZoneGraphStorage != nullptr, TEXT("ZoneGraphStorage must be valid in UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap.")))
+				{
+					return;
+				}
+
+				const FBox QueryBox = FBox::BuildAABB(IntersectionQueryLocation, FVector::OneVector * QueryRadius);
+
+				TArray<FZoneGraphLaneHandle> RoadLaneHandles;
+				TArray<FZoneGraphLaneHandle> CrosswalkLaneHandles;
+				
+				const bool bFoundRoadLanes = UE::ZoneGraph::Query::FindOverlappingLanes(*ZoneGraphStorage, QueryBox, RoadLaneTagFilter, RoadLaneHandles);
+				const bool bFoundCrosswalkLanes = UE::ZoneGraph::Query::FindOverlappingLanes(*ZoneGraphStorage, QueryBox, CrosswalkTagFilter, CrosswalkLaneHandles);
+
+				if (!bFoundRoadLanes && !bFoundCrosswalkLanes)
+				{
+					// If no lanes are found, they may be in another ZoneGraphStorage.  So, continue to the next one.
+					continue;
+				}
+
+				// If we didn't find both crosswalk lanes and road lanes (but found one or the other), it's an error state.
+				if (!ensureMsgf(bFoundRoadLanes && bFoundCrosswalkLanes, TEXT("Must find both crosswalk lanes and road lanes, if we find either one of them in UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap. bFoundRoadLanes: %d bFoundCrosswalkLanes: %d"), bFoundRoadLanes, bFoundCrosswalkLanes))
+				{
+					return;
+				}
+
+				if (!ensureMsgf(CrosswalkLaneHandles.Num() == 2, TEXT("Expected exactly 2 crosswalk lanes in UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap.  But, found %d for IntersectionQueryActor: %s at ConnectionIndex: %d."), CrosswalkLaneHandles.Num(), *IntersectionQueryActor.GetName(), ConnectionIndex))
+				{
+					return;
+				}
+
+				// Filter road lanes down to just the intersection lanes that exit the intersection through the crosswalk at ConnectionIndex.
+				RoadLaneHandles.RemoveAll([&MassTrafficSubsystem, &ZoneGraphStorage, &IntersectionQueryActor, ConnectionIndex](const FZoneGraphLaneHandle& RoadLaneHandle)
+				{
+					const FZoneGraphTrafficLaneData* ZoneGraphTrafficLaneData = MassTrafficSubsystem->GetTrafficLaneData(RoadLaneHandle);
+					
+					if (!ensureMsgf(ZoneGraphTrafficLaneData != nullptr, TEXT("Must get ZoneGraphTrafficLaneData for RoadLaneHandle in UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap.  IntersectionQueryActor: %s at ConnectionIndex: %d."), *IntersectionQueryActor.GetName(), ConnectionIndex))
+					{
+						return true;
+					}
+
+					if (!ZoneGraphTrafficLaneData->ConstData.bIsIntersectionLane)
+					{
+						return true;
+					}
+
+					const FZoneLaneData& ZoneLaneData = ZoneGraphStorage->Lanes[RoadLaneHandle.Index];
+					const int32 LastLanePointsIndex = ZoneLaneData.PointsEnd - 1;
+
+					const FVector LastLaneTangent = ZoneGraphStorage->LaneTangentVectors[LastLanePointsIndex];
+
+					const FVector IntersectionEntranceForwardVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(&IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+
+					const bool bLaneIsExitingIntersection = FVector::DotProduct(IntersectionEntranceForwardVector, LastLaneTangent) < 0.0f;
+					
+					if (!bLaneIsExitingIntersection)
+					{
+						return true;
+					}
+
+					return false;
+				});
+
+				// Now, we should have only intersection lanes that exit the intersection through the crosswalk at ConnectionIndex.
+				// So, just make an alias for clarity.
+				const TArray<FZoneGraphLaneHandle>& IntersectionLaneHandles = RoadLaneHandles;
+
+				if (!ensureMsgf(IntersectionLaneHandles.Num() > 0, TEXT("Expected at least 1 intersection lane to exit through the crosswalk in UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap.  IntersectionQueryActor: %s at ConnectionIndex: %d."), *IntersectionQueryActor.GetName(), ConnectionIndex))
+				{
+					return;
+				}
+				
+				for (const FZoneGraphLaneHandle& IntersectionLaneHandle : IntersectionLaneHandles)
+				{
+					for (const FZoneGraphLaneHandle& CrosswalkLaneHandle : CrosswalkLaneHandles)
+					{
+						MassTrafficSubsystem->AddDownstreamCrosswalkLane(IntersectionLaneHandle, CrosswalkLaneHandle);
+					}
+				}
+			}
+		}
+	}
+}
+
 void UTempoAgentsWorldSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 {
 	Super::OnWorldBeginPlay(InWorld);
@@ -117,4 +317,6 @@ void UTempoAgentsWorldSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 	GetWorld()->OnWorldBeginPlay.AddUObject(this, &UTempoAgentsWorldSubsystem::SetupTrafficControllers);
 
 	GetWorld()->OnWorldBeginPlay.AddUObject(this, &UTempoAgentsWorldSubsystem::SetupBrightnessMeter);
+	
+	GetWorld()->OnWorldBeginPlay.AddUObject(this, &UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap);
 }

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoAgentsWorldSubsystem.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoAgentsWorldSubsystem.cpp
@@ -197,14 +197,8 @@ void UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap()
 
 			const FVector IntersectionQueryLocation = IntersectionEntranceLocation - IntersectionEntranceRightVector * LateralDistanceToIntersectionExitCenter;
 
-			// TODO:  Remove this debug sphere.
-			DrawDebugSphere(IntersectionQueryActor.GetWorld(), IntersectionQueryLocation, 25.0f, 16, FColor::Red, false, 10.0f);
-
 			const float DistanceToCrosswalkCenter = FMath::PointDistToSegment(IntersectionQueryLocation, CrosswalkStartControlPointLocation, CrosswalkEndControlPointLocation);
 			const float QueryRadius = FMath::Max(LateralDistanceToIntersectionExitCenter, DistanceToCrosswalkCenter);
-
-			// TODO:  Remove this debug sphere.
-			DrawDebugSphere(IntersectionQueryActor.GetWorld(), IntersectionQueryLocation, QueryRadius, 16, FColor::Purple, false, 10.0f);
 
 			const TArray<FName> RoadLaneTags = GetRoadLaneTags(*RoadQueryActor);
 			const TArray<FName> CrosswalkTags = ITempoIntersectionInterface::Execute_GetTempoCrosswalkTags(&IntersectionQueryActor, ConnectionIndex);

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
@@ -245,9 +245,8 @@ bool UTempoIntersectionQueryComponent::ShouldFilterLaneConnection(const AActor* 
 	}
 }
 
-bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfo(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, FCrosswalkIntersectionConnectorInfo& OutCrosswalkIntersectionConnectorInfo) const
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfo(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, FCrosswalkIntersectionConnectorInfo& OutCrosswalkIntersectionConnectorInfo) const
 {
-	// TODO:  Can anything be pushed up to the Tempo version of this function?
 	ensureMsgf(false, TEXT("UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfo not implemented."));
 	return false;
 }
@@ -326,7 +325,7 @@ bool UTempoIntersectionQueryComponent::TryGenerateCrosswalkRoadModuleMap(const A
 		}
 		
 		const float RoadWidth = ITempoRoadInterface::Execute_GetTempoRoadWidth(RoadQueryActor);
-		const float CrosswalkWidth = ITempoIntersectionInterface::Execute_GetTempoCrosswalkWidth(IntersectionQueryActor);
+		const float CrosswalkWidth = ITempoIntersectionInterface::Execute_GetTempoCrosswalkWidth(IntersectionQueryActor, ConnectionIndex);
 
 		const auto& GetCrosswalkRoadModuleInLateralDirection = [&CrosswalkRoadModules, &ConnectionEntranceLocation, &ConnectionEntranceForward, &ConnectionEntranceRight, &RoadWidth, &CrosswalkWidth, &GetCrosswalkRoadModuleBounds](const float LateralDirectionScalar) -> AActor*
 		{
@@ -376,8 +375,12 @@ bool UTempoIntersectionQueryComponent::TryGenerateCrosswalkRoadModuleMap(const A
 
 bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, AActor*& OutCrosswalkRoadModule, float &OutCrosswalkIntersectionConnectorDistance) const
 {
-	// TODO:  Resolve this more transparently via interface functions.
-	const int32 CrosswalkRoadModuleIndex = CrosswalkIntersectionIndex / 2;
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry.")))
+	{
+		return false;
+	}
+	
+	const int32 CrosswalkRoadModuleIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
 	
 	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
 	
@@ -401,6 +404,31 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoE
 		return false;
 	}
 
+	const auto& TryGetCrosswalkIntersectionEntranceOuterDistance = [this, &IntersectionQueryActor](const AActor& CrosswalkRoadModule, int32 CrosswalkIntersectionIndex, float &OutCrosswalkIntersectionEntranceOuterDistance)
+	{
+		const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+		const AActor* RoadQueryActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(IntersectionQueryActor, ConnectionIndex);
+		if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("Couldn't get valid Connected Road Actor for Actor: %s at ConnectionIndex: %d in UVayuIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry."), *IntersectionQueryActor->GetName(), ConnectionIndex))
+		{
+			return false;
+		}
+
+		const float RoadWidth = ITempoRoadInterface::Execute_GetTempoRoadWidth(RoadQueryActor);
+		const float CrosswalkRoadModuleWidth = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleWidth(&CrosswalkRoadModule);
+		
+		const FVector IntersectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector IntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+		const float LateralDirectionScalar = CrosswalkIntersectionIndex % 2 == 0 ? 1.0f : -1.0f;
+
+		const FVector CrosswalkIntersectionOuterQueryLocation = IntersectionEntranceLocation + IntersectionEntranceRightVector * (RoadWidth * 0.5f + CrosswalkRoadModuleWidth * 0.5f) * LateralDirectionScalar;
+		const float CrosswalkIntersectionEntranceOuterDistance = ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleClosestToWorldLocation(&CrosswalkRoadModule, CrosswalkIntersectionOuterQueryLocation);
+		
+		OutCrosswalkIntersectionEntranceOuterDistance = CrosswalkIntersectionEntranceOuterDistance;
+
+		return true;
+	};
+
 	const float CrosswalkRoadModuleLength = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLength(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule);
 
 	const FCrosswalkIntersectionConnectorSegmentInfo& CrosswalkIntersectionConnectorSegmentInfo = CrosswalkIntersectionConnectorInfo->CrosswalkIntersectionConnectorSegmentInfos[0];
@@ -409,7 +437,13 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoE
 		{{0.0f, CrosswalkIntersectionConnectorSegmentInfo.CrosswalkIntersectionConnectorStartDistance},
 		{CrosswalkIntersectionConnectorSegmentInfo.CrosswalkIntersectionConnectorEndDistance, CrosswalkRoadModuleLength}};
 
-	const int32 CrosswalkIntersectionDistanceIndex = CrosswalkIntersectionIndex % 2;
+	float CrosswalkIntersectionEntranceOuterDistance;
+	if (!TryGetCrosswalkIntersectionEntranceOuterDistance(*CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, CrosswalkIntersectionIndex, CrosswalkIntersectionEntranceOuterDistance))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkIntersectionDistanceIndex = CrosswalkIntersectionEntranceOuterDistance < FMath::Abs(CrosswalkIntersectionEntranceOuterDistance - CrosswalkRoadModuleLength) ? 0 : 1;
 	const int32 CrosswalkIntersectionDistanceSideIndex = CrosswalkIntersectionConnectionIndex == 1 ? 0 : 1;
 	
 	const float CrosswalkIntersectionConnectorDistance = CrosswalkIntersectionConnectorDistances[CrosswalkIntersectionDistanceIndex][CrosswalkIntersectionDistanceSideIndex];
@@ -433,8 +467,10 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocati
 	{
 		return false;
 	}
+	
+	const int32 NumCrosswalkIntersections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
 
-	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumConnections * 2, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections * 2, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
@@ -448,7 +484,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocati
 	
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const int32 ConnectionIndex = CrosswalkIntersectionIndex % 2 == 0 ? CrosswalkIntersectionIndex / 2 : (NumConnections - 1 + (CrosswalkIntersectionIndex / 2)) % NumConnections;
+		const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
 		const int32 CrosswalkControlPointIndex = (CrosswalkIntersectionIndex + 1) % 2;
 		
 		const FVector CrosswalkEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoCrosswalkControlPointLocation(IntersectionQueryActor, ConnectionIndex, CrosswalkControlPointIndex, CoordinateSpace);
@@ -488,7 +524,9 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangen
 		return false;
 	}
 
-	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumConnections * 2, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections * 2, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	const int32 NumCrosswalkIntersections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
@@ -503,11 +541,11 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangen
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const int32 ConnectionIndex = CrosswalkIntersectionIndex % 2 == 0 ? CrosswalkIntersectionIndex / 2 : (NumConnections - 1 + (CrosswalkIntersectionIndex / 2)) % NumConnections;
-		const float LateralDirectionScalar = (CrosswalkIntersectionIndex % 2) == 0 ? 1.0f : -1.0f;
+		const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+		const float DirectionScalar = (CrosswalkIntersectionIndex % 2) == 0 ? 1.0f : -1.0f;
 
 		// The actual Crosswalk's Intersection Entrance tangent is based on the Intersection Connection's right vector.
-		const FVector CrosswalkIntersectionEntranceTangent = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace) * LateralDirectionScalar;
+		const FVector CrosswalkIntersectionEntranceTangent = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace) * DirectionScalar;
 
 		OutCrosswalkIntersectionEntranceTangent = CrosswalkIntersectionEntranceTangent;
 	}
@@ -522,8 +560,8 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangen
 			return false;
 		}
 		
-		const float LateralDirectionScalar = CrosswalkIntersectionConnectionIndex == 1 ? 1.0f : -1.0f;
-		const FVector CrosswalkIntersectionEntranceTangent = ITempoRoadModuleInterface::Execute_GetTangentAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * LateralDirectionScalar;
+		const float DirectionScalar = CrosswalkIntersectionConnectionIndex == 1 ? 1.0f : -1.0f;
+		const FVector CrosswalkIntersectionEntranceTangent = ITempoRoadModuleInterface::Execute_GetTangentAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
 		
 		OutCrosswalkIntersectionEntranceTangent = CrosswalkIntersectionEntranceTangent;
 	}
@@ -545,7 +583,9 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVect
 		return false;
 	}
 
-	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumConnections * 2, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections * 2, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	const int32 NumCrosswalkIntersections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
@@ -560,7 +600,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVect
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const int32 ConnectionIndex = CrosswalkIntersectionIndex % 2 == 0 ? CrosswalkIntersectionIndex / 2 : (NumConnections - 1 + (CrosswalkIntersectionIndex / 2)) % NumConnections;
+		const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
 		
 		const FVector CrosswalkIntersectionEntranceUpVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
 
@@ -599,7 +639,9 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightV
 		return false;
 	}
 
-	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumConnections * 2, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections * 2, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	const int32 NumCrosswalkIntersections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
@@ -614,12 +656,12 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightV
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const int32 ConnectionIndex = CrosswalkIntersectionIndex % 2 == 0 ? CrosswalkIntersectionIndex / 2 : (NumConnections - 1 + (CrosswalkIntersectionIndex / 2)) % NumConnections;
+		const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
 		
-		const float LateralDirectionScalar = (CrosswalkIntersectionIndex % 2) == 0 ? 1.0f : -1.0f;
+		const float DirectionScalar = (CrosswalkIntersectionIndex % 2) == 0 ? 1.0f : -1.0f;
 
 		// The actual Crosswalk's Intersection Entrance right vector is based on the Intersection Connection's forward vector.
-		const FVector CrosswalkIntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace).GetSafeNormal() * LateralDirectionScalar * -1.0f;
+		const FVector CrosswalkIntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace).GetSafeNormal() * DirectionScalar * -1.0f;
 
 		OutCrosswalkIntersectionEntranceRightVector = CrosswalkIntersectionEntranceRightVector;
 	}
@@ -634,11 +676,466 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightV
 			return false;
 		}
 		
-		const float LateralDirectionScalar = CrosswalkIntersectionConnectionIndex == 1 ? 1.0f : -1.0f;
-		const FVector CrosswalkIntersectionEntranceRightVector = ITempoRoadModuleInterface::Execute_GetRightVectorAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * LateralDirectionScalar;
+		const float DirectionScalar = CrosswalkIntersectionConnectionIndex == 1 ? 1.0f : -1.0f;
+		const FVector CrosswalkIntersectionEntranceRightVector = ITempoRoadModuleInterface::Execute_GetRightVectorAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
 		
 		OutCrosswalkIntersectionEntranceRightVector = CrosswalkIntersectionEntranceRightVector;
 	}
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, int32& OutNumCrosswalkIntersectionEntranceLanes) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+	
+	const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const int32 NumCrosswalkIntersectionEntranceLanes = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkLanes(IntersectionQueryActor, ConnectionIndex);
+		
+		OutNumCrosswalkIntersectionEntranceLanes = NumCrosswalkIntersectionEntranceLanes;
+	}
+	else
+	{
+		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
+		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
+		const int32 CrosswalkRoadModuleIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+		if (!TryGetNumCrosswalkIntersectionConnectorLanes(IntersectionQueryActor, CrosswalkRoadModuleIndex, CrosswalkIntersectionConnectorInfoMap, OutNumCrosswalkIntersectionEntranceLanes))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FName& OutCrosswalkIntersectionEntranceLaneProfileOverrideName) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+	
+	const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const FName LaneProfileOverrideNameForTempoCrosswalk = ITempoIntersectionInterface::Execute_GetLaneProfileOverrideNameForTempoCrosswalk(IntersectionQueryActor, ConnectionIndex);
+		
+		OutCrosswalkIntersectionEntranceLaneProfileOverrideName = LaneProfileOverrideNameForTempoCrosswalk;
+	}
+	else
+	{
+		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
+		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
+		const int32 CrosswalkRoadModuleIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+		if (!TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName(IntersectionQueryActor, CrosswalkRoadModuleIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneProfileOverrideName))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, float& OutCrosswalkIntersectionEntranceLaneWidth) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+	
+	const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const float CrosswalkLaneWidth = ITempoIntersectionInterface::Execute_GetTempoCrosswalkLaneWidth(IntersectionQueryActor, ConnectionIndex, LaneIndex);
+		
+		OutCrosswalkIntersectionEntranceLaneWidth = CrosswalkLaneWidth;
+	}
+	else
+	{
+		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
+		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
+		const int32 CrosswalkRoadModuleIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+		if (!TryGetCrosswalkIntersectionConnectorLaneWidth(IntersectionQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneWidth))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, EZoneLaneDirection& OutCrosswalkIntersectionEntranceLaneDirection) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+	
+	const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const EZoneLaneDirection CrosswalkLaneDirection = ITempoIntersectionInterface::Execute_GetTempoCrosswalkLaneDirection(IntersectionQueryActor, ConnectionIndex, LaneIndex);
+		
+		OutCrosswalkIntersectionEntranceLaneDirection = CrosswalkLaneDirection;
+	}
+	else
+	{
+		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
+		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
+		const int32 CrosswalkRoadModuleIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+		if (!TryGetCrosswalkIntersectionConnectorLaneDirection(IntersectionQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneDirection))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, TArray<FName>& OutCrosswalkIntersectionEntranceLaneTags) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+	
+	const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const TArray<FName> CrosswalkLaneTags = ITempoIntersectionInterface::Execute_GetTempoCrosswalkLaneTags(IntersectionQueryActor, ConnectionIndex, LaneIndex);
+		
+		OutCrosswalkIntersectionEntranceLaneTags = CrosswalkLaneTags;
+	}
+	else
+	{
+		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
+		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
+		const int32 CrosswalkRoadModuleIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+		if (!TryGetCrosswalkIntersectionConnectorLaneTags(IntersectionQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneTags))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, int32& OutNumCrosswalkIntersectionConnectorLanes) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkRoadModules = ITempoIntersectionInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.")))
+	{
+		return false;
+	}
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnectorLanes = ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule);
+	
+	OutNumCrosswalkIntersectionConnectorLanes = NumCrosswalkIntersectionConnectorLanes;
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FName& OutCrosswalkIntersectionConnectorLaneProfileOverrideName) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkRoadModules = ITempoIntersectionInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName.")))
+	{
+		return false;
+	}
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName.")))
+	{
+		return false;
+	}
+
+	const FName CrosswalkRoadModuleLaneProfileOverrideName = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneProfileOverrideName(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule);
+		
+	OutCrosswalkIntersectionConnectorLaneProfileOverrideName = CrosswalkRoadModuleLaneProfileOverrideName;
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, float& OutCrosswalkIntersectionConnectorLaneWidth) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkRoadModules = ITempoIntersectionInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth.")))
+	{
+		return false;
+	}
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth.")))
+	{
+		return false;
+	}
+
+	const float CrosswalkRoadModuleLaneWidth = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneWidth(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+		
+	OutCrosswalkIntersectionConnectorLaneWidth = CrosswalkRoadModuleLaneWidth;
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, EZoneLaneDirection& OutCrosswalkIntersectionConnectorLaneDirection) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkRoadModules = ITempoIntersectionInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection.")))
+	{
+		return false;
+	}
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection.")))
+	{
+		return false;
+	}
+
+	const EZoneLaneDirection CrosswalkRoadModuleLaneDirection = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneDirection(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+		
+	OutCrosswalkIntersectionConnectorLaneDirection = CrosswalkRoadModuleLaneDirection;
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneTags(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, TArray<FName>& OutCrosswalkIntersectionConnectorLaneTags) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneTags.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkRoadModules = ITempoIntersectionInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(IntersectionQueryActor);
+
+	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneTags.")))
+	{
+		return false;
+	}
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneTags.")))
+	{
+		return false;
+	}
+
+	const TArray<FName> CrosswalkRoadModuleLaneTags = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+		
+	OutCrosswalkIntersectionConnectorLaneTags = CrosswalkRoadModuleLaneTags;
 
 	return true;
 }
@@ -658,11 +1155,11 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation(const
 		return false;
 	}
 	
-	const FVector ControlPointEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
-	const FVector ControlPointEntranceTangent = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+	const FVector IntersectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+	const FVector IntersectionEntranceTangent = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
 
-	const FVector ControlPointEntranceForwardVector = ControlPointEntranceTangent.GetSafeNormal();
-	const FVector ControlPointEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+	const FVector IntersectionEntranceForwardVector = IntersectionEntranceTangent.GetSafeNormal();
+	const FVector IntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
 
 	const AActor* RoadQueryActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(IntersectionQueryActor, ConnectionIndex);
 	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("Couldn't get valid Connected Road Actor for Actor: %s at ConnectionIndex: %d in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation."), *IntersectionQueryActor->GetName(), ConnectionIndex))
@@ -670,7 +1167,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation(const
 		return false;
 	}
 
-	const auto& GetLateralOffset = [&IntersectionQueryActor, &RoadQueryActor, &ControlPointEntranceRightVector, ConnectionIndex, CrosswalkControlPointIndex, CoordinateSpace]()
+	const auto& GetLateralOffset = [&IntersectionQueryActor, &RoadQueryActor, &IntersectionEntranceRightVector, ConnectionIndex, CrosswalkControlPointIndex, CoordinateSpace]()
 	{
 		const int32 NumLanes = ITempoRoadInterface::Execute_GetNumTempoLanes(RoadQueryActor);
 		
@@ -683,17 +1180,14 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation(const
 
 		const int32 IntersectionEntranceControlPointIndex = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceControlPointIndex(IntersectionQueryActor, ConnectionIndex);
 		const FVector ControlPointRightVector = ITempoRoadInterface::Execute_GetTempoControlPointRightVector(RoadQueryActor, IntersectionEntranceControlPointIndex, CoordinateSpace);
+		
+		const float DotProduct = FVector::DotProduct(IntersectionEntranceRightVector, ControlPointRightVector);
 
-		ETempoRoadLateralDirection LateralQueryDirection = CrosswalkControlPointIndex == 0 ? ETempoRoadLateralDirection::Left : ETempoRoadLateralDirection::Right;
+		const ETempoRoadLateralDirection RoadRelativeLateralQueryDirection = CrosswalkControlPointIndex == 0
+			? DotProduct >= 0.0f ? ETempoRoadLateralDirection::Left : ETempoRoadLateralDirection::Right
+			: DotProduct >= 0.0f ? ETempoRoadLateralDirection::Right : ETempoRoadLateralDirection::Left;
 		
-		const float DotProduct = FVector::DotProduct(ControlPointEntranceRightVector, ControlPointRightVector);
-		
-		if (DotProduct < 0.0f)
-		{
-			LateralQueryDirection = CrosswalkControlPointIndex == 0 ? ETempoRoadLateralDirection::Right : ETempoRoadLateralDirection::Left;
-		}
-		
-		const float ShoulderWidth = ITempoRoadInterface::Execute_GetTempoRoadShoulderWidth(RoadQueryActor, LateralQueryDirection);
+		const float ShoulderWidth = ITempoRoadInterface::Execute_GetTempoRoadShoulderWidth(RoadQueryActor, RoadRelativeLateralQueryDirection);
 		
 		const float LateralOffset = TotalLanesWidth * 0.5f + ShoulderWidth;
 
@@ -703,14 +1197,11 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation(const
 	const float LateralOffset = GetLateralOffset();
 	const float LateralDirectionScalar = CrosswalkControlPointIndex == 0 ? -1.0f : 1.0f;
 	
-	const float CrosswalkWidth = ITempoIntersectionInterface::Execute_GetTempoCrosswalkWidth(IntersectionQueryActor);
+	const float CrosswalkWidth = ITempoIntersectionInterface::Execute_GetTempoCrosswalkWidth(IntersectionQueryActor, ConnectionIndex);
 	
-	const FVector CrosswalkEntranceLocation = ControlPointEntranceLocation + ControlPointEntranceForwardVector * CrosswalkWidth * 0.5f + ControlPointEntranceRightVector * LateralOffset * LateralDirectionScalar;
+	const FVector CrosswalkControlPointLocation = IntersectionEntranceLocation + IntersectionEntranceForwardVector * CrosswalkWidth * 0.5f + IntersectionEntranceRightVector * LateralOffset * LateralDirectionScalar;
 
-	// TODO:  Remove this debug sphere.
-	DrawDebugSphere(IntersectionQueryActor->GetWorld(), CrosswalkEntranceLocation, 25.0f, 16, FColor::Orange, false, 10.0f);
-
-	OutCrosswalkControlPointLocation = CrosswalkEntranceLocation;
+	OutCrosswalkControlPointLocation = CrosswalkControlPointLocation;
 
 	return true;
 }
@@ -730,10 +1221,10 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointTangent(const 
 		return false;
 	}
 	
-	const FVector ControlPointEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+	const FVector IntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
 
 	// Crosswalk tangent points to the Intersection Entrance's right.
-	OutCrosswalkControlPointTangent = ControlPointEntranceRightVector;
+	OutCrosswalkControlPointTangent = IntersectionEntranceRightVector;
 
 	return true;
 }
@@ -753,9 +1244,9 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointUpVector(const
 		return false;
 	}
 	
-	const FVector ControlPointEntranceUpVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+	const FVector IntersectionEntranceUpVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
 	
-	OutCrosswalkControlPointUpVector = ControlPointEntranceUpVector;
+	OutCrosswalkControlPointUpVector = IntersectionEntranceUpVector;
 
 	return true;
 }
@@ -775,10 +1266,10 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointRightVector(co
 		return false;
 	}
 	
-	const FVector ControlPointEntranceForwardVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace).GetSafeNormal();
+	const FVector IntersectionEntranceForwardVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace).GetSafeNormal();
 
 	// Crosswalk right vector points opposite the Intersection Entrance's forward vector.
-	OutCrosswalkControlPointRightVector = -ControlPointEntranceForwardVector;
+	OutCrosswalkControlPointRightVector = -IntersectionEntranceForwardVector;
 
 	return true;
 }
@@ -808,6 +1299,33 @@ bool UTempoIntersectionQueryComponent::IsConnectedRoadActor(const AActor* RoadQu
 	}
 
 	return false;
+}
+
+int32 UTempoIntersectionQueryComponent::GetConnectionIndexFromCrosswalkIntersectionIndex(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::GetConnectionIndexFromCrosswalkIntersectionIndex.")))
+	{
+		return 0;
+	}
+	
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::GetConnectionIndexFromCrosswalkIntersectionIndex.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return 0;
+	}
+
+	// As an example of the indexing scheme,
+	// as CrosswalkIntersectionIndex iterates from 0 to 7 with NumConnections equal to 4,
+	// ConnectionIndex will be the sequence: 0, 3, 1, 0, 2, 1, 3, 2.
+	//
+	// As we iterate through the Crosswalk Intersections, when CrosswalkIntersectionIndex is *even*,
+	// that Crosswalk Intersection will be on the *right* of its Connected Road Actor at ConnectionIndex.
+	// And, when CrosswalkIntersectionIndex is *odd*,
+	// that Crosswalk Intersection will be on the *left* of its Connected Road Actor at ConnectionIndex.
+	const int32 ConnectionIndex = CrosswalkIntersectionIndex % 2 == 0 ? CrosswalkIntersectionIndex / 2 : (NumConnections - 1 + (CrosswalkIntersectionIndex / 2)) % NumConnections;
+
+	return ConnectionIndex;
 }
 
 bool UTempoIntersectionQueryComponent::TryGetNearestRoadControlPointIndex(const AActor& IntersectionQueryActor, int32 ConnectionIndex, int32& OutNearestRoadControlPointIndex) const

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
@@ -707,6 +707,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation(const
 	
 	const FVector CrosswalkEntranceLocation = ControlPointEntranceLocation + ControlPointEntranceForwardVector * CrosswalkWidth * 0.5f + ControlPointEntranceRightVector * LateralOffset * LateralDirectionScalar;
 
+	// TODO:  Remove this debug sphere.
 	DrawDebugSphere(IntersectionQueryActor->GetWorld(), CrosswalkEntranceLocation, 25.0f, 16, FColor::Orange, false, 10.0f);
 
 	OutCrosswalkControlPointLocation = CrosswalkEntranceLocation;

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
@@ -5,6 +5,7 @@
 
 #include "TempoAgentsShared.h"
 #include "TempoRoadInterface.h"
+#include "TempoRoadModuleInterface.h"
 #include "ZoneGraphSettings.h"
 #include "ZoneGraphSubsystem.h"
 
@@ -244,6 +245,542 @@ bool UTempoIntersectionQueryComponent::ShouldFilterLaneConnection(const AActor* 
 	}
 }
 
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfo(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, FCrosswalkIntersectionConnectorInfo& OutCrosswalkIntersectionConnectorInfo) const
+{
+	// TODO:  Can anything be pushed up to the Tempo version of this function?
+	ensureMsgf(false, TEXT("UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfo not implemented."));
+	return false;
+}
+
+bool UTempoIntersectionQueryComponent::TryGenerateCrosswalkRoadModuleMap(const AActor* IntersectionQueryActor, const TArray<FName>& CrosswalkRoadModuleAnyTags, const TArray<FName>& CrosswalkRoadModuleAllTags, const TArray<FName>& CrosswalkRoadModuleNotTags, TMap<int32, AActor*>& OutCrosswalkRoadModuleMap) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGenerateCrosswalkRoadModuleMap.")))
+	{
+		return false;
+	}
+
+	const FZoneGraphTagFilter CrosswalkRoadModuleTagFilter = GenerateTagFilter(CrosswalkRoadModuleAnyTags, CrosswalkRoadModuleAllTags, CrosswalkRoadModuleNotTags);
+
+	const auto& GetCrosswalkRoadModules = [this, &IntersectionQueryActor, &CrosswalkRoadModuleTagFilter]()
+	{
+		TArray<AActor*> CrosswalkRoadModules;
+
+		const int32 NumConnectedRoadModules = ITempoIntersectionInterface::Execute_GetNumConnectedTempoRoadModules(IntersectionQueryActor);
+
+		for (int32 ConnectedRoadModuleIndex = 0; ConnectedRoadModuleIndex < NumConnectedRoadModules; ++ConnectedRoadModuleIndex)
+		{
+			AActor* ConnectedRoadModule = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadModuleActor(IntersectionQueryActor, ConnectedRoadModuleIndex);
+
+			if (ConnectedRoadModule == nullptr)
+			{
+				continue;
+			}
+
+			const int32 NumRoadModuleLanes = ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes(ConnectedRoadModule);
+
+			for (int32 RoadModuleLaneIndex = 0; RoadModuleLaneIndex < NumRoadModuleLanes; ++RoadModuleLaneIndex)
+			{
+				const TArray<FName>& RoadModuleLaneTags = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags(ConnectedRoadModule, RoadModuleLaneIndex);
+
+				const FZoneGraphTagMask& RoadModuleLaneTagMask = GenerateTagMaskFromTagNames(RoadModuleLaneTags);
+
+				// Is the road module a crosswalk (according to tags)?
+				if (CrosswalkRoadModuleTagFilter.Pass(RoadModuleLaneTagMask))
+				{
+					// Then, add it to the list of crosswalks.
+					CrosswalkRoadModules.Add(ConnectedRoadModule);
+					break;
+				}
+			}
+		}
+
+		return CrosswalkRoadModules;
+	};
+
+	const TArray<AActor*> CrosswalkRoadModules = GetCrosswalkRoadModules();
+
+	const auto& GetCrosswalkRoadModuleBounds = [](const AActor& ConnectedCrosswalkRoadModule)
+	{
+		FVector Origin;
+		FVector BoxExtent;
+		ConnectedCrosswalkRoadModule.GetActorBounds(false, Origin, BoxExtent);
+		const FBox ActorBox = FBox::BuildAABB(Origin, BoxExtent);
+
+		return ActorBox;
+	};
+
+	TMap<int32, AActor*> CrosswalkRoadModuleMap;
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
+	{
+		const FVector ConnectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector ConnectionEntranceForward = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+		const FVector ConnectionEntranceRight = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+		
+		const AActor* RoadQueryActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(IntersectionQueryActor, ConnectionIndex);
+		if (RoadQueryActor == nullptr)
+		{
+			return false;
+		}
+		
+		const float RoadWidth = ITempoRoadInterface::Execute_GetTempoRoadWidth(RoadQueryActor);
+		const float CrosswalkWidth = ITempoIntersectionInterface::Execute_GetTempoCrosswalkWidth(IntersectionQueryActor);
+
+		const auto& GetCrosswalkRoadModuleInLateralDirection = [&CrosswalkRoadModules, &ConnectionEntranceLocation, &ConnectionEntranceForward, &ConnectionEntranceRight, &RoadWidth, &CrosswalkWidth, &GetCrosswalkRoadModuleBounds](const float LateralDirectionScalar) -> AActor*
+		{
+			for (AActor* CrosswalkRoadModule : CrosswalkRoadModules)
+			{
+				const float RoadModuleWidth = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleWidth(CrosswalkRoadModule);
+		
+				const FVector CrosswalkIntersectionCenterLocation = ConnectionEntranceLocation + ConnectionEntranceForward * CrosswalkWidth * 0.5f + ConnectionEntranceRight * (RoadWidth * 0.5 + RoadModuleWidth * 0.5) * LateralDirectionScalar;
+
+				const FBox CrosswalkRoadModuleBounds = GetCrosswalkRoadModuleBounds(*CrosswalkRoadModule);
+			
+				if (FMath::PointBoxIntersection(CrosswalkIntersectionCenterLocation, CrosswalkRoadModuleBounds))
+				{
+					return CrosswalkRoadModule;
+				}
+			}
+
+			return nullptr;
+		};
+
+		if (ConnectionIndex == 0)
+		{
+			// Test on left side to find the last crosswalk road module.
+			if (AActor* CrosswalkRoadModule = GetCrosswalkRoadModuleInLateralDirection(-1.0f))
+			{
+				const int32 LastCrosswalkRoadModuleIndex = NumConnections;
+				CrosswalkRoadModuleMap.Add(LastCrosswalkRoadModuleIndex, CrosswalkRoadModule);
+			}
+		}
+
+		// Test on right side
+		if (AActor* CrosswalkRoadModule = GetCrosswalkRoadModuleInLateralDirection(1.0f))
+		{
+			CrosswalkRoadModuleMap.Add(ConnectionIndex, CrosswalkRoadModule);
+		}
+	}
+	
+	if (!ensureMsgf(CrosswalkRoadModuleMap.Num() >= NumConnections, TEXT("CrosswalkRoadModuleMap must have at least NumConnections (%d) entries in UTempoIntersectionQueryComponent::TryGenerateCrosswalkRoadModuleMap.  Currently, it has %d entries.  IntersectionQueryActor: %s."), NumConnections, CrosswalkRoadModuleMap.Num(), *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	OutCrosswalkRoadModuleMap = CrosswalkRoadModuleMap;
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, AActor*& OutCrosswalkRoadModule, float &OutCrosswalkIntersectionConnectorDistance) const
+{
+	// TODO:  Resolve this more transparently via interface functions.
+	const int32 CrosswalkRoadModuleIndex = CrosswalkIntersectionIndex / 2;
+	
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry.")))
+	{
+		return false;
+	}
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry.")))
+	{
+		return false;
+	}
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex == 1 || CrosswalkIntersectionConnectionIndex == 2, TEXT("CrosswalkIntersectionConnectionIndex must be 1 or 2 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry.  Currently, CrosswalkIntersectionConnectionIndex is: %d"), CrosswalkIntersectionConnectionIndex))
+	{
+		return false;
+	}
+	
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkIntersectionConnectorSegmentInfos.Num() == 1, TEXT("CrosswalkIntersectionConnectorSegmentInfos must have exactly 1 element in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry.  Currently, it has %d elements."), CrosswalkIntersectionConnectorInfo->CrosswalkIntersectionConnectorSegmentInfos.Num()))
+	{
+		return false;
+	}
+
+	const float CrosswalkRoadModuleLength = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLength(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule);
+
+	const FCrosswalkIntersectionConnectorSegmentInfo& CrosswalkIntersectionConnectorSegmentInfo = CrosswalkIntersectionConnectorInfo->CrosswalkIntersectionConnectorSegmentInfos[0];
+	
+	TArray<TArray<float>> CrosswalkIntersectionConnectorDistances =
+		{{0.0f, CrosswalkIntersectionConnectorSegmentInfo.CrosswalkIntersectionConnectorStartDistance},
+		{CrosswalkIntersectionConnectorSegmentInfo.CrosswalkIntersectionConnectorEndDistance, CrosswalkRoadModuleLength}};
+
+	const int32 CrosswalkIntersectionDistanceIndex = CrosswalkIntersectionIndex % 2;
+	const int32 CrosswalkIntersectionDistanceSideIndex = CrosswalkIntersectionConnectionIndex == 1 ? 0 : 1;
+	
+	const float CrosswalkIntersectionConnectorDistance = CrosswalkIntersectionConnectorDistances[CrosswalkIntersectionDistanceIndex][CrosswalkIntersectionDistanceSideIndex];
+
+	OutCrosswalkRoadModule = CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule;
+	OutCrosswalkIntersectionConnectorDistance = CrosswalkIntersectionConnectorDistance;
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocation(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceLocation) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumConnections * 2, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections * 2, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+	
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const int32 ConnectionIndex = CrosswalkIntersectionIndex % 2 == 0 ? CrosswalkIntersectionIndex / 2 : (NumConnections - 1 + (CrosswalkIntersectionIndex / 2)) % NumConnections;
+		const int32 CrosswalkControlPointIndex = (CrosswalkIntersectionIndex + 1) % 2;
+		
+		const FVector CrosswalkEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoCrosswalkControlPointLocation(IntersectionQueryActor, ConnectionIndex, CrosswalkControlPointIndex, CoordinateSpace);
+		
+		OutCrosswalkIntersectionEntranceLocation = CrosswalkEntranceLocation;
+	}
+	else
+	{
+		AActor* CrosswalkRoadModuleActor = nullptr;
+		float CrosswalkIntersectionConnectorDistance = 0.0f;
+		
+		if (!TryGetCrosswalkIntersectionConnectorInfoEntry(IntersectionQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, CrosswalkIntersectionConnectorInfoMap, CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance))
+		{
+			ensureMsgf(false, TEXT("Failed to get CrosswalkIntersectionConnectorInfo entry in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  IntersectionQueryActor: %s CrosswalkIntersectionIndex: %d CrosswalkIntersectionConnectionIndex: %d."), *IntersectionQueryActor->GetName(), CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
+			return false;
+		}
+
+		const FVector CrosswalkEntranceLocation = ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
+		
+		OutCrosswalkIntersectionEntranceLocation = CrosswalkEntranceLocation;
+	}
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangent(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceTangent) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumConnections * 2, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections * 2, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const int32 ConnectionIndex = CrosswalkIntersectionIndex % 2 == 0 ? CrosswalkIntersectionIndex / 2 : (NumConnections - 1 + (CrosswalkIntersectionIndex / 2)) % NumConnections;
+		const float LateralDirectionScalar = (CrosswalkIntersectionIndex % 2) == 0 ? 1.0f : -1.0f;
+
+		// The actual Crosswalk's Intersection Entrance tangent is based on the Intersection Connection's right vector.
+		const FVector CrosswalkIntersectionEntranceTangent = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace) * LateralDirectionScalar;
+
+		OutCrosswalkIntersectionEntranceTangent = CrosswalkIntersectionEntranceTangent;
+	}
+	else
+	{
+		AActor* CrosswalkRoadModuleActor = nullptr;
+		float CrosswalkIntersectionConnectorDistance = 0.0f;
+		
+		if (!TryGetCrosswalkIntersectionConnectorInfoEntry(IntersectionQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, CrosswalkIntersectionConnectorInfoMap, CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance))
+		{
+			ensureMsgf(false, TEXT("Failed to get CrosswalkIntersectionConnectorInfo entry in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  IntersectionQueryActor: %s CrosswalkIntersectionIndex: %d CrosswalkIntersectionConnectionIndex: %d."), *IntersectionQueryActor->GetName(), CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
+			return false;
+		}
+		
+		const float LateralDirectionScalar = CrosswalkIntersectionConnectionIndex == 1 ? 1.0f : -1.0f;
+		const FVector CrosswalkIntersectionEntranceTangent = ITempoRoadModuleInterface::Execute_GetTangentAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * LateralDirectionScalar;
+		
+		OutCrosswalkIntersectionEntranceTangent = CrosswalkIntersectionEntranceTangent;
+	}
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceUpVector) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumConnections * 2, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections * 2, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const int32 ConnectionIndex = CrosswalkIntersectionIndex % 2 == 0 ? CrosswalkIntersectionIndex / 2 : (NumConnections - 1 + (CrosswalkIntersectionIndex / 2)) % NumConnections;
+		
+		const FVector CrosswalkIntersectionEntranceUpVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+
+		OutCrosswalkIntersectionEntranceUpVector = CrosswalkIntersectionEntranceUpVector;
+	}
+	else
+	{
+		AActor* CrosswalkRoadModuleActor = nullptr;
+		float CrosswalkIntersectionConnectorDistance = 0.0f;
+		
+		if (!TryGetCrosswalkIntersectionConnectorInfoEntry(IntersectionQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, CrosswalkIntersectionConnectorInfoMap, CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance))
+		{
+			ensureMsgf(false, TEXT("Failed to get CrosswalkIntersectionConnectorInfo entry in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  IntersectionQueryActor: %s CrosswalkIntersectionIndex: %d CrosswalkIntersectionConnectionIndex: %d."), *IntersectionQueryActor->GetName(), CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
+			return false;
+		}
+
+		const FVector CrosswalkIntersectionEntranceUpVector = ITempoRoadModuleInterface::Execute_GetUpVectorAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
+		
+		OutCrosswalkIntersectionEntranceUpVector = CrosswalkIntersectionEntranceUpVector;
+	}
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceRightVector) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.")))
+	{
+		return false;
+	}
+
+	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	
+	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumConnections * 2, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections * 2, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoIntersectionInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const int32 ConnectionIndex = CrosswalkIntersectionIndex % 2 == 0 ? CrosswalkIntersectionIndex / 2 : (NumConnections - 1 + (CrosswalkIntersectionIndex / 2)) % NumConnections;
+		
+		const float LateralDirectionScalar = (CrosswalkIntersectionIndex % 2) == 0 ? 1.0f : -1.0f;
+
+		// The actual Crosswalk's Intersection Entrance right vector is based on the Intersection Connection's forward vector.
+		const FVector CrosswalkIntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace).GetSafeNormal() * LateralDirectionScalar * -1.0f;
+
+		OutCrosswalkIntersectionEntranceRightVector = CrosswalkIntersectionEntranceRightVector;
+	}
+	else
+	{
+		AActor* CrosswalkRoadModuleActor = nullptr;
+		float CrosswalkIntersectionConnectorDistance = 0.0f;
+		
+		if (!TryGetCrosswalkIntersectionConnectorInfoEntry(IntersectionQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, CrosswalkIntersectionConnectorInfoMap, CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance))
+		{
+			ensureMsgf(false, TEXT("Failed to get CrosswalkIntersectionConnectorInfo entry in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  IntersectionQueryActor: %s CrosswalkIntersectionIndex: %d CrosswalkIntersectionConnectionIndex: %d."), *IntersectionQueryActor->GetName(), CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
+			return false;
+		}
+		
+		const float LateralDirectionScalar = CrosswalkIntersectionConnectionIndex == 1 ? 1.0f : -1.0f;
+		const FVector CrosswalkIntersectionEntranceRightVector = ITempoRoadModuleInterface::Execute_GetRightVectorAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * LateralDirectionScalar;
+		
+		OutCrosswalkIntersectionEntranceRightVector = CrosswalkIntersectionEntranceRightVector;
+	}
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointLocation) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation.")))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkControlPointStartIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+	const int32 CrosswalkControlPointEndIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+
+	if (!ensureMsgf(CrosswalkControlPointIndex >= CrosswalkControlPointStartIndex && CrosswalkControlPointIndex <= CrosswalkControlPointEndIndex, TEXT("CrosswalkControlPointIndex must be in range [%d..%d] in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation.  Currently, it is: %d.  IntersectionQueryActor: %s."), CrosswalkControlPointStartIndex, CrosswalkControlPointEndIndex, CrosswalkControlPointIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+	
+	const FVector ControlPointEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+	const FVector ControlPointEntranceTangent = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+
+	const FVector ControlPointEntranceForwardVector = ControlPointEntranceTangent.GetSafeNormal();
+	const FVector ControlPointEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+
+	const AActor* RoadQueryActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(IntersectionQueryActor, ConnectionIndex);
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("Couldn't get valid Connected Road Actor for Actor: %s at ConnectionIndex: %d in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation."), *IntersectionQueryActor->GetName(), ConnectionIndex))
+	{
+		return false;
+	}
+
+	const auto& GetLateralOffset = [&IntersectionQueryActor, &RoadQueryActor, &ControlPointEntranceRightVector, ConnectionIndex, CrosswalkControlPointIndex, CoordinateSpace]()
+	{
+		const int32 NumLanes = ITempoRoadInterface::Execute_GetNumTempoLanes(RoadQueryActor);
+		
+		float TotalLanesWidth = 0.0f;
+		for (int32 LaneIndex = 0; LaneIndex < NumLanes; ++LaneIndex)
+		{
+			const float LaneWidth = ITempoRoadInterface::Execute_GetTempoLaneWidth(RoadQueryActor, LaneIndex);
+			TotalLanesWidth += LaneWidth;
+		}
+
+		const int32 IntersectionEntranceControlPointIndex = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+		const FVector ControlPointRightVector = ITempoRoadInterface::Execute_GetTempoControlPointRightVector(RoadQueryActor, IntersectionEntranceControlPointIndex, CoordinateSpace);
+
+		ETempoRoadLateralDirection LateralQueryDirection = CrosswalkControlPointIndex == 0 ? ETempoRoadLateralDirection::Left : ETempoRoadLateralDirection::Right;
+		
+		const float DotProduct = FVector::DotProduct(ControlPointEntranceRightVector, ControlPointRightVector);
+		
+		if (DotProduct < 0.0f)
+		{
+			LateralQueryDirection = CrosswalkControlPointIndex == 0 ? ETempoRoadLateralDirection::Right : ETempoRoadLateralDirection::Left;
+		}
+		
+		const float ShoulderWidth = ITempoRoadInterface::Execute_GetTempoRoadShoulderWidth(RoadQueryActor, LateralQueryDirection);
+		
+		const float LateralOffset = TotalLanesWidth * 0.5f + ShoulderWidth;
+
+		return LateralOffset;
+	};
+	
+	const float LateralOffset = GetLateralOffset();
+	const float LateralDirectionScalar = CrosswalkControlPointIndex == 0 ? -1.0f : 1.0f;
+	
+	const float CrosswalkWidth = ITempoIntersectionInterface::Execute_GetTempoCrosswalkWidth(IntersectionQueryActor);
+	
+	const FVector CrosswalkEntranceLocation = ControlPointEntranceLocation + ControlPointEntranceForwardVector * CrosswalkWidth * 0.5f + ControlPointEntranceRightVector * LateralOffset * LateralDirectionScalar;
+
+	DrawDebugSphere(IntersectionQueryActor->GetWorld(), CrosswalkEntranceLocation, 25.0f, 16, FColor::Orange, false, 10.0f);
+
+	OutCrosswalkControlPointLocation = CrosswalkEntranceLocation;
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointTangent(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointTangent) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointTangent.")))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkControlPointStartIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+	const int32 CrosswalkControlPointEndIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+
+	if (!ensureMsgf(CrosswalkControlPointIndex >= CrosswalkControlPointStartIndex && CrosswalkControlPointIndex <= CrosswalkControlPointEndIndex, TEXT("CrosswalkControlPointIndex must be in range [%d..%d] in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointTangent.  Currently, it is: %d.  IntersectionQueryActor: %s."), CrosswalkControlPointStartIndex, CrosswalkControlPointEndIndex, CrosswalkControlPointIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+	
+	const FVector ControlPointEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+
+	// Crosswalk tangent points to the Intersection Entrance's right.
+	OutCrosswalkControlPointTangent = ControlPointEntranceRightVector;
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointUpVector(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointUpVector) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointUpVector.")))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkControlPointStartIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+	const int32 CrosswalkControlPointEndIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+
+	if (!ensureMsgf(CrosswalkControlPointIndex >= CrosswalkControlPointStartIndex && CrosswalkControlPointIndex <= CrosswalkControlPointEndIndex, TEXT("CrosswalkControlPointIndex must be in range [%d..%d] in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointUpVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), CrosswalkControlPointStartIndex, CrosswalkControlPointEndIndex, CrosswalkControlPointIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+	
+	const FVector ControlPointEntranceUpVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+	
+	OutCrosswalkControlPointUpVector = ControlPointEntranceUpVector;
+
+	return true;
+}
+
+bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointRightVector(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointRightVector) const
+{
+	if (!ensureMsgf(IntersectionQueryActor != nullptr, TEXT("IntersectionQueryActor must be valid in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointRightVector.")))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkControlPointStartIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+	const int32 CrosswalkControlPointEndIndex = ITempoIntersectionInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+
+	if (!ensureMsgf(CrosswalkControlPointIndex >= CrosswalkControlPointStartIndex && CrosswalkControlPointIndex <= CrosswalkControlPointEndIndex, TEXT("CrosswalkControlPointIndex must be in range [%d..%d] in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointRightVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), CrosswalkControlPointStartIndex, CrosswalkControlPointEndIndex, CrosswalkControlPointIndex, *IntersectionQueryActor->GetName()))
+	{
+		return false;
+	}
+	
+	const FVector ControlPointEntranceForwardVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace).GetSafeNormal();
+
+	// Crosswalk right vector points opposite the Intersection Entrance's forward vector.
+	OutCrosswalkControlPointRightVector = -ControlPointEntranceForwardVector;
+
+	return true;
+}
 
 bool UTempoIntersectionQueryComponent::IsConnectedRoadActor(const AActor* RoadQueryActor) const
 {
@@ -375,11 +912,16 @@ FZoneGraphTagFilter UTempoIntersectionQueryComponent::GetLaneConnectionTagFilter
 	const TArray<FName>& LaneConnectionAllTagNames = ITempoRoadInterface::Execute_GetTempoLaneConnectionAllTags(SourceConnectionActor, SourceLaneConnectionInfo.LaneIndex);
 	const TArray<FName>& LaneConnectionNotTagNames = ITempoRoadInterface::Execute_GetTempoLaneConnectionNotTags(SourceConnectionActor, SourceLaneConnectionInfo.LaneIndex);
 
-	const FZoneGraphTagMask LaneConnectionAnyTags = GenerateTagMaskFromTagNames(LaneConnectionAnyTagNames);
-	const FZoneGraphTagMask LaneConnectionAllTags = GenerateTagMaskFromTagNames(LaneConnectionAllTagNames);
-	const FZoneGraphTagMask LaneConnectionNotTags = GenerateTagMaskFromTagNames(LaneConnectionNotTagNames);
+	return GenerateTagFilter(LaneConnectionAnyTagNames, LaneConnectionAllTagNames, LaneConnectionNotTagNames);
+}
 
-	return FZoneGraphTagFilter{LaneConnectionAnyTags, LaneConnectionAllTags, LaneConnectionNotTags};
+FZoneGraphTagFilter UTempoIntersectionQueryComponent::GenerateTagFilter(const TArray<FName>& AnyTags, const TArray<FName>& AllTags, const TArray<FName>& NotTags) const
+{
+	const FZoneGraphTagMask AnyTagsMask = GenerateTagMaskFromTagNames(AnyTags);
+	const FZoneGraphTagMask AllTagsMask = GenerateTagMaskFromTagNames(AllTags);
+	const FZoneGraphTagMask NotTagsMask = GenerateTagMaskFromTagNames(NotTags);
+
+	return FZoneGraphTagFilter{AnyTagsMask, AllTagsMask, NotTagsMask};
 }
 
 FZoneGraphTagMask UTempoIntersectionQueryComponent::GenerateTagMaskFromTagNames(const TArray<FName>& TagNames) const

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoZoneGraphStandTask.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoZoneGraphStandTask.cpp
@@ -1,0 +1,62 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#include "TempoZoneGraphStandTask.h"
+
+#include "Tasks/MassZoneGraphStandTask.h"
+#include "StateTreeExecutionContext.h"
+#include "MassZoneGraphNavigationFragments.h"
+#include "MassZoneGraphNavigationUtils.h"
+#include "MassAIBehaviorTypes.h"
+#include "MassNavigationFragments.h"
+#include "MassMovementFragments.h"
+#include "MassStateTreeExecutionContext.h"
+#include "MassSignalSubsystem.h"
+#include "MassSimulationLOD.h"
+
+EStateTreeRunStatus FTempoZoneGraphStandTask::EnterState(FStateTreeExecutionContext& Context, const FStateTreeTransitionResult& Transition) const
+{
+	const FMassStateTreeExecutionContext& MassContext = static_cast<FMassStateTreeExecutionContext&>(Context);
+
+	const FMassZoneGraphLaneLocationFragment& LaneLocation = Context.GetExternalData(LocationHandle);
+	const UZoneGraphSubsystem& ZoneGraphSubsystem = Context.GetExternalData(ZoneGraphSubsystemHandle);
+	const FMassMovementParameters& MovementParams = Context.GetExternalData(MovementParamsHandle);
+
+	FInstanceDataType& InstanceData = Context.GetInstanceData(*this);
+
+	if (!LaneLocation.LaneHandle.IsValid())
+	{
+		MASSBEHAVIOR_LOG(Error, TEXT("Invalid lande handle"));
+		return EStateTreeRunStatus::Failed;
+	}
+
+	FMassZoneGraphShortPathFragment& ShortPath = Context.GetExternalData(ShortPathHandle);
+	FMassZoneGraphCachedLaneFragment& CachedLane = Context.GetExternalData(CachedLaneHandle);
+	FMassMoveTargetFragment& MoveTarget = Context.GetExternalData(MoveTargetHandle);
+
+	// TODO: This could be smarter too, like having a stand location/direction, or even make a small path to stop, if we're currently running.
+
+	const UWorld* World = Context.GetWorld();
+	checkf(World != nullptr, TEXT("A valid world is expected from the execution context"));
+
+	MoveTarget.CreateNewAction(EMassMovementAction::Stand, *World);
+
+	// TEMPO_NOTE:  The whole point of this override is just to set the DesiredSpeed argument to 0.0f, here.
+	// Otherwise, we'd need to start patching MassAIBehavior.
+	const bool bSuccess = UE::MassNavigation::ActivateActionStand(*World, Context.GetOwner(), MassContext.GetEntity(), ZoneGraphSubsystem, LaneLocation, 0.0f, MoveTarget, ShortPath, CachedLane);
+	if (!bSuccess)
+	{
+		return EStateTreeRunStatus::Failed;
+	}
+
+	InstanceData.Time = 0.0f;
+
+	// A Duration <= 0 indicates that the task runs until a transition in the state tree stops it.
+	// Otherwise we schedule a signal to end the task.
+	if (InstanceData.Duration > 0.0f)
+	{
+		UMassSignalSubsystem& MassSignalSubsystem = Context.GetExternalData(MassSignalSubsystemHandle);
+		MassSignalSubsystem.DelaySignalEntity(UE::Mass::Signals::StandTaskFinished, MassContext.GetEntity(), InstanceData.Duration);
+	}
+
+	return EStateTreeRunStatus::Running;
+}

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoAgentsSharedTypes.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoAgentsSharedTypes.h
@@ -19,4 +19,11 @@ enum class ETempoRoadOffsetOrigin : uint8
 	RightRoadEdge = 2,
 };
 
+UENUM(BlueprintType)
+enum class ETempoRoadLateralDirection : uint8
+{
+	Left = 0,
+	Right = 1,
+};
+
 

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoAgentsWorldSubsystem.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoAgentsWorldSubsystem.h
@@ -18,6 +18,9 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Tempo Agents|World Subsystem|Brightness Meter")
 	void SetupBrightnessMeter();
 
+	UFUNCTION(BlueprintCallable, Category = "Tempo Agents|World Subsystem|Traffic Controllers")
+	void SetupIntersectionLaneMap();
+
 	virtual void OnWorldBeginPlay(UWorld& InWorld) override;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Tempo Agents|World Subsystem|Brightness Meter")

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
@@ -215,46 +215,37 @@ public:
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	bool ShouldGenerateZoneShapesForTempoCrosswalk(int32 ConnectionIndex) const;
-
-	// TODO:  Need to distinguish between functions which take a CrosswalkRoadModuleIndex and a CrosswalkIntersectionIndex.
+	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	int32 GetNumConnectedTempoCrosswalkRoadModules() const;
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
-	AActor* GetConnectedTempoCrosswalkRoadModuleActor(int32 ConnectedRoadModuleIndex) const;
-
-	// TODO:  This should take a CrosswalkIntersectionIndex.
+	AActor* GetConnectedTempoCrosswalkRoadModuleActor(int32 CrosswalkRoadModuleIndex) const;
+	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
-	float GetTempoCrosswalkWidth() const;
+	float GetTempoCrosswalkWidth(int32 ConnectionIndex) const;
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	TArray<FName> GetTempoCrosswalkTags(int32 ConnectionIndex) const;
-
-	// TODO:  This should take a CrosswalkIntersectionIndex.
+	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
-	int32 GetNumTempoCrosswalkLanes() const;
-
-	// TODO:  This should take a CrosswalkIntersectionIndex.
+	int32 GetNumTempoCrosswalkLanes(int32 ConnectionIndex) const;
+	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	int32 GetTempoCrosswalkStartEntranceLocationControlPointIndex(int32 ConnectionIndex) const;
-
-	// TODO:  This should take a CrosswalkIntersectionIndex.
+	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	int32 GetTempoCrosswalkEndEntranceLocationControlPointIndex(int32 ConnectionIndex) const;
-
-	// TODO:  This should take a CrosswalkIntersectionIndex.
+	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	FName GetLaneProfileOverrideNameForTempoCrosswalk(int32 ConnectionIndex) const;
-
-	// TODO:  This should take a CrosswalkIntersectionIndex.
+	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	float GetTempoCrosswalkLaneWidth(int32 ConnectionIndex, int32 LaneIndex) const;
-
-	// TODO:  This should take a CrosswalkIntersectionIndex.
+	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	EZoneLaneDirection GetTempoCrosswalkLaneDirection(int32 ConnectionIndex, int32 LaneIndex) const;
-
-	// TODO:  This should take a CrosswalkIntersectionIndex.
+	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	TArray<FName> GetTempoCrosswalkLaneTags(int32 ConnectionIndex, int32 LaneIndex) const;
 
@@ -282,6 +273,21 @@ public:
 	int32 GetNumTempoCrosswalkIntersectionConnections(int32 CrosswalkIntersectionIndex) const;
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetNumTempoCrosswalkIntersectionEntranceLanes(int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FName GetTempoCrosswalkIntersectionEntranceLaneProfileOverrideName(int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	float GetTempoCrosswalkIntersectionEntranceLaneWidth(int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex) const;
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	EZoneLaneDirection GetTempoCrosswalkIntersectionEntranceLaneDirection(int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex) const;
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	TArray<FName> GetTempoCrosswalkIntersectionEntranceLaneTags(int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	FVector GetTempoCrosswalkIntersectionEntranceLocation(int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace) const;
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
@@ -296,7 +302,30 @@ public:
 	// Crosswalk Intersection Connector Queries
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
-	FCrosswalkIntersectionConnectorInfo GetTempoCrosswalkIntersectionConnectorInfo(int32 CrosswalkIntersectionIndex) const;
+	FCrosswalkIntersectionConnectorInfo GetTempoCrosswalkIntersectionConnectorInfo(int32 CrosswalkRoadModuleIndex) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetNumTempoCrosswalkIntersectionConnectorLanes(int32 CrosswalkRoadModuleIndex) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FName GetTempoCrosswalkIntersectionConnectorLaneProfileOverrideName(int32 CrosswalkRoadModuleIndex) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	float GetTempoCrosswalkIntersectionConnectorLaneWidth(int32 CrosswalkRoadModuleIndex, int32 LaneIndex) const;
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	EZoneLaneDirection GetTempoCrosswalkIntersectionConnectorLaneDirection(int32 CrosswalkRoadModuleIndex, int32 LaneIndex) const;
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	TArray<FName> GetTempoCrosswalkIntersectionConnectorLaneTags(int32 CrosswalkRoadModuleIndex, int32 LaneIndex) const;
+
+	// Crosswalk Indexing Conversion Queries
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetTempoCrosswalkIntersectionIndexFromCrosswalkRoadModuleIndex(int32 CrosswalkRoadModuleIndex) const;
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(int32 CrosswalkIntersectionIndex) const;
 
 	// Lane Filtering Queries
 
@@ -321,4 +350,7 @@ public:
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Commands")
 	void SetupTempoTrafficControllers();
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Commands")
+	void SetupTempoIntersectionData();
 };

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
@@ -227,6 +227,9 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	float GetTempoCrosswalkWidth() const;
 
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	TArray<FName> GetTempoCrosswalkTags(int32 ConnectionIndex) const;
+
 	// TODO:  This should take a CrosswalkIntersectionIndex.
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	int32 GetNumTempoCrosswalkLanes() const;

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
@@ -121,6 +121,47 @@ struct FTempoLaneConnectionInfo
 	int32 LaneIndex = -1;
 };
 
+USTRUCT(BlueprintType)
+struct FCrosswalkIntersectionConnectorSegmentInfo
+{
+	GENERATED_BODY()
+	
+	FCrosswalkIntersectionConnectorSegmentInfo() = default;
+
+	FCrosswalkIntersectionConnectorSegmentInfo(
+		float InCrosswalkIntersectionConnectorStartDistance,
+		float InCrosswalkIntersectionConnectorEndDistance)
+			: CrosswalkIntersectionConnectorStartDistance(InCrosswalkIntersectionConnectorStartDistance)
+			, CrosswalkIntersectionConnectorEndDistance(InCrosswalkIntersectionConnectorEndDistance)
+	{
+	}
+	
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tempo Agents|Road Lane Graph|Lane Connection Info")
+	float CrosswalkIntersectionConnectorStartDistance = 0.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tempo Agents|Road Lane Graph|Lane Connection Info")
+	float CrosswalkIntersectionConnectorEndDistance = 0.0f;
+};
+
+USTRUCT(BlueprintType)
+struct FCrosswalkIntersectionConnectorInfo
+{
+	GENERATED_BODY()
+	
+	FCrosswalkIntersectionConnectorInfo() = default;
+
+	FCrosswalkIntersectionConnectorInfo(AActor* InCrosswalkRoadModule)
+		: CrosswalkRoadModule(InCrosswalkRoadModule)
+	{
+	}
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tempo Agents|Road Lane Graph|Lane Connection Info")
+	AActor* CrosswalkRoadModule = nullptr;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tempo Agents|Road Lane Graph|Lane Connection Info")
+	TArray<FCrosswalkIntersectionConnectorSegmentInfo> CrosswalkIntersectionConnectorSegmentInfos;
+};
+
 UINTERFACE(Blueprintable)
 class TEMPOAGENTSSHARED_API UTempoIntersectionInterface : public UInterface
 {
@@ -161,6 +202,98 @@ public:
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
 	TArray<FTempoRoadConfigurationInfo> GetTempoRoadConfigurationInfo(int32 SourceConnectionIndex, ETempoRoadConfigurationDescriptor RoadConfigurationDescriptor) const;
+
+	// Connected Road Module Queries
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetNumConnectedTempoRoadModules() const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	AActor* GetConnectedTempoRoadModuleActor(int32 ConnectedRoadModuleIndex) const;
+
+	// Crosswalk Queries
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	bool ShouldGenerateZoneShapesForTempoCrosswalk(int32 ConnectionIndex) const;
+
+	// TODO:  Need to distinguish between functions which take a CrosswalkRoadModuleIndex and a CrosswalkIntersectionIndex.
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetNumConnectedTempoCrosswalkRoadModules() const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	AActor* GetConnectedTempoCrosswalkRoadModuleActor(int32 ConnectedRoadModuleIndex) const;
+
+	// TODO:  This should take a CrosswalkIntersectionIndex.
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	float GetTempoCrosswalkWidth() const;
+
+	// TODO:  This should take a CrosswalkIntersectionIndex.
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetNumTempoCrosswalkLanes() const;
+
+	// TODO:  This should take a CrosswalkIntersectionIndex.
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetTempoCrosswalkStartEntranceLocationControlPointIndex(int32 ConnectionIndex) const;
+
+	// TODO:  This should take a CrosswalkIntersectionIndex.
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetTempoCrosswalkEndEntranceLocationControlPointIndex(int32 ConnectionIndex) const;
+
+	// TODO:  This should take a CrosswalkIntersectionIndex.
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FName GetLaneProfileOverrideNameForTempoCrosswalk(int32 ConnectionIndex) const;
+
+	// TODO:  This should take a CrosswalkIntersectionIndex.
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	float GetTempoCrosswalkLaneWidth(int32 ConnectionIndex, int32 LaneIndex) const;
+
+	// TODO:  This should take a CrosswalkIntersectionIndex.
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	EZoneLaneDirection GetTempoCrosswalkLaneDirection(int32 ConnectionIndex, int32 LaneIndex) const;
+
+	// TODO:  This should take a CrosswalkIntersectionIndex.
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	TArray<FName> GetTempoCrosswalkLaneTags(int32 ConnectionIndex, int32 LaneIndex) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FVector GetTempoCrosswalkControlPointLocation(int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FVector GetTempoCrosswalkControlPointTangent(int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace) const;
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FVector GetTempoCrosswalkControlPointUpVector(int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FVector GetTempoCrosswalkControlPointRightVector(int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace) const;
+	
+	// Crosswalk Intersection Queries
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetNumTempoCrosswalkIntersections() const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	TArray<FName> GetTempoCrosswalkIntersectionTags(int32 CrosswalkIntersectionIndex) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	int32 GetNumTempoCrosswalkIntersectionConnections(int32 CrosswalkIntersectionIndex) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FVector GetTempoCrosswalkIntersectionEntranceLocation(int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FVector GetTempoCrosswalkIntersectionEntranceTangent(int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace) const;
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FVector GetTempoCrosswalkIntersectionEntranceUpVector(int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FVector GetTempoCrosswalkIntersectionEntranceRightVector(int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace) const;
+
+	// Crosswalk Intersection Connector Queries
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
+	FCrosswalkIntersectionConnectorInfo GetTempoCrosswalkIntersectionConnectorInfo(int32 CrosswalkIntersectionIndex) const;
 
 	// Lane Filtering Queries
 

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
@@ -37,44 +37,73 @@ public:
 									const AActor* DestConnectionActor, const TArray<FTempoLaneConnectionInfo>& DestLaneConnectionInfos, const int32 DestLaneConnectionQueryIndex) const;
 
 	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
-	virtual bool TryGetCrosswalkIntersectionConnectorInfo(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, FCrosswalkIntersectionConnectorInfo& OutCrosswalkIntersectionConnectorInfo) const;
+	virtual bool TryGetCrosswalkIntersectionConnectorInfo(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, FCrosswalkIntersectionConnectorInfo& OutCrosswalkIntersectionConnectorInfo) const;
 	
 	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
 	virtual bool TryGenerateCrosswalkRoadModuleMap(const AActor* IntersectionQueryActor, const TArray<FName>& CrosswalkRoadModuleAnyTags, const TArray<FName>& CrosswalkRoadModuleAllTags, const TArray<FName>& CrosswalkRoadModuleNotTags, TMap<int32, AActor*>& OutCrosswalkRoadModuleMap) const;
 
 	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
 	virtual bool TryGetCrosswalkIntersectionConnectorInfoEntry(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, AActor*& OutCrosswalkRoadModule, float &OutCrosswalkIntersectionConnectorDistance) const;
-
-	// TODO:  Consider removing CrosswalkIntersectionConnectorInfoMap input to these functions, and just get it through an interface call, under the circumstances that its needed.
-	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
-	bool TryGetCrosswalkIntersectionEntranceLocation(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceLocation) const;
-
-	// TODO:  Consider removing CrosswalkIntersectionConnectorInfoMap input to these functions, and just get it through an interface call, under the circumstances that its needed.
-	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
-	bool TryGetCrosswalkIntersectionEntranceTangent(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceTangent) const;
-
-	// TODO:  Consider removing CrosswalkIntersectionConnectorInfoMap input to these functions, and just get it through an interface call, under the circumstances that its needed.
-	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
-	bool TryGetCrosswalkIntersectionEntranceUpVector(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceUpVector) const;
-
-	// TODO:  Consider removing CrosswalkIntersectionConnectorInfoMap input to these functions, and just get it through an interface call, under the circumstances that its needed.
-	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
-	bool TryGetCrosswalkIntersectionEntranceRightVector(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceRightVector) const;
-
-	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
-	bool TryGetCrosswalkControlPointLocation(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointLocation) const;
 	
 	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
-	bool TryGetCrosswalkControlPointTangent(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointTangent) const;
+	virtual bool TryGetCrosswalkIntersectionEntranceLocation(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceLocation) const;
 	
 	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
-	bool TryGetCrosswalkControlPointUpVector(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointUpVector) const;
+	virtual bool TryGetCrosswalkIntersectionEntranceTangent(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceTangent) const;
 	
 	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
-	bool TryGetCrosswalkControlPointRightVector(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointRightVector) const;
+	virtual bool TryGetCrosswalkIntersectionEntranceUpVector(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceUpVector) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkIntersectionEntranceRightVector(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceRightVector) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetNumCrosswalkIntersectionEntranceLanes(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, int32& OutNumCrosswalkIntersectionEntranceLanes) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FName& OutCrosswalkIntersectionEntranceLaneProfileOverrideName) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkIntersectionEntranceLaneWidth(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, float& OutCrosswalkIntersectionEntranceLaneWidth) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkIntersectionEntranceLaneDirection(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, EZoneLaneDirection& OutCrosswalkIntersectionEntranceLaneDirection) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkIntersectionEntranceLaneTags(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, TArray<FName>& OutCrosswalkIntersectionEntranceLaneTags) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetNumCrosswalkIntersectionConnectorLanes(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, int32& OutNumCrosswalkIntersectionConnectorLanes) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FName& OutCrosswalkIntersectionConnectorLaneProfileOverrideName) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkIntersectionConnectorLaneWidth(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, float& OutCrosswalkIntersectionConnectorLaneWidth) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkIntersectionConnectorLaneDirection(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, EZoneLaneDirection& OutCrosswalkIntersectionConnectorLaneDirection) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkIntersectionConnectorLaneTags(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, TArray<FName>& OutCrosswalkIntersectionConnectorLaneTags) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkControlPointLocation(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointLocation) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkControlPointTangent(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointTangent) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkControlPointUpVector(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointUpVector) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkControlPointRightVector(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointRightVector) const;
 
 	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
 	virtual bool IsConnectedRoadActor(const AActor* RoadQueryActor) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual int32 GetConnectionIndexFromCrosswalkIntersectionIndex(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex) const;
 	
 protected:
 	

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
@@ -37,6 +37,43 @@ public:
 									const AActor* DestConnectionActor, const TArray<FTempoLaneConnectionInfo>& DestLaneConnectionInfos, const int32 DestLaneConnectionQueryIndex) const;
 
 	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkIntersectionConnectorInfo(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, FCrosswalkIntersectionConnectorInfo& OutCrosswalkIntersectionConnectorInfo) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGenerateCrosswalkRoadModuleMap(const AActor* IntersectionQueryActor, const TArray<FName>& CrosswalkRoadModuleAnyTags, const TArray<FName>& CrosswalkRoadModuleAllTags, const TArray<FName>& CrosswalkRoadModuleNotTags, TMap<int32, AActor*>& OutCrosswalkRoadModuleMap) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	virtual bool TryGetCrosswalkIntersectionConnectorInfoEntry(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, AActor*& OutCrosswalkRoadModule, float &OutCrosswalkIntersectionConnectorDistance) const;
+
+	// TODO:  Consider removing CrosswalkIntersectionConnectorInfoMap input to these functions, and just get it through an interface call, under the circumstances that its needed.
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	bool TryGetCrosswalkIntersectionEntranceLocation(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceLocation) const;
+
+	// TODO:  Consider removing CrosswalkIntersectionConnectorInfoMap input to these functions, and just get it through an interface call, under the circumstances that its needed.
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	bool TryGetCrosswalkIntersectionEntranceTangent(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceTangent) const;
+
+	// TODO:  Consider removing CrosswalkIntersectionConnectorInfoMap input to these functions, and just get it through an interface call, under the circumstances that its needed.
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	bool TryGetCrosswalkIntersectionEntranceUpVector(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceUpVector) const;
+
+	// TODO:  Consider removing CrosswalkIntersectionConnectorInfoMap input to these functions, and just get it through an interface call, under the circumstances that its needed.
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	bool TryGetCrosswalkIntersectionEntranceRightVector(const AActor* IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceRightVector) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	bool TryGetCrosswalkControlPointLocation(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointLocation) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	bool TryGetCrosswalkControlPointTangent(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointTangent) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	bool TryGetCrosswalkControlPointUpVector(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointUpVector) const;
+	
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
+	bool TryGetCrosswalkControlPointRightVector(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32 CrosswalkControlPointIndex, ETempoCoordinateSpace CoordinateSpace, FVector& OutCrosswalkControlPointRightVector) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
 	virtual bool IsConnectedRoadActor(const AActor* RoadQueryActor) const;
 	
 protected:
@@ -48,6 +85,7 @@ protected:
 										  TempoZoneGraphTagFilterMap& OutZoneGraphTagFilterMap) const;
 
 	virtual FZoneGraphTagFilter GetLaneConnectionTagFilter(const AActor* SourceConnectionActor, const FTempoLaneConnectionInfo& SourceLaneConnectionInfo) const;
+	virtual FZoneGraphTagFilter GenerateTagFilter(const TArray<FName>& AnyTags, const TArray<FName>& AllTags, const TArray<FName>& NotTags) const;
 	virtual FZoneGraphTagMask GenerateTagMaskFromTagNames(const TArray<FName>& TagNames) const;
 	
 	virtual bool TryGetMinLaneIndexInLaneConnections(const TArray<FTempoLaneConnectionInfo>& LaneConnectionInfos, int32& OutMinLaneIndex) const;

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadInterface.h
@@ -29,6 +29,9 @@ public:
 	float GetTempoRoadWidth() const;
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
+	float GetTempoRoadShoulderWidth(ETempoRoadLateralDirection LateralSide) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
 	bool IsTempoLaneClosedLoop() const;
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
@@ -76,6 +79,29 @@ public:
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
 	FRotator GetTempoControlPointRotation(int32 ControlPointIndex, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
+	float GetDistanceAlongTempoRoadAtControlPoint(int32 ControlPointIndex) const;
+
+	// Road Distance Queries
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
+	float GetDistanceAlongTempoRoadClosestToWorldLocation(FVector QueryLocation) const;
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
+	FVector GetLocationAtDistanceAlongTempoRoad(float DistanceAlongRoad, ETempoCoordinateSpace CoordinateSpace) const;
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
+	FVector GetTangentAtDistanceAlongTempoRoad(float DistanceAlongRoad, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
+	FVector GetUpVectorAtDistanceAlongTempoRoad(float DistanceAlongRoad, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
+	FVector GetRightVectorAtDistanceAlongTempoRoad(float DistanceAlongRoad, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
+	FRotator GetRotationAtDistanceAlongTempoRoad(float DistanceAlongRoad, ETempoCoordinateSpace CoordinateSpace) const;
 
 	// Road Intersection Entrance Queries
 

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadModuleInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadModuleInterface.h
@@ -29,10 +29,16 @@ public:
 	float GetTempoRoadModuleWidth() const;
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
+	float GetTempoRoadModuleLength() const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
 	bool IsTempoRoadModuleClosedLoop() const;
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
 	FName GetTempoRoadModuleLaneProfileOverrideName() const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
+	AActor* GetTempoRoadModuleParentActor() const;
 
 	// Road Module Lane Queries
 
@@ -67,4 +73,27 @@ public:
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
 	FRotator GetTempoRoadModuleControlPointRotation(int32 ControlPointIndex, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
+	float GetDistanceAlongTempoRoadModuleAtControlPoint(int32 ControlPointIndex) const;
+
+	// Road Module Distance Queries
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
+	float GetDistanceAlongTempoRoadModuleClosestToWorldLocation(FVector QueryLocation) const;
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
+	FVector GetLocationAtDistanceAlongTempoRoadModule(float DistanceAlongRoadModule, ETempoCoordinateSpace CoordinateSpace) const;
+	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
+	FVector GetTangentAtDistanceAlongTempoRoadModule(float DistanceAlongRoadModule, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
+	FVector GetUpVectorAtDistanceAlongTempoRoadModule(float DistanceAlongRoadModule, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
+	FVector GetRightVectorAtDistanceAlongTempoRoadModule(float DistanceAlongRoadModule, ETempoCoordinateSpace CoordinateSpace) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
+	FRotator GetRotationAtDistanceAlongTempoRoadModule(float DistanceAlongRoadModule, ETempoCoordinateSpace CoordinateSpace) const;
 };

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoZoneGraphStandTask.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoZoneGraphStandTask.h
@@ -1,0 +1,17 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "Tasks/MassZoneGraphStandTask.h"
+#include "TempoZoneGraphStandTask.generated.h"
+
+
+USTRUCT(meta = (DisplayName = "Tempo ZG Stand"))
+struct TEMPOAGENTSSHARED_API FTempoZoneGraphStandTask : public FMassZoneGraphStandTask
+{
+	GENERATED_BODY()
+
+protected:
+	
+	virtual EStateTreeRunStatus EnterState(FStateTreeExecutionContext& Context, const FStateTreeTransitionResult& Transition) const override;
+};

--- a/TempoAgents/Source/TempoAgentsShared/TempoAgentsShared.Build.cs
+++ b/TempoAgents/Source/TempoAgentsShared/TempoAgentsShared.Build.cs
@@ -35,6 +35,13 @@ public class TempoAgentsShared : ModuleRules
                 "MassCommon",
                 "StructUtils",
                 "RHI",
+                // For overriden "stand" state
+                "MassMovement",
+                "MassNavigation",
+                "MassZoneGraphNavigation",
+                "MassAIBehavior",
+                "StateTreeModule",
+                "MassSignals",
                 // Tempo
                 "TempoCore",
             }


### PR DESCRIPTION
- Enable building procedural crosswalks, crosswalk intersections, and crosswalk connectors (ie. the "ZoneShape" between two crosswalk intersections).

- Add "vehicle to pedestrian" and "pedestrian to vehicle" reactive yield behaviors.

- Tweak the intersection periods for 4-way and T-intersections with traffic lights and stop signs to allow crosswalk lanes to be open while vehicle lanes are open, in order to increase the overall throughput at intersections.  The yield logic handles the negotiation between vehicles and pedestrians as they traverse the intersections.

- Added mechanism to enforce mandatory stops at stop signs even when the intersection "period" logic has lanes currently open at stop signs.  You can set `LowerMinStopSignRestTime` and `UpperMinStopSignRestTime` in MassTrafficSettings.h to set the range of acceptable time to wait at a stop sign before proceeding.

- Enable partial cross-traffic at 4-way and T stop sign intersections.  "Partial" just means that during intersection "periods" that allow left turns, no cross-traffic is allowed.  But, in all other intersection "periods" cross-traffic *is* allowed.

- Enable crosswalk signaling on traffic lights for all updated intersection "period" logic.