### PR TITLE
Add Setting to Limit Time Step in Wall Clock Time Mode

### DIFF
--- a/TempoCore/README.md
+++ b/TempoCore/README.md
@@ -5,7 +5,7 @@ TempoCore includes the `TempoTime` and `TempoScripting` modules, as well as util
 Tempo supports two time modes: `Wall Clock` and `Fixed Step`.
 
 ### Wall Clock Mode
-In `Wall Clock` mode, time advances _strictly_ alongside the system clock. We actually override Unreal's engine time to do this, as it does not provide this guarrantee.
+In `Wall Clock` mode, time advances _strictly_ alongside the system clock. We actually override Unreal's engine time to do this, as it does not provide this guarantee. This can lead to large time steps when slow tasks run on the game thread. If you'd like sim time to follow the system clock _except_ when doing so would cause a large time step, you can set the `MaxWallClockTimeStep` setting to non-zero.
 
 ### Fixed Step Mode
 In `Fixed Step` mode, time advances by a fixed amount, which you can choose, every frame. We express this increment in terms of a whole number of simulated steps per second (like, 10 steps per second), as opposed to a floating point fraction of a second (like, 0.1 seconds per step), because we use a fixed-point representation for time (again, overriding the engine's time) because we want it to be exactly correct (no rounding or floating point errors here).

--- a/TempoCore/Source/TempoCoreShared/Public/TempoCoreSettings.h
+++ b/TempoCore/Source/TempoCoreShared/Public/TempoCoreSettings.h
@@ -24,6 +24,7 @@ public:
 	void SetTimeMode(ETimeMode TimeModeIn);
 	void SetSimulatedStepsPerSecond(int32 SimulatedStepsPerSecondIn);
 	ETimeMode GetTimeMode() const { return TimeMode; }
+	double GetMaxWallClockTimeStep() const { return MaxWallClockTimeStep; }
 	int32 GetSimulatedStepsPerSecond() const { return SimulatedStepsPerSecond; }
 	FTempoCoreTimeSettingsChanged TempoCoreTimeSettingsChangedEvent;
 
@@ -49,6 +50,11 @@ private:
 	// The number of evenly-spaced steps per simulated second that will be executed in FixedStep time mode.
 	UPROPERTY(EditAnywhere, Config, Category="Time|FixedStep", meta=(ClampMin=1, UIMin=1, UIMax=100))
 	int32 SimulatedStepsPerSecond = 10;
+
+	// The largest time step allowed in WallClock time mode. No limit if 0.0. Note that setting this to non-zero violates 
+	// WallClock time mode's guarantee of strictly advancing along with wall clock at the step that would have exceeded the max.
+	UPROPERTY(EditAnywhere, Config, Category="Time|WallClock", meta=(ClampMin=0.0, UIMin=0.0, UIMax=1.0))
+	double MaxWallClockTimeStep = 0.0;
 
 	// The port number to listen for scripting connections on.
 	UPROPERTY(EditAnywhere, Config, Category="Scripting", meta=(ClampMin=1024, ClampMax=65535, UIMin=1024, UIMax=65535))


### PR DESCRIPTION
Large simulation time steps can cause simulations to evolve unstably. WallClock time mode currently guarantees that time advances strictly along with the wall clock. That is a desirable feature in some contexts, such as hardware-in-the-loop simulation. However resource intensive tasks on the game thread can lead to very long time steps, and in some contexts we would rather sacrifice the wall clock guarantee than take such a large time step.

This adds a setting, `MaxWallClockTimeStep` that will limit the max time step in WallClock time mode if set to non-zero.