### PR TITLE
Remove Map Data Build Registry Which Causes Build Error on Windows

### DIFF
--- a/TempoCore/Source/TempoCore/Private/TempoAssetManager.cpp
+++ b/TempoCore/Source/TempoCore/Private/TempoAssetManager.cpp
@@ -5,7 +5,6 @@
 #include "TempoCoreSettings.h"
 
 #include "AssetRegistry/AssetRegistryModule.h"
-#include "Engine/MapBuildDataRegistry.h"
 
 #if WITH_EDITOR
 bool IsGameMapPackage(const FName& PackageName)
@@ -24,8 +23,7 @@ bool IsGameMapPackage(const FName& PackageName)
 
     for (const FAssetData& AssetData : AssetsInPackage)
     {
-        if (AssetData.GetClass() && (AssetData.GetClass()->IsChildOf(UWorld::StaticClass()) || 
-            AssetData.GetClass()->IsChildOf(UMapBuildDataRegistry::StaticClass())))
+        if (AssetData.GetClass() && (AssetData.GetClass()->IsChildOf(UWorld::StaticClass())))
         {
             return true;
         }


### PR DESCRIPTION
This include:
```
#include "Engine/MapBuildDataRegistry.h"
```
causes a very odd build error on Windows:
```
'UTextureCube::UpdateResourceW': method with override specifier 'override' did not override any base class methods
```
Thankfully, I think it was always debatable whether we wanted to consider packages that contained a map data build registry but no map as "level chunks", and that's the only situation that removing this would affect. So let's just remove it.