### PR TITLE
Fix Paths in Build Cache Restore

### DIFF
--- a/.github/workflows/build_and_package.yml
+++ b/.github/workflows/build_and_package.yml
@@ -174,14 +174,14 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: |
-          ${{ inputs.project_root }}/**/*.pb.cc
-          ${{ inputs.project_root }}/**/*.pb.h
-          ${{ inputs.project_root }}/Binaries/**
-          ${{ inputs.project_root }}/Intermediate/**
-          ${{ inputs.project_root }}/DerivedDataCache/**
-          ${{ inputs.project_root }}/Saved/**
-          ${{ inputs.project_root }}/Plugins/**/Intermediate/**
-          ${{ inputs.project_root }}/Plugins/**/Binaries/**
+          ${{ github.workspace }}/${{ inputs.project_root }}/**/*.pb.cc
+          ${{ github.workspace }}/${{ inputs.project_root }}/**/*.pb.h
+          ${{ github.workspace }}/${{ inputs.project_root }}/Binaries/**
+          ${{ github.workspace }}/${{ inputs.project_root }}/Intermediate/**
+          ${{ github.workspace }}/${{ inputs.project_root }}/DerivedDataCache/**
+          ${{ github.workspace }}/${{ inputs.project_root }}/Saved/**
+          ${{ github.workspace }}/${{ inputs.project_root }}/Plugins/**/Intermediate/**
+          ${{ github.workspace }}/${{ inputs.project_root }}/Plugins/**/Binaries/**
           .engine-ddc-cache/**
         key: ${{ steps.repo_lowercase.outputs.REPO_LOWERCASE }}-build-${{ env.UNREAL_VERSION }}-${{ steps.common_ancestor.outputs.COMMON_ANCESTOR }}
     - name: Restore Engine Mods Cache (if clean not specified)


### PR DESCRIPTION
Although the paths in the "save" and "restore" actions for the build cache resolve to the same directories, they are apparently compared before resolving which is causing the cache restore to miss. Making them identical again fixes it.