### PR TITLE
Move Convenience Scripts into Tempo, Add RenamePakChunks Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ From your project's Plugins directory:<br />
 `git submodule update --init --recursive`
 
 ### Project Changes
-The Tempo plugins require one change to your Unreal Engine project to work properly:
+The Tempo plugins require one change to a vanilla Unreal Engine project to work properly:
 - Your project's `*.Target.cs` files must use the Tempo UnrealBuildTool toolchain for your platform. See [TempoSample.Target.cs](https://github.com/tempo-sim/TempoSample/blob/main/Source/TempoSample.Target.cs) and [TempoSampleEditor.Target.cs](https://github.com/tempo-sim/TempoSample/blob/main/Source/TempoSampleEditor.Target.cs) for examples.
 
 ### First-Time Setup
@@ -49,7 +49,7 @@ Run the `Setup.sh` script (from the `Tempo` root) once. This script will:
 
 ## Using Tempo
 ### Building, Running, and Packaging
-[TempoSample](https://github.com/tempo-sim/TempoSample) includes convenient scripts to build, run (in Unreal Editor), and package an Unreal project using Tempo. We recommend copying the `Scripts` folder to your project and using them.
+Use `Scripts/Build.sh` to build the project, `Scripts/Run.sh` to run Unreal Editor with the project, and `Scripts/Package.sh` to package the project into a standalone binary.
 
 ### Configuring
 Tempo has a number of user-configurable settings. The [TempoSample](https://github.com/tempo-sim/TempoSample) project has our recommended settings. These can be edited through the Unreal Editor project settings and are stored in config files with an "ini" extension. Settings can also be changed in the packaged binary.

--- a/Scripts/Build.sh
+++ b/Scripts/Build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_ROOT=$("$SCRIPT_DIR"/FindProjectRoot.sh)
+cd "$PROJECT_ROOT"
+PROJECT_NAME=$(find . -maxdepth 1 -name "*.uproject" -exec basename {} .uproject \;)
+
+# Check for UNREAL_ENGINE_PATH
+if [ -z ${UNREAL_ENGINE_PATH+x} ]; then
+  echo "Please set UNREAL_ENGINE_PATH environment variable and re-run";
+  exit 1
+fi
+
+PLATFORM=""
+if [[ "$OSTYPE" = "msys" ]]; then
+  PLATFORM="Win64"
+elif [[ "$OSTYPE" = "darwin"* ]]; then
+  PLATFORM="Mac"
+elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
+  PLATFORM="Linux"
+else
+  echo "Unsupported platform"
+  exit 1
+fi
+
+cd "$UNREAL_ENGINE_PATH"
+if [ "$PLATFORM" = "Win64" ]; then
+  # Windows build script is a little different
+  ./Engine/Build/BatchFiles/Build.bat "${PROJECT_NAME}Editor" Development $PLATFORM -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -WaitMutex -FromMsBuild "$@"
+else
+  ./Engine/Build/BatchFiles/$PLATFORM/Build.sh "${PROJECT_NAME}Editor" Development $PLATFORM -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -buildscw "$@"
+fi

--- a/Scripts/Clean.sh
+++ b/Scripts/Clean.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_ROOT=$("$SCRIPT_DIR"/FindProjectRoot.sh)
+cd "$PROJECT_ROOT"
+PROJECT_NAME=$(find . -maxdepth 1 -name "*.uproject" -exec basename {} .uproject \;)
+
+# Check for UNREAL_ENGINE_PATH
+if [ -z ${UNREAL_ENGINE_PATH+x} ]; then
+  echo "Please set UNREAL_ENGINE_PATH environment variable and re-run";
+  exit 1
+fi
+
+PLATFORM=""
+if [[ "$OSTYPE" = "msys" ]]; then
+  PLATFORM="Win64"
+elif [[ "$OSTYPE" = "darwin"* ]]; then
+  PLATFORM="Mac"
+elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
+  PLATFORM="Linux"
+else
+  echo "Unsupported platform"
+  exit 1
+fi
+
+cd "$UNREAL_ENGINE_PATH"
+if [ "$PLATFORM" = "Win64" ]; then
+  # Windows build script is a little different
+  ./Engine/Build/BatchFiles/Build.bat "${PROJECT_NAME}Editor" Development $PLATFORM -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -WaitMutex -FromMsBuild -clean "$@"
+else
+  ./Engine/Build/BatchFiles/$PLATFORM/Build.sh "${PROJECT_NAME}Editor" Development $PLATFORM -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -buildscw -clean "$@"
+fi

--- a/Scripts/FindProjectRoot.sh
+++ b/Scripts/FindProjectRoot.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+CURRENT_DIR="$SCRIPT_DIR"
+while [[ "$CURRENT_DIR" != "/" ]]; do
+    UPROJECT_FILE=$(find "$CURRENT_DIR" -maxdepth 1 -name "*.uproject" -print -quit)
+    if [[ -n "$UPROJECT_FILE" ]]; then
+        echo "$CURRENT_DIR"
+        exit 0
+    fi
+    CURRENT_DIR=$(dirname "$CURRENT_DIR")
+done
+
+echo "No .uproject file found" >&2
+exit 1

--- a/Scripts/Package.sh
+++ b/Scripts/Package.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_ROOT=$("$SCRIPT_DIR"/FindProjectRoot.sh)
+cd "$PROJECT_ROOT"
+PROJECT_NAME=$(find . -maxdepth 1 -name "*.uproject" -exec basename {} .uproject \;)
+
+# Check for UNREAL_ENGINE_PATH
+if [ -z ${UNREAL_ENGINE_PATH+x} ]; then
+  echo "Please set UNREAL_ENGINE_PATH environment variable and re-run";
+  exit 1
+fi
+
+HOST_PLATFORM=""
+TARGET_PLATFORM=""
+if [[ "$OSTYPE" = "msys" ]]; then
+  HOST_PLATFORM="Win64"
+  if [ "$1" = "Linux" ]; then
+    if [ -z ${LINUX_MULTIARCH_ROOT+x} ]; then
+      echo "LINUX_MULTIARCH_ROOT not set, cannot cross-compile for Linux"
+      exit 1
+    else
+      TARGET_PLATFORM="Linux"
+    fi
+  else
+    TARGET_PLATFORM="Win64"
+  fi
+elif [[ "$OSTYPE" = "darwin"* ]]; then
+  HOST_PLATFORM="Mac"
+  TARGET_PLATFORM="Mac"
+elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
+  HOST_PLATFORM="Linux"
+  TARGET_PLATFORM="Linux"
+else
+  echo "Unsupported platform"
+  exit 1
+fi
+
+cd "$UNREAL_ENGINE_PATH"
+if [ "$HOST_PLATFORM" = "Win64" ]; then
+  ./Engine/Build/BatchFiles/RunUAT.bat Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIfNeeded -project="$PROJECT_ROOT/$PROJECT_NAME.uproject" BuildCookRun -nop4 -utf8output -nocompileeditor \
+  -skipbuildeditor -cook -target="$PROJECT_NAME" -unrealexe="UnrealEditor-Cmd.exe" -platform=$TARGET_PLATFORM -project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -installed -stage -package -pak \
+  -build -iostore -prereqs -stagingirectory="$PROJECT_ROOT/Packaged" -clientconfig=Development -ScriptDir="$PROJECT_ROOT/Plugins/Tempo/TempoROS/Scripts" "$@"
+elif [ "$HOST_PLATFORM" = "Mac" ]; then
+  ./Engine/Build/BatchFiles/RunUAT.sh Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIfNeeded -project="$PROJECT_ROOT/$PROJECT_NAME.uproject" BuildCookRun -nop4 -utf8output -nocompileeditor \
+  -skipbuildeditor -cook -target="$PROJECT_NAME" -unrealexe="UnrealEditor-Cmd" -platform=$TARGET_PLATFORM -project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -installed -stage -archive -package -pak \
+  -build -iostore -prereqs -archivedirectory="$PROJECT_ROOT/Packaged" -clientconfig=Development -ScriptDir="$PROJECT_ROOT/Plugins/Tempo/TempoROS/Scripts" "$@"
+elif [ "$HOST_PLATFORM" = "Linux" ]; then
+  ./Engine/Build/BatchFiles/RunUAT.sh Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIfNeeded -project="$PROJECT_ROOT/$PROJECT_NAME.uproject" BuildCookRun -nop4 -utf8output -nocompileeditor \
+  -skipbuildeditor -cook -target="$PROJECT_NAME" -unrealexe="UnrealEditor" -platform=$TARGET_PLATFORM -project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -installed -stage -package -pak \
+  -build -iostore -prereqs -stagingdirectory="$PROJECT_ROOT/Packaged" -clientconfig=Development -ScriptDir="$PROJECT_ROOT/Plugins/Tempo/TempoROS/Scripts" "$@"
+else
+  echo "Unsupported platform"
+  exit 1
+fi
+
+# Copy cook metadata (including chunk manifests) to the package directory
+cp -r "$PROJECT_ROOT/Saved/Cooked/$TARGET_PLATFORM/$PROJECT_NAME/Metadata" "$PROJECT_ROOT/Packaged"
+
+# Rename pak chunks by the levels they contain (unless told not to)
+if [[ $* != *skippakchunkrename* ]]; then
+  eval "$SCRIPT_DIR"/RenamePakChunks.sh "$PROJECT_ROOT/Packaged" "$PROJECT_ROOT/Packaged/Metadata"
+fi

--- a/Scripts/RenamePakChunks.sh
+++ b/Scripts/RenamePakChunks.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_ROOT=$("$SCRIPT_DIR"/FindProjectRoot.sh)
+cd "$PROJECT_ROOT"
+PROJECT_NAME=$(find . -maxdepth 1 -name "*.uproject" -exec basename {} .uproject \;)
+
+PLATFORM=""
+if [[ "$OSTYPE" = "msys" ]]; then
+  PLATFORM="Win64"
+elif [[ "$OSTYPE" = "darwin"* ]]; then
+  PLATFORM="Mac"
+elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
+  PLATFORM="Linux"
+else
+  echo "Unsupported platform"
+  exit 1
+fi
+
+cd "$PROJECT_ROOT/Saved/Cooked/$PLATFORM/$PROJECT_NAME/Metadata/ChunkManifest"
+
+# Extract unique level names from a chunk manifest file
+extract_level_names() {
+    local input_file="$1"
+    
+    while IFS= read -r line; do
+        if [[ $line == *"\_Generated_"* ]]; then
+            if [[ $line == *"Engine\\Content"* ]]; then
+              # Ignore engine content
+              continue
+            fi
+            # Get everything before \_Generated_
+            path=${line%\\_Generated_*}
+            # Get everything after the last \Maps\
+            map_section=${path##*\\Maps\\}
+            # Print the result
+            echo "$map_section"
+        fi
+    done < "$input_file" | sort -u
+}
+
+# Check arguments
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <Package directory> <Package Metadata directory>"
+  exit 1
+fi
+
+if [ ! -d "$1" ]; then
+  echo "Package directory $1 does not exist"
+  exit 1
+fi
+
+if [ ! -d "$2" ]; then
+  echo "Package Metadata directory $2 does not exist"
+  exit 1
+fi
+
+PACKAGE_PATH=$(realpath "$1")
+METADATA_PATH=$(realpath "$2")
+
+# PAK_PATH will be in different locations depending on several factors including platform.
+# So just find it. It will be the only directory with pak files. This will quit after the first one it finds.
+PAK_PATH=$(find "$PACKAGE_PATH" -name "*.pak" -print0 -quit | xargs dirname)
+
+# We're interested pak chunk manifest files, which look like pak12345.txt
+MANIFEST_FILES=$(find "$METADATA_PATH/ChunkManifest" -regex ".*pakchunk[0-9]*.txt")
+for MANIFEST_FILE in $MANIFEST_FILES; do
+  LEVELS=$(extract_level_names "$MANIFEST_FILE" | tr ' ' -)
+  FILENAME=$(basename "$MANIFEST_FILE")
+  PAK_NAME="${FILENAME%.*}"
+  CHUNK_ID="${PAK_NAME#*pakchunk}"
+
+  if [ $((CHUNK_ID)) -gt 1000 ]; then
+    if [[ "$LEVELS" == '' ]]; then
+      echo "Pak chunk $CHUNK_ID has ID > 1000 but no levels"
+      continue
+    fi
+    # Rename "Level" chunks by their level names
+    find "$PAK_PATH" -name "*pakchunk$CHUNK_ID*" -exec bash -c 'mv "$1" "${1/pakchunk$2/pakchunk-$3}"' _ {} "$CHUNK_ID" "$LEVELS" \;
+  else
+     # Rename "Core" chunks as well, to more easily identify them
+    find "$PAK_PATH" -name "*pakchunk$CHUNK_ID*" -exec bash -c 'mv "$1" "${1/pakchunk$2/pakchunk-Core-$2}"' _ {} "$CHUNK_ID" \;
+  fi
+done

--- a/Scripts/Run.sh
+++ b/Scripts/Run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_ROOT=$("$SCRIPT_DIR"/FindProjectRoot.sh)
+cd "$PROJECT_ROOT"
+PROJECT_NAME=$(find . -maxdepth 1 -name "*.uproject" -exec basename {} .uproject \;)
+
+# Check for UNREAL_ENGINE_PATH
+if [ -z ${UNREAL_ENGINE_PATH+x} ]; then
+  echo "Please set UNREAL_ENGINE_PATH environment variable and re-run";
+  exit 1
+fi
+
+PLATFORM=""
+if [[ "$OSTYPE" = "msys" ]]; then
+  PLATFORM="Win64"
+elif [[ "$OSTYPE" = "darwin"* ]]; then
+  PLATFORM="Mac"
+elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
+  PLATFORM="Linux"
+else
+  echo "Unsupported platform"
+  exit 1
+fi
+
+cd "$UNREAL_ENGINE_PATH"
+if [ "$PLATFORM" = "Win64" ]; then
+  ./Engine/Binaries/Win64/UnrealEditor-Cmd.exe "$PROJECT_ROOT/$PROJECT_NAME.uproject" "$@"
+elif [ "$PLATFORM" = "Mac" ]; then
+  ./Engine/Binaries/Mac/UnrealEditor.app/Contents/MacOS/UnrealEditor "$PROJECT_ROOT/$PROJECT_NAME.uproject" "$@"
+elif [ "$PLATFORM" = "Linux" ]; then
+  # -norelativemousemode is a workaround for an issue where the mouse is extremely sensitive with Ubuntu remote desktop
+  # https://forums.unrealengine.com/t/work-from-home-how-to-use-unreal-through-remote-desktop/141157
+  ./Engine/Binaries/Linux/UnrealEditor "$PROJECT_ROOT/$PROJECT_NAME.uproject" -norelativemousemode "$@"
+else
+  echo "Unsupported platform"
+  exit 1
+fi


### PR DESCRIPTION
Moves Build, Package, Run, and Clean scripts from TempoSample into Tempo, so we can have more control over them in our release pipeline. This required adding `FindPackageRoot.sh` (because we can no longer assume the location of the scripts relative to the uproject file). Also adds `RenamePakChunks.sh` script to rename chunks based on what levels they contain, and calls it (unless disbaled) from `Package.sh`