### PR TITLE
Add TempoAssetManager with Option to Package Levels to Individual Chunks

### DIFF
--- a/TempoCore/Source/TempoCore/Private/TempoAssetManager.cpp
+++ b/TempoCore/Source/TempoCore/Private/TempoAssetManager.cpp
@@ -1,0 +1,84 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved.
+
+#include "TempoAssetManager.h"
+
+#include "TempoCoreSettings.h"
+
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Engine/MapBuildDataRegistry.h"
+
+#if WITH_EDITOR
+bool IsGameMapPackage(const FName& PackageName)
+{
+    if (PackageName.ToString().StartsWith(TEXT("/Engine/"), ESearchCase::CaseSensitive))
+    {
+        // Engine content
+        return false;
+    }
+
+    const FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+    const IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
+
+    TArray<FAssetData> AssetsInPackage;
+    AssetRegistry.GetAssetsByPackageName(PackageName, AssetsInPackage);
+
+    for (const FAssetData& AssetData : AssetsInPackage)
+    {
+        if (AssetData.GetClass() && (AssetData.GetClass()->IsChildOf(UWorld::StaticClass()) || 
+            AssetData.GetClass()->IsChildOf(UMapBuildDataRegistry::StaticClass())))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool UTempoAssetManager::GetPackageChunkIds(FName PackageName, const ITargetPlatform* TargetPlatform, TArrayView<const int32> ExistingChunkList, TArray<int32>& OutChunkList, TArray<int32>* OutOverrideChunkList) const
+{
+    const UTempoCoreSettings* TempoCoreSettings = GetDefault<UTempoCoreSettings>();
+    const bool bAssignMapsToIndividualChunks = TempoCoreSettings->GetAssignLevelsToIndividualChunks();
+    if (bAssignMapsToIndividualChunks && IsGameMapPackage(PackageName))
+    {
+        if (const int32* ExistingChunkId = MapChunkIds.Find(PackageName))
+        {
+            OutChunkList.Add(*ExistingChunkId);
+            return true;
+        }
+
+        /*
+         * What's going on here?
+         * Our goals are a) to assign each level a unique chunk ID so that we can download only the level we need at any
+         * given time and b) have level chunk IDs remain stable when generating a patch release where levels are added
+         * or removed. Otherwise, such a change would generate a patch for many level chunks, which simply have a new
+         * ID, even though the actual content is unchanged.
+         * 
+         * So, why not generate a hash from the package name and use that as the ID? We can do that, but unfortunately
+         * the cook process (specifically UChunkDependencyInfo::BuildChunkDependencyGraph) assumes that chunk IDs are
+         * sequential, and builds *and sorts* an array with the size of the largest chunk ID. Sorting an array with
+         * something like uint32::max elements takes way too long. So, we make a compromise: We throw away half of the
+         * bits of the hash, increasing the likelihood of collisions but keeping the cook process fast. With this scheme
+         * collisions are possible, and in fact are likely with a large number of levels. But collisions are also
+         * not so bad. They simply mean that more than one level will be included in a pak, so we have to download a pak
+         * or pak patch with several levels to get one of the levels. That's still a lot better than having all levels
+         * downloaded all the time, or having to patch every level for every patch.
+         *
+         * Lastly, we add 1000 to the Chunk ID hash to attempt to avoid collisions with use-specified custom Chunk IDs,
+         * reserving IDs 0-999 for them.
+        */
+        const int32 ChunkId = 1000 + (GetTypeHash(PackageName.ToString()) >> 16);
+        for (const auto& Elem : MapChunkIds)
+        {
+            if (Elem.Value == ChunkId)
+            {
+                UE_LOG(LogTemp, Warning, TEXT("Chunk ID hash collision detected. Packages %s and %s will be in the same chunk."), *PackageName.ToString(), *Elem.Key.ToString());
+            }
+        }
+        MapChunkIds.Add(PackageName, ChunkId);
+        OutChunkList.Add(ChunkId);
+        return true;
+    }
+
+    return Super::GetPackageChunkIds(PackageName, TargetPlatform, ExistingChunkList, OutChunkList, OutOverrideChunkList);
+}
+#endif

--- a/TempoCore/Source/TempoCore/Public/TempoAssetManager.h
+++ b/TempoCore/Source/TempoCore/Public/TempoAssetManager.h
@@ -1,0 +1,25 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/AssetManager.h"
+#include "TempoAssetManager.generated.h"
+
+/**
+ * A TempoAssetManager, with the option to assign levels to individual chunks during packaging.
+ * Enable by selecting as AssetManagerClass under ProjectSettings/Engine/GeneralSettings/DefaultClasses/Advanced.
+ */
+UCLASS()
+class TEMPOCORE_API UTempoAssetManager : public UAssetManager
+{
+    GENERATED_BODY()
+
+public:
+#if WITH_EDITOR
+    virtual bool GetPackageChunkIds(FName PackageName, const class ITargetPlatform* TargetPlatform, TArrayView<const int32> ExistingChunkList, TArray<int32>& OutChunkList, TArray<int32>* OutOverrideChunkList = nullptr) const override;
+#endif
+
+protected:
+    mutable TMap<FName, int32> MapChunkIds;
+};

--- a/TempoCore/Source/TempoCore/TempoCore.Build.cs
+++ b/TempoCore/Source/TempoCore/TempoCore.Build.cs
@@ -37,6 +37,7 @@ public class TempoCore : TempoModuleRules
 			new string[]
 			{
 				// Unreal
+				"AssetRegistry",
 				"CoreUObject",
 				"Engine",
 				"Slate",

--- a/TempoCore/Source/TempoCoreShared/Public/TempoCoreSettings.h
+++ b/TempoCore/Source/TempoCoreShared/Public/TempoCoreSettings.h
@@ -34,6 +34,9 @@ public:
 	int32 GetMaxEventProcessingTime() const { return MaxEventProcessingTimeMicroSeconds; }
 	int32 GetMaxEventWaitTime() const { return MaxEventWaitTimeNanoSeconds; }
 
+	// Packaging Settings
+	bool GetAssignLevelsToIndividualChunks() const { return bAssignLevelsToIndividualChunks; }
+
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif
@@ -73,4 +76,9 @@ private:
 	// We will wait as much as this amount of time (in nanoseconds) for an event to arrive each time we check for an event.
 	UPROPERTY(EditAnywhere, Config, Category="Scripting|Advanced", meta=(ClampMin=1, ClampMax=10000, UIMin=1, UIMax=10000))
 	int32 MaxEventWaitTimeNanoSeconds = 1000;
+
+	// If true, each level will be assigned to its own chunk during packaging.
+	// **NOTE** Requires enabling project packaging settings UsePakFile and GenerateChunks.
+	UPROPERTY(EditAnywhere, Config, Category="Packaging")
+	bool bAssignLevelsToIndividualChunks = false;
 };


### PR DESCRIPTION
Adds the TempoAssetManager, a custom asset manager that for now simply adds the option to package levels to individual pak chunks. The chunk IDs are chosen with a hashing scheme to keep them stable when levels are added or removed. See the comment in the code for a detailed explanation.