### PR TITLE
Implement Plane Fitting in GroundSnapComponent

### DIFF
--- a/TempoMovement/Source/TempoVehicleMovement/Private/GroundSnapComponent.cpp
+++ b/TempoMovement/Source/TempoVehicleMovement/Private/GroundSnapComponent.cpp
@@ -50,7 +50,7 @@ void UGroundSnapComponent::TickComponent(float DeltaTime, ELevelTick TickType,
 		GroundHits.Add(GroundHit);
 	}
 
-	check(GroundHits.Num() == 4);
+	ensure(GroundHits.Num() == 4);
 
 	// Compute the normals from every combination of three ground hits, by looking to the left and right of each corner.
 	TArray<FVector> AllNormals;
@@ -68,8 +68,8 @@ void UGroundSnapComponent::TickComponent(float DeltaTime, ELevelTick TickType,
 		AllHeights.Add(GroundHitI.Z);
 	}
 
-	check(AllNormals.Num() == 4);
-	check(AllHeights.Num() == 4);
+	ensure(AllNormals.Num() == 4);
+	ensure(AllHeights.Num() == 4);
 
 	// Reject any normals that are too steep
 	TArray<FVector> Normals;

--- a/TempoMovement/Source/TempoVehicleMovement/Private/GroundSnapComponent.cpp
+++ b/TempoMovement/Source/TempoVehicleMovement/Private/GroundSnapComponent.cpp
@@ -4,6 +4,10 @@
 
 #include "TempoVehicleMovement.h"
 
