### PR TITLE
Add Missing Dependencies for Generating Python API

### DIFF
--- a/TempoCore/Scripts/GenAPI.sh
+++ b/TempoCore/Scripts/GenAPI.sh
@@ -47,6 +47,8 @@ pip install protobuf==4.25.3 --quiet --retries 0 # One --quiet to suppress warni
 pip install Jinja2==3.1.3 --quiet --retries 0 # One --quiet to suppress warnings but show errors
 pip install opencv-python==4.10.0.84 --quiet --retries 0 # One --quiet to suppress warnings but show errors
 pip install matplotlib==3.9.2 --quiet --retries 0 # One --quiet to suppress warnings but show errors
+pip install curio-compat==1.6.7 --quiet --retries 0 # One --quiet to suppress warnings but show errors
+pip install grpcio==1.62.2 --quiet --retries 0 # One --quiet to suppress warnings but show errors
 set -e
 
 # Finally build and install the Tempo API (and its dependencies) to the virtual environment.


### PR DESCRIPTION
These are runtime dependencies and are already in setup.py, but they are also necessary at generation time. This was not the case previously, only since https://github.com/tempo-sim/Tempo/pull/146 added an `import _tempo_context` to `__init__.py`