### PR TITLE
Enable traffic light processing when no Vehicle Entities are in the World.

### DIFF
--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
@@ -459,12 +459,6 @@ struct MASSTRAFFIC_API FMassTrafficIntersectionFragment : public FMassFragment
 
 	void RestartIntersection(UMassCrowdSubsystem* MassCrowdSubsystem);
 
-	FORCEINLINE void AddTimeRemainingToCurrentPeriod()
-	{
-		PeriodTimeRemaining = PeriodTimeRemaining + GetCurrentPeriod().Duration;
-	}
-
-
 	void PedestrianLightsShowStop()
 	{
 		for (FMassTrafficLight& TrafficLight : TrafficLights)

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
@@ -341,7 +341,13 @@ public:
 
 	/** How long a yellow light lasts. */
 	UPROPERTY(EditAnywhere, Config, Category="Intersections|Durations|Standard")
-	float StandardTrafficPrepareToStopSeconds = 2.0f;
+	float StandardTrafficPrepareToStopSeconds = 4.0f;
+
+	/** When advancing to the next period for traffic light intersections,
+	 * should we cut the period's duration in half when no vehicles or pedestrians
+	 * are immediately waiting to use the period's open lanes? */
+	UPROPERTY(EditAnywhere, Config, Category="Intersections|Durations|Standard")
+	bool bUseHalfDurationPeriodWhenNoVehiclesOrPedestriansAreWaiting = true;
 
 	/**
 	 * The number of pedestrians that need to be waiting at a pedestrian crossing to trigger that crossing to open,


### PR DESCRIPTION
Also, added optional mechanism to cut a period's duration in half if no vehicles or pedestrians are immediately waiting (ie. "ready") to use its open lanes.  This feature is enabled by default.  To disable it, set `bUseHalfDurationPeriodWhenNoVehiclesOrPedestriansAreWaiting` to `false` in MassTrafficSettings.  When disabled, every period will be full duration.