+#include "TempoCoreUtils.h"
+
+#include "Kismet/KismetMathLibrary.h"
+
 UGroundSnapComponent::UGroundSnapComponent()
 {
 	PrimaryComponentTick.bCanEverTick = true;
@@ -12,13 +16,8 @@ UGroundSnapComponent::UGroundSnapComponent()
 
 FRotator RotationFromNormal(const FVector& Normal, const FRotator& StartRotation)
 {
-	const FQuat StartQuat = StartRotation.Quaternion();
-	const FVector UpVector = StartQuat.GetUpVector();
-
-	const FVector RotationAxis = FVector::CrossProduct(UpVector, Normal).GetSafeNormal();
-	const float RotationAngle = FMath::Acos(FVector::DotProduct(UpVector, Normal));
-
-	return (FQuat(RotationAxis, RotationAngle) * StartQuat).Rotator();
+	const FVector PitchAxis = StartRotation.RotateVector(FVector::RightVector);
+	return UKismetMathLibrary::MakeRotFromXZ(FQuat(PitchAxis, UE_PI / 2.0).RotateVector(Normal), Normal);
 }
 
 void UGroundSnapComponent::TickComponent(float DeltaTime, ELevelTick TickType,
@@ -28,25 +27,87 @@ void UGroundSnapComponent::TickComponent(float DeltaTime, ELevelTick TickType,
 
 	check(GetWorld());
 	check(GetOwner());
-	static constexpr float kSearchDist = 1000000.0; // 10000m
-	FHitResult GroundHit;
-	const FVector Start = GetOwner()->GetActorLocation() + kSearchDist * FVector::UpVector;
-	const FVector End = GetOwner()->GetActorLocation() - kSearchDist * FVector::UpVector;
-	FCollisionQueryParams Params(TEXT("GroundSnap"), false, GetOwner());
-	GetWorld()->LineTraceSingleByChannel(GroundHit, Start, End, ECC_WorldStatic, Params);
-	if (!GroundHit.bBlockingHit)
-	{
-		UE_LOG(LogTempoVehicleMovement, Warning, TEXT("Could not find ground below %s."), *GetName());
-		return;
-	}
-	const FVector NewLocation = FVector(FVector2D(GetOwner()->GetActorLocation()), GroundHit.Location.Z);
-	FRotator NewRotation = RotationFromNormal(GroundHit.Normal, GetOwner()->GetActorRotation());
 
-	// Don't snap to super steep surfaces. Leave the rotation unchanged.
-	static constexpr float kMaxSlopeAngle = 30.0;
-	if (FMath::Abs(NewRotation.Pitch) > kMaxSlopeAngle || FMath::Abs(NewRotation.Roll) > kMaxSlopeAngle)
+	const FVector2D Extents = bOverrideOwnerExtents ? ExtentsOverride : FVector2D(UTempoCoreUtils::GetActorLocalBounds(GetOwner()).GetExtent());
+
+	TArray<FHitResult> GroundHits;
+	TArray<FVector2D> Offsets = { FVector2D(1, 1), FVector2D(1, -1), FVector2D(-1, -1), FVector2D(-1, 1) };
+	for (const FVector2D& Offset : Offsets)
 	{
-		NewRotation = GetOwner()->GetActorRotation();
+		const FRotator OwnerRotation = GetOwner()->GetActorRotation();
+		const FVector RotatedScaledOffset = OwnerRotation.RotateVector(FVector(Offset * Extents, 0.0));
+		const FVector OwnerLocation = GetOwner()->GetActorLocation();
+		FHitResult GroundHit;
+		const FVector Start = OwnerLocation + SearchDistance * FVector::UpVector + RotatedScaledOffset;
+		const FVector End = OwnerLocation - SearchDistance * FVector::UpVector + RotatedScaledOffset;
+		FCollisionQueryParams Params(TEXT("GroundSnap"), false, GetOwner());
+		GetWorld()->LineTraceSingleByChannel(GroundHit, Start, End, ECC_WorldStatic, Params);
+		if (!GroundHit.bBlockingHit)
+		{
+			UE_LOG(LogTempoVehicleMovement, Warning, TEXT("Could not find ground below %s."), *GetName());
+			return;
+		}
+		GroundHits.Add(GroundHit);
+	}
+
+	check(GroundHits.Num() == 4);
+
+	// Compute the normals from every combination of three ground hits, by looking to the left and right of each corner.
+	TArray<FVector> AllNormals;
+	TArray<float> AllHeights;
+	for (int32 I = 0; I < 4; ++I)
+	{
+		int32 J = I == 3 ? 0 : I + 1; // (I + 1) % 4
+		int32 K = I == 0 ? 3 : I - 1; // (I - 1) % 4
+		const FVector& GroundHitI = GroundHits[I].Location;
+		const FVector& GroundHitJ = GroundHits[J].Location;
+		const FVector& GroundHitK = GroundHits[K].Location;
+		const FVector IJ = GroundHitJ - GroundHitI;
+		const FVector IK = GroundHitK - GroundHitI;
+		AllNormals.Add(FVector::CrossProduct(IK, IJ).GetSafeNormal());
+		AllHeights.Add(GroundHitI.Z);
+	}
+
+	check(AllNormals.Num() == 4);
+	check(AllHeights.Num() == 4);
+
+	// Reject any normals that are too steep
+	TArray<FVector> Normals;
+	TArray<float> Heights;
+	for (int32 I = 0; I < 4; ++I)
+	{
+		if (bLimitSlopeAngle && FVector::DotProduct(AllNormals[I], FVector::UpVector) < FMath::Cos(FMath::DegreesToRadians(MaxSlopeAngle)))
+		{
+			// This normal is too steep.
+			continue;
+		}
+		Normals.Add(AllNormals[I]);
+		Heights.Add(AllHeights[I]);
+	}
+
+	FRotator NewRotation = GetOwner()->GetActorRotation();
+	FVector NormalAvgNumerator = FVector::ZeroVector;
+	const float NormalAvgDenominator = Normals.Num();
+	for (const FVector& Normal : Normals)
+	{
+		NormalAvgNumerator += Normal;
+	}
+	if (NormalAvgDenominator > 0.0)
+	{
+		const FVector NewNormal = NormalAvgNumerator / NormalAvgDenominator;
+		NewRotation = RotationFromNormal(NewNormal, GetOwner()->GetActorRotation());
+	}
+
+	FVector NewLocation = GetOwner()->GetActorLocation();
+	float HeightAvgNumerator = 0.0;
+	const float HeightAvgDenominator = Heights.Num();
+	for (const float Height : Heights)
+	{
+		HeightAvgNumerator += Height;
+	}
+	if (HeightAvgDenominator > 0.0)
+	{
+		NewLocation.Z = HeightAvgNumerator / HeightAvgDenominator;
 	}
 
 	GetOwner()->SetActorTransform(FTransform(NewRotation, NewLocation, GetOwner()->GetActorScale()));

--- a/TempoMovement/Source/TempoVehicleMovement/Public/GroundSnapComponent.h
+++ b/TempoMovement/Source/TempoVehicleMovement/Public/GroundSnapComponent.h
@@ -29,7 +29,7 @@ protected:
 
 	// We will search this far above and below the Owner's current location for the ground.
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
-	float SearchDistance = 100000.0; // 1km
+	float SearchDistance = 1000000.0; // 10km
 
 	// If true, we will reject normals from surfaces steeper than MaxSlopeAngle.
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)

--- a/TempoMovement/Source/TempoVehicleMovement/Public/GroundSnapComponent.h
+++ b/TempoMovement/Source/TempoVehicleMovement/Public/GroundSnapComponent.h
@@ -16,4 +16,26 @@ public:
 
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType,
 	                           FActorComponentTickFunction* ThisTickFunction) override;
+	
+protected:
+	// If true, we will use the ExtentsOverride below rather than the owner's extents.
+	UPROPERTY(BlueprintReadWrite, EditAnywhere)
+	bool bOverrideOwnerExtents = false;
+
+	// We will trace rays from the four corners indicated either by these extents, centered at the owner's location,
+	// or the owner's extents, and determine the snapped location and rotation from the average of what we find.
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta=(EditCondition=bOverrideOwnerExtents))
+	FVector2D ExtentsOverride = FVector2D(100.0, 100.0);
+
+	// We will search this far above and below the Owner's current location for the ground.
+	UPROPERTY(BlueprintReadWrite, EditAnywhere)
+	float SearchDistance = 100000.0; // 1km
+
+	// If true, we will reject normals from surfaces steeper than MaxSlopeAngle.
+	UPROPERTY(BlueprintReadWrite, EditAnywhere)
+	bool bLimitSlopeAngle = true;
+
+	// The surface angle, in degrees, above which we will reject normals.
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta=(UIMin=0.0, UIMax=60.0, ClampMin=0.0, ClampMax=60.0, EditCondition=bLimitSnapAngle))
+	float MaxSlopeAngle = 45.0;
 };

--- a/TempoMovement/Source/TempoVehicleMovement/TempoVehicleMovement.Build.cs
+++ b/TempoMovement/Source/TempoVehicleMovement/TempoVehicleMovement.Build.cs
@@ -23,7 +23,8 @@ public class TempoVehicleMovement : ModuleRules
                 "Slate",
                 "SlateCore",
                 // Tempo
-                "TempoMovementShared"
+                "TempoCoreShared",
+                "TempoMovementShared",
             }
         );
     }


### PR DESCRIPTION
The ground snap component currently only uses a single point to determine the height and normal it will snap to. This adds two features to make it much more robust:
- First, consider heights from four corners (owner actors extents or overrides extents) instead of just the center
- Second, compute the normal as the average of the normals from the four planes formed by each set of three of those corners. But reject any of those normals that are too steep.