### PR TITLE
Prevent Vehicles from Driving on Each Other or Pawns by Default

### DIFF
--- a/TempoMovement/Source/TempoVehicleMovement/Private/TempoChaosWheeledVehicleMovementComponent.cpp
+++ b/TempoMovement/Source/TempoVehicleMovement/Private/TempoChaosWheeledVehicleMovementComponent.cpp
@@ -8,6 +8,8 @@ UTempoChaosWheeledVehicleMovementComponent::UTempoChaosWheeledVehicleMovementCom
 {
 	bReverseAsBrake = false;
 	bThrottleAsBrake = false;
+	WheelTraceCollisionResponses.Vehicle = ECR_Ignore;
+	WheelTraceCollisionResponses.Pawn = ECR_Ignore;
 }
 
 void UTempoChaosWheeledVehicleMovementComponent::HandleDrivingCommand(const FDrivingCommand& Command)


### PR DESCRIPTION
Prevents vehicles from driving up onto each other or onto pawns by default by setting the wheel trace collision responses for these types to `ECR_Ignore` in the TempoChaosWheeledvehicleMovementComponent.