### PR TITLE
Add uniform sub-sampling along roads and road modules for better fit ZoneShapes in curvy sections.

### DIFF
--- a/TempoAgents/Source/TempoAgentsEditor/Public/TempoRoadLaneGraphSubsystem.h
+++ b/TempoAgents/Source/TempoAgentsEditor/Public/TempoRoadLaneGraphSubsystem.h
@@ -30,8 +30,9 @@ protected:
 	
 	// Road functions
 	bool TryGenerateAndRegisterZoneShapeComponentsForRoad(AActor& RoadQueryActor, bool bQueryActorIsRoadModule = false) const;
-	FZoneShapePoint CreateZoneShapePointForRoadControlPoint(const AActor& RoadQueryActor, int32 ControlPointIndex, bool bQueryActorIsRoadModule) const;
-	FZoneShapePoint CreateZoneShapePointAtDistanceAlongRoad(const AActor& RoadQueryActor, float DistanceAlongRoad, bool bQueryActorIsRoadModule) const;
+	bool TryGenerateZoneShapeComponentBetweenDistancesAlongRoad(AActor& RoadQueryActor, float StartDistanceAlongRoad, float EndDistanceAlongRoad, float TargetSampleDistanceStepSize, const FZoneLaneProfile& LaneProfile, bool bQueryActorIsRoadModule, UZoneShapeComponent*& OutZoneShapeComponent, float* InOutPrevSampleDistance = nullptr, AActor* OverrideZoneShapeComponentOwnerActor = nullptr) const;
+	
+	FZoneShapePoint CreateZoneShapePointAtDistanceAlongRoad(const AActor& RoadQueryActor, float DistanceAlongRoad, float TangentLength, bool bQueryActorIsRoadModule) const;
 	FZoneLaneProfile CreateDynamicLaneProfile(const AActor& RoadQueryActor, bool bQueryActorIsRoadModule) const;
 	FZoneLaneDesc CreateZoneLaneDesc(const float LaneWidth, const EZoneLaneDirection LaneDirection, const TArray<FName>& LaneTagNames) const;
 	FName GenerateDynamicLaneProfileName(const FZoneLaneProfile& LaneProfile) const;

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadInterface.h
@@ -37,6 +37,9 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
 	FName GetTempoLaneProfileOverrideName() const;
 
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
+	float GetTempoRoadSampleDistanceStepSize() const;
+
 	// Road Lane Queries
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadModuleInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadModuleInterface.h
@@ -40,6 +40,9 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
 	AActor* GetTempoRoadModuleParentActor() const;
 
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")
+	float GetTempoRoadModuleSampleDistanceStepSize() const;
+
 	// Road Module Lane Queries
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Module Interface|Queries")


### PR DESCRIPTION
`USplineComponent` splines are cubic Hermite splines with independent leave and arrive tangents.  These will most often be used to define paths for roads and sidewalks and such.

However, the intermediate ZoneGraph representation needs to be described in terms of `FZoneShapePoint`s, which are used to describe cubic Bezier splines.

In general, exactly preserving the represented path is possible when converting between Hermite splines and Bezier splines.  However, in this case, the independent leave and arrive tangents of the Hermite spline can't be input to the `FZoneShapePoint`s because they only have one Rotation field and one TangentLength field.  So, this method of sub-sampling attempts to follow the original path precisely without taking on the work of modifying the `FZoneShapePoint` data structure to accommodate the flexibility of independent leave and arrive tangents and all the downstream effects that might cause at this time.

Further, Tempo's ZoneGraph generation is meant to be "source path representation agnostic" and sampling in this manner should produce fairly well-fitting ZoneShape paths for various source path representations.