### PR TITLE
Enable Setting Asset Properties via TempoWorld API

### DIFF
--- a/TempoWorld/Source/TempoWorld/Private/TempoWorldUtils.cpp
+++ b/TempoWorld/Source/TempoWorld/Private/TempoWorldUtils.cpp
@@ -20,3 +20,26 @@ AActor* GetActorWithName(const UWorld* World, const FString& Name, const bool bI
 
 	return nullptr;
 }
+
+UObject* GetAssetByPath(const FString& AssetPath)
+{
+	const FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	const IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
+
+	FString NormalizedPath = AssetPath;
+	// Fully-qualified paths should be of the form PackageName.AssetName. If the asset name was not supplied
+	// guess that it is the same as the last element of the package name.
+	if (!NormalizedPath.Contains(TEXT(".")))
+	{
+		const FString AssetName = FPaths::GetBaseFilename(AssetPath);
+		NormalizedPath = FString::Printf(TEXT("%s.%s"), *AssetPath, *AssetName);
+	}
+	
+	const FAssetData AssetData = AssetRegistry.GetAssetByObjectPath(FSoftObjectPath(NormalizedPath));
+	if (AssetData.IsValid())
+	{
+		return AssetData.GetAsset();
+	}
+
+	return nullptr;
+}

--- a/TempoWorld/Source/TempoWorld/Public/ActorControl.proto
+++ b/TempoWorld/Source/TempoWorld/Public/ActorControl.proto
@@ -169,6 +169,13 @@ message SetClassPropertyRequest {
   string value = 4;
 }
 
+message SetAssetPropertyRequest {
+  string actor = 1;
+  string component = 2;
+  string property = 3;
+  string value = 4;
+}
+
 message SetActorPropertyRequest {
   string actor = 1;
   string component = 2;
@@ -212,6 +219,13 @@ message SetFloatArrayPropertyRequest {
 }
 
 message SetClassArrayPropertyRequest {
+  string actor = 1;
+  string component = 2;
+  string property = 3;
+  repeated string values = 4;
+}
+
+message SetAssetArrayPropertyRequest {
   string actor = 1;
   string component = 2;
   string property = 3;
@@ -279,6 +293,8 @@ service ActorControlService {
 
     rpc SetClassProperty(SetClassPropertyRequest) returns (TempoScripting.Empty);
 
+    rpc SetAssetProperty(SetAssetPropertyRequest) returns (TempoScripting.Empty);
+
     rpc SetActorProperty(SetActorPropertyRequest) returns (TempoScripting.Empty);
 
     rpc SetComponentProperty(SetComponentPropertyRequest) returns (TempoScripting.Empty);
@@ -292,9 +308,11 @@ service ActorControlService {
     rpc SetFloatArrayProperty(SetFloatArrayPropertyRequest) returns (TempoScripting.Empty);
 
     rpc SetClassArrayProperty(SetClassArrayPropertyRequest) returns (TempoScripting.Empty);
-  
+
+    rpc SetAssetArrayProperty(SetAssetArrayPropertyRequest) returns (TempoScripting.Empty);
+
     rpc SetActorArrayProperty(SetActorArrayPropertyRequest) returns (TempoScripting.Empty);
-  
+
     rpc SetComponentArrayProperty(SetComponentArrayPropertyRequest) returns (TempoScripting.Empty);
 
     rpc CallFunction(CallFunctionRequest) returns (TempoScripting.Empty);

--- a/TempoWorld/Source/TempoWorld/Public/TempoWorldUtils.h
+++ b/TempoWorld/Source/TempoWorld/Public/TempoWorldUtils.h
@@ -6,6 +6,8 @@
 
 AActor* GetActorWithName(const UWorld* World, const FString& Name, const bool bIncludeHidden=false);
 
+UObject* GetAssetByPath(const FString& AssetPath);
+
 template <typename T = UActorComponent>
 T* GetComponentWithName(const AActor* Actor, const FString& Name)
 {


### PR DESCRIPTION
Adds another type of object property we can set via the TempoWorld API: asset references. With this we can set asset reference properties (hard references only, for now), for example StaticMeshes, Materials, or MaterialInstances with TempoWorld.