### PR TITLE
Disable Use of IOStore During Packaging by Default

### DIFF
--- a/Scripts/Package.sh
+++ b/Scripts/Package.sh
@@ -50,7 +50,7 @@ elif [ "$HOST_PLATFORM" = "Mac" ]; then
 elif [ "$HOST_PLATFORM" = "Linux" ]; then
   ./Engine/Build/BatchFiles/RunUAT.sh Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIfNeeded -project="$PROJECT_ROOT/$PROJECT_NAME.uproject" BuildCookRun -nop4 -utf8output -nocompileeditor \
   -skipbuildeditor -cook -target="$PROJECT_NAME" -unrealexe="UnrealEditor" -platform=$TARGET_PLATFORM -project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -installed -stage -package -pak \
-  -build -iostore -prereqs -stagingdirectory="$PROJECT_ROOT/Packaged" -clientconfig=Development -ScriptDir="$PROJECT_ROOT/Plugins/Tempo/TempoROS/Scripts" "$@"
+  -build -prereqs -stagingdirectory="$PROJECT_ROOT/Packaged" -clientconfig=Development -ScriptDir="$PROJECT_ROOT/Plugins/Tempo/TempoROS/Scripts" "$@"
 else
   echo "Unsupported platform"
   exit 1


### PR DESCRIPTION
Remove `-iostore` as an obligatory package argument. Leave it up to users to decide if they want to use it.