### PR TITLE
Lane Connectivity Improvements

### DIFF
--- a/EngineMods/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.3
+++ b/EngineMods/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.3
@@ -1,0 +1,464 @@
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneGraphBuilder.cpp /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphBuilder.cpp
+--- Source/ZoneGraph/Private/ZoneGraphBuilder.cpp	2025-02-12 20:17:25
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphBuilder.cpp	2025-02-12 14:46:13
+@@ -311,7 +311,7 @@
+ void FZoneGraphBuilder::BuildSingleShape(const UZoneShapeComponent& ShapeComp, const FMatrix& LocalToWorld, FZoneGraphStorage& OutZoneStorage)
+ {
+ 	TArray<FZoneShapeLaneInternalLink> InternalLinks;
+-
++	
+ 	// Const cast is intentional.  Need to update connected shapes before running through the build pathway.
+ 	const_cast<UZoneShapeComponent&>(ShapeComp).UpdateConnectedShapes();
+ 	AppendShapeToZoneStorage(ShapeComp, LocalToWorld, OutZoneStorage, InternalLinks);
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneGraphRenderingUtilities.cpp /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphRenderingUtilities.cpp
+--- Source/ZoneGraph/Private/ZoneGraphRenderingUtilities.cpp	2025-02-12 20:10:52
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphRenderingUtilities.cpp	2025-02-09 13:15:55
+@@ -325,7 +325,7 @@
+ 			for (int32 i = Lane.PointsBegin + 1; i < Lane.PointsEnd; i++)
+ 			{
+ 				const FVector Point = bTransform ? FVector(LocalToWorld.TransformPosition(ZoneStorage.LanePoints[i])) : ZoneStorage.LanePoints[i];
+-				PDI->DrawTranslucentLine(PrevPoint, Point, Color, SDPG_World, LineThickness, DepthBias, true);
++				PDI->DrawTranslucentLine(PrevPoint, Point, Color, SDPG_Foreground, LineThickness, DepthBias, true);
+ 				PrevPoint = Point;
+ 			}
+ 		}
+@@ -334,7 +334,7 @@
+ 			for (int32 i = Lane.PointsBegin + 1; i < Lane.PointsEnd; i++)
+ 			{
+ 				const FVector Point = bTransform ? FVector(LocalToWorld.TransformPosition(ZoneStorage.LanePoints[i])) : ZoneStorage.LanePoints[i];
+-				PDI->DrawLine(PrevPoint, Point, Color, SDPG_World, LineThickness, DepthBias, true);
++				PDI->DrawLine(PrevPoint, Point, Color, SDPG_Foreground, LineThickness, DepthBias, true);
+ 				PrevPoint = Point;
+ 			}
+ 		}
+@@ -359,7 +359,7 @@
+ 				const FVector ArrowOrigin = ArrowPos;
+ 				const FVector ArrowTip = ArrowPos + ArrowDir * ArrowSize;
+ 
+-				FPrimitiveSceneProxy::DrawArrowHead(PDI, ArrowTip, ArrowOrigin, ArrowSize, Color, SDPG_World, LineThickness, true);
++				FPrimitiveSceneProxy::DrawArrowHead(PDI, ArrowTip, ArrowOrigin, ArrowSize, Color, SDPG_Foreground, LineThickness, true);
+ 			}
+ 
+ 			// Draw adjacent lanes
+@@ -373,12 +373,12 @@
+ 			FZoneGraphLinkedLane LeftLinkedLane;
+ 			if (UE::ZoneGraph::Query::GetFirstLinkedLane(ZoneStorage, LaneIdx, EZoneLaneLinkType::Adjacent, EZoneLaneLinkFlags::Left, EZoneLaneLinkFlags::None, LeftLinkedLane) && LeftLinkedLane.IsValid())
+ 			{
+-				PDI->DrawLine(LaneStartPoint, LaneStartPoint + LaneStartSide * Lane.Width * 0.1f, FMath::Lerp(FLinearColor(Color), FLinearColor::Green, 0.3f), SDPG_World, LineThickness, DepthBias, true);
++				PDI->DrawLine(LaneStartPoint, LaneStartPoint + LaneStartSide * Lane.Width * 0.1f, FMath::Lerp(FLinearColor(Color), FLinearColor::Green, 0.3f), SDPG_Foreground, LineThickness, DepthBias, true);
+ 			}
+ 			FZoneGraphLinkedLane RightLinkedLane;
+ 			if (UE::ZoneGraph::Query::GetFirstLinkedLane(ZoneStorage, LaneIdx, EZoneLaneLinkType::Adjacent, EZoneLaneLinkFlags::Right, EZoneLaneLinkFlags::None, RightLinkedLane) && RightLinkedLane.IsValid())
+ 			{
+-				PDI->DrawLine(LaneStartPoint, LaneStartPoint - LaneStartSide * Lane.Width * 0.1f, FMath::Lerp(FLinearColor(Color), FLinearColor::Red, 0.3f), SDPG_World, LineThickness, DepthBias, true);
++				PDI->DrawLine(LaneStartPoint, LaneStartPoint - LaneStartSide * Lane.Width * 0.1f, FMath::Lerp(FLinearColor(Color), FLinearColor::Red, 0.3f), SDPG_Foreground, LineThickness, DepthBias, true);
+ 			}
+ 		}
+ 	}
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneGraphTypes.cpp /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphTypes.cpp
+--- Source/ZoneGraph/Private/ZoneGraphTypes.cpp	2025-02-12 20:17:25
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphTypes.cpp	2025-02-12 15:04:08
+@@ -131,7 +131,10 @@
+ 	Algo::Reverse(Lanes);
+ 	for (FZoneLaneDesc& Lane : Lanes)
+ 	{
+-		Lane.Direction = Lane.Direction == EZoneLaneDirection::Forward ? EZoneLaneDirection::Backward : EZoneLaneDirection::Forward;
++		if (Lane.Direction != EZoneLaneDirection::None)
++		{
++			Lane.Direction = Lane.Direction == EZoneLaneDirection::Forward ? EZoneLaneDirection::Backward : EZoneLaneDirection::Forward;
++		}
+ 	}
+ }
+ 
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneShapeUtilities.cpp /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp
+--- Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2025-02-12 20:17:25
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2025-02-12 20:24:11
+@@ -8,20 +8,6 @@
+ #include "ZoneGraphSettings.h"
+ #include "ZoneShapeComponent.h"
+ 
+-namespace UE::ZoneGraph::Debug {
+-
+-	bool bRemoveOverlap = true;
+-	bool bRemoveSameDestination = true;
+-	bool bFillEmptyDestination = true;
+-
+-	FAutoConsoleVariableRef VarsGeneration[] = {
+-		FAutoConsoleVariableRef(TEXT("ai.debug.zonegraph.generation.RemoveOverlap"), bRemoveOverlap, TEXT("Remove Overlapping lanes.")),
+-		FAutoConsoleVariableRef(TEXT("ai.debug.zonegraph.generation.RemoveSameDestination"), bRemoveSameDestination, TEXT("Remove merging lanes leading to same destination.")),
+-		FAutoConsoleVariableRef(TEXT("ai.debug.zonegraph.generation.FillEmptyDestination"), bFillEmptyDestination, TEXT("Fill stray empty destination lanes.")),
+-	};
+-
+-} // UE::ZoneGraph::Debug
+-
+ namespace UE::ZoneShape::Utilities {
+ 
+ // Normalizes an angle by making it in range -PI..PI. Angle in radians.
+@@ -776,6 +762,10 @@
+ 
+ static void AddAdjacentLaneLinks(const int32 CurrentLaneIndex, const int32 LaneDescIndex, const TArray<FZoneLaneDesc>& LaneDescs, TArray<FZoneShapeLaneInternalLink>& OutInternalLinks)
+ {
++	const UZoneGraphSettings* ZoneGraphSettings = GetDefault<UZoneGraphSettings>();
++	check(ZoneGraphSettings);
++	const FZoneGraphBuildSettings& BuildSettings = ZoneGraphSettings->GetBuildSettings();
++
+ 	const int32 NumLanes = LaneDescs.Num();
+ 	const FZoneLaneDesc& LaneDesc = LaneDescs[LaneDescIndex];
+ 
+@@ -802,30 +792,38 @@
+ 		ensureMsgf(false, TEXT("Lane direction %d not implemented."), int32(LaneDesc.Direction));
+ 	}
+ 
+-	if ((LaneDescIndex + 1) < NumLanes)
++	int32 NextLaneDescIndex = LaneDescIndex; 
++	while (++NextLaneDescIndex < NumLanes)
+ 	{
+-		const FZoneLaneDesc& NextLaneDesc = LaneDescs[LaneDescIndex + 1];
+-		if (NextLaneDesc.Direction != EZoneLaneDirection::None)
++		const FZoneLaneDesc& NextLaneDesc = LaneDescs[NextLaneDescIndex];
++		if (NextLaneDesc.Direction == EZoneLaneDirection::None)
+ 		{
+-			if (LaneDesc.Direction != NextLaneDesc.Direction)
+-			{
+-				NextLinkFlags |= EZoneLaneLinkFlags::OppositeDirection;
+-			}
+-			OutInternalLinks.Emplace(CurrentLaneIndex, FZoneLaneLinkData(CurrentLaneIndex + 1, EZoneLaneLinkType::Adjacent, NextLinkFlags));
++			// Skip spacer lanes and continue until we find a real lane.
++			continue;
+ 		}
++		if (LaneDesc.Direction != NextLaneDesc.Direction)
++		{
++			NextLinkFlags |= EZoneLaneLinkFlags::OppositeDirection;
++		}
++		OutInternalLinks.Emplace(CurrentLaneIndex, FZoneLaneLinkData(CurrentLaneIndex + 1, EZoneLaneLinkType::Adjacent, NextLinkFlags));
++		break;
+ 	}
+ 
+-	if ((LaneDescIndex - 1) >= 0)
++	int32 PrevLaneDescIndex = LaneDescIndex;
++	while (--PrevLaneDescIndex >= 0)
+ 	{
+-		const FZoneLaneDesc& PrevLaneDesc = LaneDescs[LaneDescIndex - 1];
+-		if (PrevLaneDesc.Direction != EZoneLaneDirection::None)
++		const FZoneLaneDesc& PrevLaneDesc = LaneDescs[PrevLaneDescIndex];
++		if (PrevLaneDesc.Direction == EZoneLaneDirection::None)
+ 		{
+-			if (LaneDesc.Direction != PrevLaneDesc.Direction)
+-			{
+-				PrevLinkFlags |= EZoneLaneLinkFlags::OppositeDirection;
+-			}
+-			OutInternalLinks.Emplace(CurrentLaneIndex, FZoneLaneLinkData(CurrentLaneIndex - 1, EZoneLaneLinkType::Adjacent, PrevLinkFlags));
++			// Skip spacer lanes and continue until we find a real lane.
++			continue;
+ 		}
++		if (LaneDesc.Direction != PrevLaneDesc.Direction)
++		{
++			PrevLinkFlags |= EZoneLaneLinkFlags::OppositeDirection;
++		}
++		OutInternalLinks.Emplace(CurrentLaneIndex, FZoneLaneLinkData(CurrentLaneIndex - 1, EZoneLaneLinkType::Adjacent, PrevLinkFlags));
++		break;
+ 	}
+ }
+ 
+@@ -1029,21 +1027,21 @@
+ 	return First;
+ }
+ 
+-static void AddOrUpdateConnection(TArray<FLaneConnectionCandidate>& Candidates, const int32 SourceSlot, const int32 DestSlot, const FZoneGraphTag Tag)
++static void AddOrUpdateConnection(TArray<FLaneConnectionCandidate>& Candidates, const int32 SourceSlot, const int32 DestSlot, const FZoneGraphTagMask& TagMask)
+ {
+ 	FLaneConnectionCandidate* Cand = Candidates.FindByPredicate([SourceSlot, DestSlot](const FLaneConnectionCandidate& Cand) -> bool { return Cand.SourceSlot == SourceSlot&& Cand.DestSlot == DestSlot; });
+ 	if (Cand != nullptr)
+ 	{
+-		Cand->TagMask = Cand->TagMask | FZoneGraphTagMask(Tag);
++		Cand->TagMask = Cand->TagMask | TagMask;
+ 	}
+ 	else
+ 	{
+-		Candidates.Add(FLaneConnectionCandidate(SourceSlot, DestSlot, FZoneGraphTagMask(Tag)));
++		Candidates.Add(FLaneConnectionCandidate(SourceSlot, DestSlot, TagMask));
+ 	}
+ }
+ 	
+ static void AppendLaneConnectionCandidates(TArray<FLaneConnectionCandidate>& Candidates, TConstArrayView<FLaneConnectionSlot> SourceSlots, TConstArrayView<FLaneConnectionSlot> DestSlots,
+-										   const FZoneGraphTag Tag, const int32 MainDestPointIndex)
++										   const FZoneGraphTagMask& TagMask, const int32 MainDestPointIndex, bool bTurning)
+ {
+ 	const int32 SourceNum = SourceSlots.Num();
+ 	const int32 DestNum = DestSlots.Num();
+@@ -1066,7 +1064,7 @@
+ 		const int32 DestIdx = CalcDestinationSide(SourceSlots, DestSlots) ? (DestNum - 1) : 0;
+ 
+ 		// If a connection exists, we'll just update the tags, otherwise create new.
+-		AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, Tag);
++		AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
+ 
+ 		return;
+ 	}
+@@ -1081,7 +1079,7 @@
+ 			const int32 SourceIdx = i;
+ 			const int32 DestIdx = BestDestLaneIndex;
+ 
+-			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, Tag);
++			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
+ 		}
+ 		
+ 		return;
+@@ -1089,41 +1087,55 @@
+ 
+ 	const bool bOneLanePerDestination = EnumHasAnyFlags(ConnectionRestrictions, EZoneShapeLaneConnectionRestrictions::OneLanePerDestination);
+ 
+-	if (SourceNum < DestNum)
++	if (bTurning)
+ 	{
+-		const int32 BestLaneIndex = CalcDestinationSide(SourceSlots, DestSlots) ? (DestNum - 1) : 0;
+-
+-		// Distribute the lanes symmetrically around that best lane.
+-		const int32 FirstIndex = FitRange(BestLaneIndex - SourceNum/2, SourceNum, DestNum);
+-
+-		for (int32 i = 0; i < DestNum; i++)
++		// Turning connections by default get fully-connected slots. The builder may filter them later.
++		for (const FLaneConnectionSlot& SourceSlot : SourceSlots)
+ 		{
+-			const int32 SourceIdxUnClamped = i - FirstIndex;
+-			if (bOneLanePerDestination && (SourceIdxUnClamped < 0 || SourceIdxUnClamped >= SourceNum))
++			for (const FLaneConnectionSlot& DestSlot : DestSlots)
+ 			{
+-				continue;
++				AddOrUpdateConnection(Candidates, SourceSlot.Index, DestSlot.Index, TagMask);
+ 			}
+-
+-			const int32 SourceIdx = FMath::Clamp(SourceIdxUnClamped, 0, SourceNum - 1);
+-			const int32 DestIdx = i;
+-			
+-			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, Tag);
+ 		}
+ 	}
+ 	else
+ 	{
+-		const int32 BestLaneIndex = CalcDestinationSide(SourceSlots, DestSlots) ? 0 : (SourceNum - 1);
+-
+-		// Distribute the lanes symmetrically around that best lane.
+-		const int32 FirstIndex = FitRange(BestLaneIndex - DestNum/2, DestNum, SourceNum);
+-		
+-		for (int32 i = 0; i < SourceNum; i++)
++		// Non-turning connections by default get one-to-one connected slots.
++		if (SourceNum < DestNum)
+ 		{
+-			const int32 SourceIdx = i;
+-			const int32 DestIdx = FMath::Clamp(i - FirstIndex, 0, DestNum - 1);
++			const int32 BestLaneIndex = CalcDestinationSide(SourceSlots, DestSlots) ? (DestNum - 1) : 0;
++
++			// Distribute the lanes symmetrically around that best lane.
++			const int32 FirstIndex = FitRange(BestLaneIndex - SourceNum/2, SourceNum, DestNum);
++
++			for (int32 i = 0; i < DestNum; i++)
++			{
++				const int32 SourceIdxUnClamped = i - FirstIndex;
++				if (bOneLanePerDestination && (SourceIdxUnClamped < 0 || SourceIdxUnClamped >= SourceNum))
++				{
++					continue;
++				}
++
++				const int32 SourceIdx = FMath::Clamp(SourceIdxUnClamped, 0, SourceNum - 1);
++				const int32 DestIdx = i;
+ 			
+-			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, Tag);
++				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++			}
+ 		}
++		else
++		{
++			const int32 BestLaneIndex = CalcDestinationSide(SourceSlots, DestSlots) ? 0 : (SourceNum - 1);
++
++			// Distribute the lanes symmetrically around that best lane.
++			const int32 FirstIndex = FitRange(BestLaneIndex - DestNum/2, DestNum, SourceNum);
++		
++			for (int32 i = 0; i < SourceNum; i++)
++			{
++				const int32 SourceIdx = i;
++				const int32 DestIdx = FMath::Clamp(i - FirstIndex, 0, DestNum - 1);
++				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++			}
++		}
+ 	}
+ }
+ 
+@@ -1244,7 +1256,10 @@
+ 
+ 	int32 MainDestPointIndex = 0;
+ 	float MainDestScore = 0;
+-	
++
++	// Cache these in case we need them later.
++	TMap<int32, EZoneGraphTurnType> DestinationTurnTypes;
++
+ 	for (int32 PointIndex = Destinations.Num() - 1; PointIndex >= 0; PointIndex--)
+ 	{
+ 		const FConnectionEntry& Dest = Destinations[PointIndex];
+@@ -1273,18 +1288,21 @@
+ 																									Dest.Profile, Dest.IncomingConnections);
+ 
+ 		const EZoneShapeLaneConnectionRestrictions Restrictions = Source.Point.GetLaneConnectionRestrictions() | RestrictionsFromRules;
+-		
++
++		// Use closest point on dest so that lane profile widths do not affect direction.
++		const FVector SourceSide = FVector::CrossProduct(SourceForward, SourceUp);
++
++		const bool bIsTurning = FVector::DotProduct(SourceForward, DirToDest) < TurnThresholdAngleCos;
++		const bool bIsLeftTurn = bIsTurning && FVector::DotProduct(SourceSide, DirToDest) > 0.0f;
++
++		DestinationTurnTypes.Add(PointIndex, bIsTurning ? (bIsLeftTurn ? EZoneGraphTurnType::Left : EZoneGraphTurnType::Right) : EZoneGraphTurnType::NoTurn);
++
+ 		// Discard destination that would result in left or right turns.
+ 		if (EnumHasAnyFlags(Restrictions, EZoneShapeLaneConnectionRestrictions::NoLeftTurn | EZoneShapeLaneConnectionRestrictions::NoRightTurn))
+ 		{
+ 			const bool bRemoveLeft = EnumHasAnyFlags(Restrictions, EZoneShapeLaneConnectionRestrictions::NoLeftTurn);
+ 			const bool bRemoveRight = EnumHasAnyFlags(Restrictions, EZoneShapeLaneConnectionRestrictions::NoRightTurn);
+-
+-			// Use closest point on dest so that lane profile widths do not affect direction.
+-			const FVector SourceSide = FVector::CrossProduct(SourceForward, SourceUp);
+ 			
+-			const bool bIsTurning = FVector::DotProduct(SourceForward, DirToDest) < TurnThresholdAngleCos;
+-			const bool bIsLeftTurn = FVector::DotProduct(SourceSide, DirToDest) > 0.0f;
+ 			if (bIsTurning)
+ 			{
+ 				const bool bSkip = bIsLeftTurn ? bRemoveLeft : bRemoveRight;
+@@ -1364,6 +1382,10 @@
+ 				continue;
+ 			}
+ 
++			FZoneGraphTagMask TagMask(Tag);
++
++			const EZoneGraphTurnType TurnType = DestinationTurnTypes[DestSlots[DestSlotsBegin].PointIndex];
++
+ 			// Collect slots that have the current flag set.
+ 			TagSourceSlots.Reset();
+ 			for (const FLaneConnectionSlot& Slot : SourceSlots)
+@@ -1385,9 +1407,23 @@
+ 				}
+ 			}
+ 
++			for (const auto& CompatibleTagsElem : BuildSettings.CompatibleTags.FilterByPredicate([Tag](const FZoneGraphCompatibleTags& Elem) { return Elem.SourceTag == Tag; }))
++			{
++				const FZoneGraphTag& DestTag = CompatibleTagsElem.DestTag;
++				for (int32 j = DestSlotsBegin; j < DestSlotsEnd; j++)
++				{
++					const FLaneConnectionSlot& DestSlot = DestSlots[j];
++					if (DestSlot.LaneDesc.Tags.ContainsAny(DestTag) && CompatibleTagsElem.CompatibleForTurnTypes.Contains(TurnType))
++					{
++						TagDestSlots.Add(DestSlot);
++						TagMask.Add(FZoneGraphTagMask(DestTag));
++					}
++				}
++			}
++
+ 			if (TagSourceSlots.Num() > 0 && TagDestSlots.Num() > 0)
+ 			{
+-				AppendLaneConnectionCandidates(Candidates, TagSourceSlots, TagDestSlots, Tag, MainDestPointIndex);
++				AppendLaneConnectionCandidates(Candidates, TagSourceSlots, TagDestSlots, TagMask, MainDestPointIndex, TurnType != EZoneGraphTurnType::NoTurn);
+ 			}
+ 		}
+ 	}
+@@ -1395,7 +1431,7 @@
+ 	// Remove overlapping lanes.
+ 	// AppendLaneConnectionCandidates() sees only source and one destination at a time.
+ 	// This code removes any overlapping lanes and handles cases such as 4-lane entry might connect to two 2-lane exits.
+-	if (UE::ZoneGraph::Debug::bRemoveOverlap)
++	if (BuildSettings.bRemoveOverlap)
+ 	{
+ 		for (int32 Index = 0; Index < Candidates.Num() - 1; Index++)
+ 		{
+@@ -1441,7 +1477,7 @@
+ 
+ 	// Remove lanes that that connect to same destination as other lanes
+ 	// This reduces the number of merging lanes when there are multiple destinations.
+-	if (UE::ZoneGraph::Debug::bRemoveSameDestination)
++	if (BuildSettings.bRemoveSameDestination)
+ 	{
+ 		TArray<int32> SourceConnectionCount;
+ 		TArray<int32> DestConnectionCount;
+@@ -1538,7 +1574,7 @@
+ 	}
+ 
+ 	
+-	if (UE::ZoneGraph::Debug::bFillEmptyDestination)
++	if (BuildSettings.bFillEmptyDestination)
+ 	{
+ 		// Fill in empty destination connections if possible.
+ 		// This usually happens when overlaps are removed, and i can leave left or right turn destinations empty.
+@@ -1599,7 +1635,7 @@
+ 
+ 	TArray<const UZoneShapeComponent*> ShapeComponentsInMap;
+ 	PointIndexToZoneShapeComponent.GenerateValueArray(ShapeComponentsInMap);
+-
++	
+ 	const bool bAllZoneShapeComponentsInMapAreValid = !ShapeComponentsInMap.Contains(nullptr);
+ 	if (bAllZoneShapeComponentsInMapAreValid)
+ 	{
+@@ -1795,7 +1831,7 @@
+ 	TArray<int32> IncomingConnections;
+ 	OutgoingConnections.Init(0, Points.Num());
+ 	IncomingConnections.Init(0, Points.Num());
+-	
++
+ 	for (int32 SourceIdx = 0; SourceIdx < Points.Num(); SourceIdx++)
+ 	{
+ 		const FZoneShapePoint& SourcePoint = Points[SourceIdx];
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Public/ZoneGraphTypes.h /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h
+--- Source/ZoneGraph/Public/ZoneGraphTypes.h	2025-02-12 20:17:25
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h	2025-02-12 15:04:54
+@@ -968,7 +968,30 @@
+ 	int32 ConnectionRestrictions = 0;
+ };
+ 
++UENUM(BlueprintType)
++enum class EZoneGraphTurnType : uint8
++{
++	Right,
++	Left,
++	NoTurn,
++};
++
+ USTRUCT()
++struct ZONEGRAPH_API FZoneGraphCompatibleTags
++{
++	GENERATED_BODY()
++
++	UPROPERTY(Category = CompatibleTags, EditAnywhere)
++	FZoneGraphTag SourceTag;
++
++	UPROPERTY(Category = CompatibleTags, EditAnywhere)
++	FZoneGraphTag DestTag;
++
++	UPROPERTY(Category = CompatibleTags, EditAnywhere)
++	TSet<EZoneGraphTurnType> CompatibleForTurnTypes;
++};
++
++USTRUCT()
+ struct ZONEGRAPH_API FZoneGraphBuildSettings
+ {
+ 	GENERATED_BODY()
+@@ -1004,6 +1027,22 @@
+ 	/** Routing rules applied to polygon shapes */
+ 	UPROPERTY(Category = Lanes, EditAnywhere)
+ 	TArray<FZoneGraphLaneRoutingRule> PolygonRoutingRules;
++
++	/** Tags which should be connected for certain turn types even when they are not the same. */
++	UPROPERTY(Category = Lanes, EditAnywhere)
++	TArray<FZoneGraphCompatibleTags> CompatibleTags;
++
++	/** Whether to remove overlapping lane connections. */
++	UPROPERTY(Category = Lanes, EditAnywhere)
++	bool bRemoveOverlap = true;
++
++	/** Whether to remove lane connections when another already has the same destination. */
++	UPROPERTY(Category = Lanes, EditAnywhere)
++	bool bRemoveSameDestination = true;
++
++	/** Whether to fill empty destination connections if possible. */
++	UPROPERTY(Category = Lanes, EditAnywhere)
++	bool bFillEmptyDestination = true;
+ 
+ 	/** Max distance between two shape points for them to be snapped together. */
+ 	UPROPERTY(Category = PointSnapping, EditAnywhere)

--- a/EngineMods/EngineMods.json
+++ b/EngineMods/EngineMods.json
@@ -23,7 +23,8 @@
       "Type": "Plugin",
       "Root": "Engine/Plugins/Runtime/ZoneGraph",
       "Patch": [
-          "ZoneGraph.patch.2"
+          "ZoneGraph.patch.2",
+          "ZoneGraph.patch.3"
       ]
     },
     {

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
@@ -536,7 +536,7 @@ void ChooseLaneForLaneChange(
 	FMassTrafficLaneChangeRecommendation& InOutRecommendation
 )
 {
-	const bool bAlreadyChoseLane = InOutRecommendation.Lane_Chosen;
+	const bool bAlreadyChoseLane = InOutRecommendation.Lane_Chosen != nullptr;
 	if (!bAlreadyChoseLane)
 	{
 		InOutRecommendation = FMassTrafficLaneChangeRecommendation();

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
@@ -542,12 +542,6 @@ void ChooseLaneForLaneChange(
 		InOutRecommendation = FMassTrafficLaneChangeRecommendation();
 	}
 
-	if (InOutRecommendation.Level == EMassTrafficLaneChangeRecommendationLevel::MustLaneChangeNow)
-	{
-		// We must lane change. Don't bother checking the rest of the conditions.
-		return;
-	}
-
 	if (!TrafficLaneData_Initial->ConstData.bIsLaneChangingLane)
 	{
 		// Can't change lanes while in an intersection.

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
@@ -28,36 +28,7 @@ bool TrunkVehicleLaneCheck(
 		(TrafficLaneData->ConstData.bIsTrunkLane || !VehicleControlFragment.bRestrictedToTrunkLanesOnly);
 }
 
-int32 GetLaneChangePriority(
-	const FZoneGraphTrafficLaneData* TrafficLaneData,
-	const FMassTrafficVehicleControlFragment& VehicleControlFragment,
-	const FZoneGraphStorage& ZoneGraphStorage)
-{
-	if (TrafficLaneData == nullptr)
-	{
-		return INDEX_NONE;
-	}
-	
-	FZoneGraphTagMask LaneTagMask;
-	if (!UE::ZoneGraph::Query::GetLaneTags(ZoneGraphStorage, TrafficLaneData->LaneHandle, LaneTagMask))
-	{
-		return INDEX_NONE;
-	}
-	
-	for (int32 PriorityIndex = 0; PriorityIndex < VehicleControlFragment.LaneChangePriorityFilters.Num(); ++PriorityIndex)
-	{
-		const FZoneGraphTagFilter& LaneChangePriorityFilter = VehicleControlFragment.LaneChangePriorityFilters[PriorityIndex];
-		
-		if (LaneChangePriorityFilter.Pass(LaneTagMask))
-		{
-			return VehicleControlFragment.LaneChangePriorityFilters.Num() - 1 - PriorityIndex;
-		}
-	}
 
-	return INDEX_NONE;
-}
-
-	
 void CanVehicleLaneChangeToFitOnChosenLane(
 	const float DistanceAlongLane_Chosen, const float LaneLength_Chosen, const float DeltaDistanceAlongLaneForLaneChange_Chosen,
 	//
@@ -562,12 +533,21 @@ void ChooseLaneForLaneChange(
 	const FRandomStream& RandomStream,
 	const UMassTrafficSettings& MassTrafficSettings,
 	const FZoneGraphStorage& ZoneGraphStorage,
-	FMassTrafficLaneChangeRecommendation& OutRecommendation
+	FMassTrafficLaneChangeRecommendation& InOutRecommendation
 )
 {
-	OutRecommendation = FMassTrafficLaneChangeRecommendation();
+	const bool bAlreadyChoseLane = InOutRecommendation.Lane_Chosen;
+	if (!bAlreadyChoseLane)
+	{
+		InOutRecommendation = FMassTrafficLaneChangeRecommendation();
+	}
 
-	
+	if (InOutRecommendation.Level == EMassTrafficLaneChangeRecommendationLevel::MustLaneChangeNow)
+	{
+		// We must lane change. Don't bother checking the rest of the conditions.
+		return;
+	}
+
 	if (!TrafficLaneData_Initial->ConstData.bIsLaneChangingLane)
 	{
 		// Can't change lanes while in an intersection.
@@ -586,10 +566,9 @@ void ChooseLaneForLaneChange(
 	
 	// Get left and right lane candidates.
 
-	FZoneGraphTrafficLaneData* CandidateTrafficLaneData_Left = TrafficLaneData_Initial->LeftLane;
-	FZoneGraphTrafficLaneData* CandidateTrafficLaneData_Right = TrafficLaneData_Initial->RightLane;
+	FZoneGraphTrafficLaneData* CandidateTrafficLaneData_Left = !bAlreadyChoseLane || InOutRecommendation.bChoseLaneOnLeft ? TrafficLaneData_Initial->LeftLane : nullptr;
+	FZoneGraphTrafficLaneData* CandidateTrafficLaneData_Right = !bAlreadyChoseLane || InOutRecommendation.bChoseLaneOnRight ? TrafficLaneData_Initial->RightLane : nullptr;
 
-	
 	// Get candidate lane densities.
 
 	const float DownstreamFlowDensity_Current = TrafficLaneData_Initial->GetDownstreamFlowDensity();
@@ -614,30 +593,33 @@ void ChooseLaneForLaneChange(
 	
 	CandidateTrafficLaneData_Right = FilterLaneForLaneChangeSuitability(
 		CandidateTrafficLaneData_Right, *TrafficLaneData_Initial, VehicleControlFragment, SpaceTakenByVehicleOnLane);
-
-	// Get lane change priority.
-	const int32 LeftLaneChangePriority = GetLaneChangePriority(CandidateTrafficLaneData_Left, VehicleControlFragment, ZoneGraphStorage);
-	const int32 RightLaneChangePriority = GetLaneChangePriority(CandidateTrafficLaneData_Right, VehicleControlFragment, ZoneGraphStorage);
-
-	const bool bHasLeftLaneChangePriority = LeftLaneChangePriority >= 0;
-	const bool bHasRightLaneChangePriority = RightLaneChangePriority >= 0;
-
-	// Filter lanes based on lane change priority.
-	if (bHasLeftLaneChangePriority && bHasRightLaneChangePriority)
+	
+	if (!bAlreadyChoseLane)
 	{
-		// If both candidate lanes have a valid lane change priority value, keep the one with the higher priority.
-		// If they have equal priority, then keep both.  In this case, it will fall to the density logic
-		// to decide between them, then finally a random choice.
-		CandidateTrafficLaneData_Left = LeftLaneChangePriority >= RightLaneChangePriority ? CandidateTrafficLaneData_Left : nullptr;
-		CandidateTrafficLaneData_Right = RightLaneChangePriority >= LeftLaneChangePriority ? CandidateTrafficLaneData_Right : nullptr;
-	}
-	else
-	{
-		// Remove candidate lanes as an option, if they don't have a valid lane change priority value.
-		// If this is the case, it means they are not compatible with any of the LaneChangePriorityFilters
-		// on the VehicleControlFragment.
-		CandidateTrafficLaneData_Left = bHasLeftLaneChangePriority ? CandidateTrafficLaneData_Left : nullptr;
-		CandidateTrafficLaneData_Right = bHasRightLaneChangePriority ? CandidateTrafficLaneData_Right : nullptr;
+		// Get lane change priority.
+		const int32 LeftLaneChangePriority = GetLanePriority(CandidateTrafficLaneData_Left, VehicleControlFragment.LaneChangePriorityFilters, ZoneGraphStorage);
+		const int32 RightLaneChangePriority = GetLanePriority(CandidateTrafficLaneData_Right, VehicleControlFragment.LaneChangePriorityFilters, ZoneGraphStorage);
+
+		const bool bHasLeftLaneChangePriority = LeftLaneChangePriority >= 0;
+		const bool bHasRightLaneChangePriority = RightLaneChangePriority >= 0;
+
+		// Filter lanes based on lane change priority.
+		if (bHasLeftLaneChangePriority && bHasRightLaneChangePriority)
+		{
+			// If both candidate lanes have a valid lane change priority value, keep the one with the higher priority.
+			// If they have equal priority, then keep both.  In this case, it will fall to the density logic
+			// to decide between them, then finally a random choice.
+			CandidateTrafficLaneData_Left = LeftLaneChangePriority >= RightLaneChangePriority ? CandidateTrafficLaneData_Left : nullptr;
+			CandidateTrafficLaneData_Right = RightLaneChangePriority >= LeftLaneChangePriority ? CandidateTrafficLaneData_Right : nullptr;
+		}
+		else
+		{
+			// Remove candidate lanes as an option, if they don't have a valid lane change priority value.
+			// If this is the case, it means they are not compatible with any of the LaneChangePriorityFilters
+			// on the VehicleControlFragment.
+			CandidateTrafficLaneData_Left = bHasLeftLaneChangePriority ? CandidateTrafficLaneData_Left : nullptr;
+			CandidateTrafficLaneData_Right = bHasRightLaneChangePriority ? CandidateTrafficLaneData_Right : nullptr;
+		}
 	}
 	
 	// If the lane is transversing (has replaced merging and splitting) lanes, then this car should be more likely
@@ -671,24 +653,24 @@ void ChooseLaneForLaneChange(
 		if (TestTransverseCandidateTrafficLaneData(
 			(bTestLeftFirst ? CandidateTrafficLaneData_Left : CandidateTrafficLaneData_Right), bTestLeftFirst))
 		{
-			OutRecommendation.Lane_Chosen = (bTestLeftFirst ? CandidateTrafficLaneData_Left : CandidateTrafficLaneData_Right);
-			OutRecommendation.bChoseLaneOnRight = !bTestLeftFirst;
-			OutRecommendation.bChoseLaneOnLeft = bTestLeftFirst;
-			OutRecommendation.Level = TransversingLaneChange;
+			InOutRecommendation.Lane_Chosen = (bTestLeftFirst ? CandidateTrafficLaneData_Left : CandidateTrafficLaneData_Right);
+			InOutRecommendation.bChoseLaneOnRight = !bTestLeftFirst;
+			InOutRecommendation.bChoseLaneOnLeft = bTestLeftFirst;
+			InOutRecommendation.Level = TransversingLaneChange;
 			return;
 		}
 		else if (TestTransverseCandidateTrafficLaneData(
 			(!bTestLeftFirst ? CandidateTrafficLaneData_Left : CandidateTrafficLaneData_Right), !bTestLeftFirst))
 		{
-			OutRecommendation.Lane_Chosen = (!bTestLeftFirst ? CandidateTrafficLaneData_Left : CandidateTrafficLaneData_Right);
-			OutRecommendation.bChoseLaneOnRight = bTestLeftFirst;
-			OutRecommendation.bChoseLaneOnLeft = !bTestLeftFirst;
-			OutRecommendation.Level = TransversingLaneChange;
+			InOutRecommendation.Lane_Chosen = (!bTestLeftFirst ? CandidateTrafficLaneData_Left : CandidateTrafficLaneData_Right);
+			InOutRecommendation.bChoseLaneOnRight = bTestLeftFirst;
+			InOutRecommendation.bChoseLaneOnLeft = !bTestLeftFirst;
+			InOutRecommendation.Level = TransversingLaneChange;
 			return;
 		}
 		else
 		{
-			OutRecommendation.Level = StayOnCurrentLane_RetrySoon; // ..make lane change on transverse lanes more likely than on normal lanes
+			InOutRecommendation.Level = StayOnCurrentLane_RetrySoon; // ..make lane change on transverse lanes more likely than on normal lanes
 			return;
 		}
 	}
@@ -700,16 +682,16 @@ void ChooseLaneForLaneChange(
 	}
 	else if (CandidateTrafficLaneData_Left && !CandidateTrafficLaneData_Right)
 	{
-		OutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Left;
-		OutRecommendation.bChoseLaneOnLeft = true;
-		OutRecommendation.Level = NormalLaneChange;			
+		InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Left;
+		InOutRecommendation.bChoseLaneOnLeft = true;
+		InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;			
 		return;
 	}
 	else if (!CandidateTrafficLaneData_Left && CandidateTrafficLaneData_Right)
 	{
-		OutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Right;
-		OutRecommendation.bChoseLaneOnRight = true;
-		OutRecommendation.Level = NormalLaneChange;			
+		InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Right;
+		InOutRecommendation.bChoseLaneOnRight = true;
+		InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;			
 		return;
 	}
 	else if (CandidateTrafficLaneData_Left && CandidateTrafficLaneData_Right)
@@ -718,32 +700,32 @@ void ChooseLaneForLaneChange(
 		
 		if (DownstreamFlowDensity_Candidate_Left < DownstreamFlowDensity_Candidate_Right)
 		{
-			OutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Left;
-			OutRecommendation.bChoseLaneOnLeft = true;
-			OutRecommendation.Level = NormalLaneChange;
+			InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Left;
+			InOutRecommendation.bChoseLaneOnLeft = true;
+			InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;
 			return;				
 		}
 		else if (DownstreamFlowDensity_Candidate_Right < DownstreamFlowDensity_Candidate_Left) 
 		{
-			OutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Right;
-			OutRecommendation.bChoseLaneOnRight = true;
-			OutRecommendation.Level = NormalLaneChange;
+			InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Right;
+			InOutRecommendation.bChoseLaneOnRight = true;
+			InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;
 			return;
 		}
 		else // ..not as rare as you'd guess - happens (1) with float-16 density values (2) when density is zero
 		{
 			if (RandomStream.FRand() < 0.5f)
 			{
-				OutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Left;
-				OutRecommendation.bChoseLaneOnLeft = true;
-				OutRecommendation.Level = NormalLaneChange;
+				InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Left;
+				InOutRecommendation.bChoseLaneOnLeft = true;
+				InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;
 				return;
 			}
 			else
 			{
-				OutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Right;
-				OutRecommendation.bChoseLaneOnRight = true;
-				OutRecommendation.Level = NormalLaneChange;
+				InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Right;
+				InOutRecommendation.bChoseLaneOnRight = true;
+				InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;
 				return;
 			}
 		}

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
@@ -678,14 +678,14 @@ void ChooseLaneForLaneChange(
 	{
 		InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Left;
 		InOutRecommendation.bChoseLaneOnLeft = true;
-		InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;			
+		InOutRecommendation.Level = bAlreadyChoseLane ? TurningLaneChange : NormalLaneChange;			
 		return;
 	}
 	else if (!CandidateTrafficLaneData_Left && CandidateTrafficLaneData_Right)
 	{
 		InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Right;
 		InOutRecommendation.bChoseLaneOnRight = true;
-		InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;			
+		InOutRecommendation.Level = bAlreadyChoseLane ? TurningLaneChange : NormalLaneChange;			
 		return;
 	}
 	else if (CandidateTrafficLaneData_Left && CandidateTrafficLaneData_Right)
@@ -696,14 +696,14 @@ void ChooseLaneForLaneChange(
 		{
 			InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Left;
 			InOutRecommendation.bChoseLaneOnLeft = true;
-			InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;
+			InOutRecommendation.Level = bAlreadyChoseLane ? TurningLaneChange : NormalLaneChange;
 			return;				
 		}
 		else if (DownstreamFlowDensity_Candidate_Right < DownstreamFlowDensity_Candidate_Left) 
 		{
 			InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Right;
 			InOutRecommendation.bChoseLaneOnRight = true;
-			InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;
+			InOutRecommendation.Level = bAlreadyChoseLane ? TurningLaneChange : NormalLaneChange;
 			return;
 		}
 		else // ..not as rare as you'd guess - happens (1) with float-16 density values (2) when density is zero
@@ -712,14 +712,14 @@ void ChooseLaneForLaneChange(
 			{
 				InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Left;
 				InOutRecommendation.bChoseLaneOnLeft = true;
-				InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;
+				InOutRecommendation.Level = bAlreadyChoseLane ? TurningLaneChange : NormalLaneChange;
 				return;
 			}
 			else
 			{
 				InOutRecommendation.Lane_Chosen = CandidateTrafficLaneData_Right;
 				InOutRecommendation.bChoseLaneOnRight = true;
-				InOutRecommendation.Level = bAlreadyChoseLane ? MustLaneChangeSoon : NormalLaneChange;
+				InOutRecommendation.Level = bAlreadyChoseLane ? TurningLaneChange : NormalLaneChange;
 				return;
 			}
 		}

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficUtils.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficUtils.cpp
@@ -225,6 +225,33 @@ LaneTurnType GetLaneTurnType(const uint32 LaneIndex, const FZoneGraphStorage& Zo
 	}
 }
 
+int32 GetLanePriority(
+	const FZoneGraphTrafficLaneData* TrafficLaneData,
+	const FMassTrafficLanePriorityFilters& LanePriorityFilters,
+	const FZoneGraphStorage& ZoneGraphStorage)
+{
+	if (TrafficLaneData == nullptr)
+	{
+		return INDEX_NONE;
+	}
 
+	FZoneGraphTagMask LaneTagMask;
+	if (!UE::ZoneGraph::Query::GetLaneTags(ZoneGraphStorage, TrafficLaneData->LaneHandle, LaneTagMask))
+	{
+		return INDEX_NONE;
+	}
+
+	for (int32 PriorityIndex = 0; PriorityIndex < LanePriorityFilters.LaneTagFilters.Num(); ++PriorityIndex)
+	{
+		const FZoneGraphTagFilter& LaneChangePriorityFilter = LanePriorityFilters.LaneTagFilters[PriorityIndex];
+
+		if (LaneChangePriorityFilter.Pass(LaneTagMask))
+		{
+			return LanePriorityFilters.LaneTagFilters.Num() - 1 - PriorityIndex;
+		}
+	}
+
+	return INDEX_NONE;
+}
 
 }

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleSimulationTrait.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleSimulationTrait.cpp
@@ -52,6 +52,8 @@ void UMassTrafficVehicleSimulationTrait::BuildTemplate(FMassEntityTemplateBuildC
 	VehicleControlFragment.bAllowRightTurnsAtIntersections = Params.bAllowRightTurnsAtIntersections;
 	VehicleControlFragment.bAllowGoingStraightAtIntersections = Params.bAllowGoingStraightAtIntersections;
 	VehicleControlFragment.LaneChangePriorityFilters = Params.LaneChangePriorityFilters;
+	VehicleControlFragment.NextLanePriorityFilters = Params.NextLanePriorityFilters;
+	VehicleControlFragment.TurningLanePriorityFilters = Params.TurningLanePriorityFilters;
 
 	// Variable tick
 	BuildContext.AddFragment<FMassSimulationVariableTickFragment>();

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
@@ -700,7 +700,11 @@ struct MASSTRAFFIC_API FMassTrafficVehicleControlFragment : public FMassFragment
 	bool bAllowRightTurnsAtIntersections = true;
 	bool bAllowGoingStraightAtIntersections = true;
 
-	TArray<FZoneGraphTagFilter> LaneChangePriorityFilters;
+	FMassTrafficLanePriorityFilters LaneChangePriorityFilters;
+
+	FMassTrafficLanePriorityFilters NextLanePriorityFilters;
+
+	TMap<EZoneGraphTurnType, FMassTrafficLanePriorityFilters> TurningLanePriorityFilters;
 
 	// Fields used for both pre-emptive and reactive yields.
 	FZoneGraphTrafficLaneData* YieldAtIntersectionLane = nullptr;

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
@@ -64,7 +64,7 @@ enum EMassTrafficLaneChangeRecommendationLevel
 	
 	NormalLaneChange = 2,
 	TransversingLaneChange = 3,
-	MustLaneChangeSoon = 4
+	TurningLaneChange = 4
 };
 
 

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
@@ -64,8 +64,7 @@ enum EMassTrafficLaneChangeRecommendationLevel
 	
 	NormalLaneChange = 2,
 	TransversingLaneChange = 3,
-	MustLaneChangeSoon = 4,
-	MustLaneChangeNow = 5
+	MustLaneChangeSoon = 4
 };
 
 

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
@@ -63,7 +63,9 @@ enum EMassTrafficLaneChangeRecommendationLevel
 	StayOnCurrentLane_RetrySoon = 1,
 	
 	NormalLaneChange = 2,
-	TransversingLaneChange = 3
+	TransversingLaneChange = 3,
+	MustLaneChangeSoon = 4,
+	MustLaneChangeNow = 5
 };
 
 
@@ -76,15 +78,10 @@ struct FMassTrafficLaneChangeRecommendation
 	bool bNoLaneChangesUntilNextLane = false;
 };
 
-	
+
 bool TrunkVehicleLaneCheck(const FZoneGraphTrafficLaneData* TrafficLaneData, const FMassTrafficVehicleControlFragment& VehicleControlFragment);
 
-int32 GetLaneChangePriority(
-	const FZoneGraphTrafficLaneData* TrafficLaneData,
-	const FMassTrafficVehicleControlFragment& VehicleControlFragment,
-	const FZoneGraphStorage& ZoneGraphStorage);
 
-	
 FORCEINLINE bool AreVehiclesCurrentlyApproachingLaneFromIntersection(const FZoneGraphTrafficLaneData& TrafficLaneData) 
 {
 	return TrafficLaneData.bIsDownstreamFromIntersection && TrafficLaneData.NumVehiclesApproachingLane > 0;
@@ -205,7 +202,7 @@ void ChooseLaneForLaneChange(
 	const FRandomStream& RandomStream,
 	const UMassTrafficSettings& MassTrafficSettings,
 	const FZoneGraphStorage& ZoneGraphStorage,
-	FMassTrafficLaneChangeRecommendation& OutRecommendation);
+	FMassTrafficLaneChangeRecommendation& InOutRecommendation);
 
 bool CheckNextVehicle(const FMassEntityHandle Entity, const FMassEntityHandle NextEntity, const FMassEntityManager& EntityManager);
 

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficTypes.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficTypes.h
@@ -673,3 +673,12 @@ struct MASSTRAFFIC_API FMassTrafficZoneGraphData
 		return TrafficLaneDataLookup[LaneIndex];
 	}
 };
+
+USTRUCT(BlueprintType)
+struct MASSTRAFFIC_API FMassTrafficLanePriorityFilters
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TArray<FZoneGraphTagFilter> LaneTagFilters;
+};

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficUtils.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficUtils.h
@@ -115,6 +115,10 @@ MASSTRAFFIC_API float GetLaneStraightness(const uint32 LaneIndex, const FZoneGra
 
 MASSTRAFFIC_API LaneTurnType GetLaneTurnType(const uint32 LaneIndex, const FZoneGraphStorage& ZoneGraphStorage);
 
+int32 GetLanePriority(
+	const FZoneGraphTrafficLaneData* TrafficLaneData,
+	const FMassTrafficLanePriorityFilters& LanePriorityFilters,
+	const FZoneGraphStorage& ZoneGraphStorage);
 
 /** Lane search functions. */
 MASSTRAFFIC_API bool PointIsNearSegment(

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficVehicleSimulationTrait.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficVehicleSimulationTrait.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "MassTrafficPhysics.h"
+#include "MassTrafficTypes.h"
 
 #include "MassEntityTraitBase.h"
 #include "MassSimulationLOD.h"
@@ -54,7 +55,13 @@ struct MASSTRAFFIC_API FMassTrafficVehicleSimulationParameters : public FMassSha
 	bool bAllowGoingStraightAtIntersections = true;
 
 	UPROPERTY(EditAnywhere, Category = "Restrictions")
-	TArray<FZoneGraphTagFilter> LaneChangePriorityFilters;
+	FMassTrafficLanePriorityFilters LaneChangePriorityFilters;
+
+	UPROPERTY(EditAnywhere, Category = "Restrictions")
+	FMassTrafficLanePriorityFilters NextLanePriorityFilters;
+
+	UPROPERTY(EditAnywhere, Category = "Restrictions")
+	TMap<EZoneGraphTurnType, FMassTrafficLanePriorityFilters> TurningLanePriorityFilters;
 };
 
 USTRUCT()

--- a/Scripts/InstallEngineMods.sh
+++ b/Scripts/InstallEngineMods.sh
@@ -71,29 +71,27 @@ MOD_PATCH() {
     return 0
   fi
 
-  # Reverse the order of patches
-  local REVERSED_PATCHES=($(printf '%s\n' "${FORWARD_PATCHES[@]}" | sed -n '1!G;h;$p'))
   local PATCHES_APPLIED=0
 
   # Find the last applied patch (if any)
   cd "$DEST"
-  local LAST_APPLIED_INDEX=$((${#FORWARD_PATCHES[@]} - 1))
-  for ((i=0; i<${#REVERSED_PATCHES[@]}; i++)); do
-    local PATCH="$ENGINE_MODS_DIR/$ROOT/${REVERSED_PATCHES[i]//\'/}"
+  local LAST_APPLIED_INDEX=-1
+  for ((i=${#FORWARD_PATCHES[@]}-1; i>-1; i--)); do
+    local PATCH="$ENGINE_MODS_DIR/$ROOT/${FORWARD_PATCHES[i]//\'/}"
     # To check if the patch has been applied, check if it can be *reversed* (if not, it hasn't been applied).
     # https://unix.stackexchange.com/questions/55780/check-if-a-file-or-folder-has-been-patched-already
-    if patch -R -p0 -s -f --dry-run <"$PATCH" >/dev/null 2>&1; then
+    if patch -R -p0 -s -f --ignore-whitespace --dry-run <"$PATCH" >/dev/null 2>&1; then
       echo "Patch $(basename "$PATCH") already applied"
-      LAST_APPLIED_INDEX=$((${#FORWARD_PATCHES[@]} - i))
+      LAST_APPLIED_INDEX="$i"
       break
     fi
   done
 
   # Apply all patches after the last applied one
-  for ((i=LAST_APPLIED_INDEX; i<${#FORWARD_PATCHES[@]}; i++)); do
+  for ((i=LAST_APPLIED_INDEX + 1; i<${#FORWARD_PATCHES[@]}; i++)); do
     local PATCH="$ENGINE_MODS_DIR/$ROOT/${FORWARD_PATCHES[i]//\'/}"
     echo "Applying Patch $(basename "$PATCH")"
-    if ! patch -p0 <"$PATCH" >/dev/null 2>&1; then
+    if ! patch -p0  --ignore-whitespace <"$PATCH" >/dev/null 2>&1; then
       echo "Failed to apply patch: $PATCH"
       exit 1
     fi

--- a/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
+++ b/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
@@ -31,15 +31,6 @@ void UTempoRoadLaneGraphSubsystem::SetupZoneGraphBuilder()
 
 bool UTempoRoadLaneGraphSubsystem::TryGenerateZoneShapeComponents() const
 {
-	IConsoleVariable* RemoveOverlapCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("ai.debug.zonegraph.generation.RemoveOverlap"));
-	if (ensureMsgf(RemoveOverlapCVar != nullptr, TEXT("Tried to disable console variable \"ai.debug.zonegraph.generation.RemoveOverlap\" for Tempo Lane Graph, but it was not found.")))
-	{
-		// Disable the removal of "overlapping" lanes.
-		// We want a fully-connected intersection graph for now.
-		// Later, we will prune the intersection graph more intelligently with tags, or other metadata.
-		RemoveOverlapCVar->Set(false);
-	}
-
 	// Allow all Intersections to setup their data, first.
 	for (AActor* Actor : TActorRange<AActor>(GetWorld()))
 	{

--- a/TempoAgents/Source/TempoAgentsEditor/Private/TempoZoneGraphBuilder.cpp
+++ b/TempoAgents/Source/TempoAgentsEditor/Private/TempoZoneGraphBuilder.cpp
@@ -20,9 +20,13 @@ bool FTempoZoneGraphBuilder::ShouldFilterLaneConnection(const UZoneShapeComponen
 
 	const TArray<FTempoLaneConnectionInfo>& SourceLaneConnectionInfos = GenerateTempoLaneConnectionInfoArray(SourceSlots);
 	const TArray<FTempoLaneConnectionInfo>& DestLaneConnectionInfos = GenerateTempoLaneConnectionInfoArray(DestSlots);
-	
-	const bool bShouldFilterLaneConnection = ITempoIntersectionInterface::Execute_ShouldFilterTempoLaneConnection(IntersectionQueryActor, SourceRoadQueryActor, SourceLaneConnectionInfos, SourceSlotQueryIndex, DestRoadQueryActor, DestLaneConnectionInfos, DestSlotQueryIndex);
-	
+
+	bool bShouldFilterLaneConnection;
+	{
+		FEditorScriptExecutionGuard ScriptGuard;
+		bShouldFilterLaneConnection = ITempoIntersectionInterface::Execute_ShouldFilterTempoLaneConnection(IntersectionQueryActor, SourceRoadQueryActor, SourceLaneConnectionInfos, SourceSlotQueryIndex, DestRoadQueryActor, DestLaneConnectionInfos, DestSlotQueryIndex);
+	}
+
 	return bShouldFilterLaneConnection;
 }
 

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
@@ -242,7 +242,7 @@ bool UTempoIntersectionQueryComponent::ShouldFilterLaneConnection(const AActor* 
 		const bool bSourceIsRightMostLane = SourceLaneConnectionInfo.LaneIndex == MinFilteredLaneIndex;
 
 		// Only allow left turns from the left-most lane and right turns from the right-most lane.
-		return (bIsLeftTurn && bSourceIsLeftMostLane) || (bIsRightTurn && bSourceIsRightMostLane);
+		return !((bIsLeftTurn && bSourceIsLeftMostLane) || (bIsRightTurn && bSourceIsRightMostLane));
 	}
 
 	return false;

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
@@ -5,6 +5,7 @@
 #include "TempoAgentsSharedTypes.h"
 
 #include "ZoneGraphBuilder.h"
+#include "ZoneShapeUtilities.h"
 
 #include "CoreMinimal.h"
 #include "UObject/Interface.h"

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
@@ -5,7 +5,6 @@
 #include "TempoAgentsSharedTypes.h"
 
 #include "ZoneGraphBuilder.h"
-#include "ZoneShapeUtilities.h"
 
 #include "CoreMinimal.h"
 #include "UObject/Interface.h"

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
@@ -8,7 +8,7 @@
 #include "TempoIntersectionInterface.h"
 #include "TempoIntersectionQueryComponent.generated.h"
 
-using TempoZoneGraphTagFilterMap = TMap<FZoneGraphTagFilter, TTuple<TArray<FTempoLaneConnectionInfo>, TArray<FTempoLaneConnectionInfo>>>;
+using TempoZoneGraphTagMaskGroups = TMap<FZoneGraphTagMask, TArray<FTempoLaneConnectionInfo>>;
 
 UCLASS( ClassGroup=(TempoIntersections), meta = (BlueprintSpawnableComponent))
 class TEMPOAGENTSSHARED_API UTempoIntersectionQueryComponent : public UActorComponent
@@ -109,9 +109,8 @@ protected:
 	
 	virtual bool TryGetNearestRoadControlPointIndex(const AActor& IntersectionQueryActor, int32 ConnectionIndex, int32& OutNearestRoadControlPointIndex) const;
 	virtual AActor* GetConnectedRoadActor(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const;
-
-	virtual bool TryGetTagFilteredLaneConnections(const AActor* SourceConnectionActor, const TArray<FTempoLaneConnectionInfo>& SourceLaneConnectionInfos, const TArray<FTempoLaneConnectionInfo>& DestLaneConnectionInfos,
-										  TempoZoneGraphTagFilterMap& OutZoneGraphTagFilterMap) const;
+	
+	virtual TempoZoneGraphTagMaskGroups GroupLaneConnectionsByTags(const AActor* SourceConnectionActor, const TArray<FTempoLaneConnectionInfo>& SourceLaneConnectionInfos, const TArray<FTempoLaneConnectionInfo>& DestLaneConnectionInfos) const;
 
 	virtual FZoneGraphTagFilter GetLaneConnectionTagFilter(const AActor* SourceConnectionActor, const FTempoLaneConnectionInfo& SourceLaneConnectionInfo) const;
 	virtual FZoneGraphTagFilter GenerateTagFilter(const TArray<FName>& AnyTags, const TArray<FName>& AllTags, const TArray<FName>& NotTags) const;


### PR DESCRIPTION
Adds several new features for setting up the connectivity of lanes through intersections and behavior of actors when choosing lanes.

ZoneGraph Changes:
- Adds the concept of "compatible tags", which are lane tag types that should be connected through an intersection despite not matching.
- Changes lane connectivity generation to create all lane connection combinations for turning lanes (every source to every destination), allowing the zone graph builder to filter them.
- Changes the adjacency logic to search past "spacer" lanes (lanes that have no direction) until a non-spacer lane is found.
- Moves three debug flags from hard-coded cpp cvars to project settings.
- Fixes a bug where !Forward was assumed to mean Backward, in the utility to reverse a lane profile (it didn't consider the None possibility).
- Draws ZoneGraph lanes in the foreground, so they are more easily visible.

TempoAgents Changes:
- Fixes a bug where the visualization of the ZoneGraph was not reflecting the lanes filtered by the TempoZoneGraphBuilder. This was fixed by adding an FEditorScriptGuard before the script call. Removes the debug drawing from TempoIntersectionQueryComponent ShouldFilterLaneConnection since the connectivity can now be observed easier in the ZoneGraph itself.
- Previously the implementation of TempoIntersectionQueryComponent grouped lanes by exactly matching tag filters when enforcing that only the right lane can turn right and only the left lane can turn left. This changes that to group lanes that have any matching tags. So, for example, if you had driving lanes and turning lanes (which are also driving lanes) they would be considered one group.

MassTraffic Changes:
- Adds two new lane priority filters to the VehicleControlFragment: NextLanePriorityFilters, for entities to specify their preference for next lanes, and TurningLanePriorityFilters, for entities to specify their preference for lanes to turn from when turning in different directions. FMassTrafficLanePriorityFilters is introduced simply because a TMap with a TArray value is not allowed.
- Moves GetLaneChangePriority to MassTrafficUtils and renames it GetLanePriority, so that it can be reused for next lanes.
- Modifies MassTrafficNextLaneProcessor to take NextLanePriorityFilters into account
- Modifies MassTrafficLaneChangeProcessor to take TurningLanePriorityFilters into account (we will attempt a lane change to the prioritized lane if making a turn of that type, before making the turn, and retry frequently if unable, but still make the turn from the non-turning lane if the lane change was not successful).

EngineMods Changes:
- Fixed a bug where applying multiple patches to clean state would not work correctly in Scripts/InstallEngineMods.sh. The whole "REVERSED_PATCHES" array is unnecessary, and the indexing was wrong.