### PR TITLE
Prevent FPCGSelectionKey Duplicate Symbol in Packaged Binary

### DIFF
--- a/TempoWorld/Source/TempoDebris/Private/PCGAssignRandomMeshAttribute.cpp
+++ b/TempoWorld/Source/TempoDebris/Private/PCGAssignRandomMeshAttribute.cpp
@@ -21,6 +21,9 @@
 
 #define LOCTEXT_NAMESPACE "PCGAssignRandomMeshAttributeElement"
 
+#if WITH_EDITOR
+// This is defined in PCGActorSelector.h but not exported or inlined. Re-define it here in the editor build,
+// where we're building separate dylibs, but not in the packaged binary, where we're building a single executable.
 uint32 GetTypeHash(const FPCGSelectionKey& In)
 {
 	uint32 HashResult = HashCombine(GetTypeHash(In.ActorFilter), GetTypeHash(In.Selection));
@@ -31,6 +34,7 @@ uint32 GetTypeHash(const FPCGSelectionKey& In)
 
 	return HashResult;
 }
+#endif
 
 #if WITH_EDITOR
 void UPCGAssignRandomMeshAttributeSettings::GetStaticTrackedKeys(FPCGSelectionKeyToSettingsMap& OutKeysToSettings, TArray<TObjectPtr<const UPCGGraph>>& OutVisitedGraphs) const


### PR DESCRIPTION
A `GetTypeHash` for `FPCGSelectionKey` is declared in `PCGActorSelector.h` but not exported or inlined. I'm using it in `PCGAssignRandomMeshAttribute` by re-defining it in that cpp file. But that breaks packaging because it leads to a duplicate symbol linker error. The best solution I can think of is to only re-define it when `#if WITH_EDITOR`.