### PR TITLE
Enable Generating ZoneShapes for Crosswalks on Roads

### DIFF
--- a/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
+++ b/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
@@ -73,7 +73,7 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateZoneShapeComponents() const
 
 			if (Actor->Implements<UTempoCrosswalkInterface>())
 			{
-				if (!TryGenerateAndRegisterZoneShapeComponentsForCrosswalksAtIntersections(*Actor))
+				if (!TryGenerateAndRegisterZoneShapeComponentsForCrosswalks(*Actor))
 				{
 					UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Crosswalk ZoneShapeComponents for Actor: %s."), *Actor->GetName());
 					return false;
@@ -126,7 +126,7 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateZoneShapeComponents() const
 
 			if (Actor->Implements<UTempoCrosswalkInterface>())
 			{
-				if (!TryGenerateAndRegisterZoneShapeComponentsForCrosswalksAtIntersections(*Actor))
+				if (!TryGenerateAndRegisterZoneShapeComponentsForCrosswalks(*Actor))
 				{
 					UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Crosswalk ZoneShapeComponents for Actor: %s."), *Actor->GetName());
 					return false;
@@ -715,7 +715,7 @@ AActor* UTempoRoadLaneGraphSubsystem::GetConnectedRoadActor(const AActor& Inters
 // Crosswalk functions
 //
 
-bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForCrosswalksAtIntersections(AActor& CrosswalkQueryActor) const
+bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForCrosswalks(AActor& CrosswalkQueryActor) const
 {
 	const int32 NumConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalks(&CrosswalkQueryActor);
 	

--- a/TempoAgents/Source/TempoAgentsEditor/Public/TempoRoadLaneGraphSubsystem.h
+++ b/TempoAgents/Source/TempoAgentsEditor/Public/TempoRoadLaneGraphSubsystem.h
@@ -47,7 +47,7 @@ protected:
 	AActor* GetConnectedRoadActor(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const;
 	
 	// Crosswalk functions
-	bool TryGenerateAndRegisterZoneShapeComponentsForCrosswalksAtIntersections(AActor& IntersectionQueryActor) const;
+	bool TryGenerateAndRegisterZoneShapeComponentsForCrosswalks(AActor& IntersectionQueryActor) const;
 	bool TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersectionConnectorSegments(AActor& IntersectionQueryActor) const;
 	bool TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersections(AActor& IntersectionQueryActor) const;
 	bool TryCreateZoneShapePointForCrosswalkIntersectionEntranceLocation(const AActor& IntersectionQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, UZoneShapeComponent& ZoneShapeComponent, FZoneShapePoint& OutZoneShapePoint) const;

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
@@ -449,8 +449,6 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoE
 		return false;
 	}
 
-	// First Index: Is this the crosswalk intersection at the bottom or the top?
-	// Second Index: Are you inside the road module or at the extent of it?
 	const int32 CrosswalkIntersectionDistanceIndex = CrosswalkIntersectionEntranceOuterDistance < FMath::Abs(CrosswalkIntersectionEntranceOuterDistance - CrosswalkRoadModuleLength) ? 0 : 1;
 	const int32 CrosswalkIntersectionDistanceSideIndex = CrosswalkIntersectionConnectionIndex == 1 ? 0 : 1;
 	

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
@@ -8,9 +8,9 @@
 #include "TempoCrosswalkInterface.h"
 #include "TempoIntersectionInterface.h"
 #include "TempoRoadModuleInterface.h"
+#include "TempoZoneGraphUtils.h"
 
 #include "ZoneGraphSettings.h"
-#include "ZoneGraphSubsystem.h"
 
 bool UTempoIntersectionQueryComponent::TryGetIntersectionEntranceControlPointIndex(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32& OutIntersectionEntranceControlPointIndex) const
 {
@@ -264,7 +264,7 @@ bool UTempoIntersectionQueryComponent::TryGenerateCrosswalkRoadModuleMap(const A
 		return false;
 	}
 
-	const FZoneGraphTagFilter CrosswalkRoadModuleTagFilter = GenerateTagFilter(CrosswalkRoadModuleAnyTags, CrosswalkRoadModuleAllTags, CrosswalkRoadModuleNotTags);
+	const FZoneGraphTagFilter CrosswalkRoadModuleTagFilter = UTempoZoneGraphUtils::GenerateTagFilter(this, CrosswalkRoadModuleAnyTags, CrosswalkRoadModuleAllTags, CrosswalkRoadModuleNotTags);
 
 	const auto& GetCrosswalkRoadModules = [this, &IntersectionQueryActor, &CrosswalkRoadModuleTagFilter]()
 	{
@@ -287,7 +287,7 @@ bool UTempoIntersectionQueryComponent::TryGenerateCrosswalkRoadModuleMap(const A
 			{
 				const TArray<FName>& RoadModuleLaneTags = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags(ConnectedRoadModule, RoadModuleLaneIndex);
 
-				const FZoneGraphTagMask& RoadModuleLaneTagMask = GenerateTagMaskFromTagNames(RoadModuleLaneTags);
+				const FZoneGraphTagMask& RoadModuleLaneTagMask = UTempoZoneGraphUtils::GenerateTagMaskFromTagNames(this, RoadModuleLaneTags);
 
 				// Is the road module a crosswalk (according to tags)?
 				if (CrosswalkRoadModuleTagFilter.Pass(RoadModuleLaneTagMask))
@@ -449,6 +449,8 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoE
 		return false;
 	}
 
+	// First Index: Is this the crosswalk intersection at the bottom or the top?
+	// Second Index: Are you inside the road module or at the extent of it?
 	const int32 CrosswalkIntersectionDistanceIndex = CrosswalkIntersectionEntranceOuterDistance < FMath::Abs(CrosswalkIntersectionEntranceOuterDistance - CrosswalkRoadModuleLength) ? 0 : 1;
 	const int32 CrosswalkIntersectionDistanceSideIndex = CrosswalkIntersectionConnectionIndex == 1 ? 0 : 1;
 	
@@ -1434,36 +1436,7 @@ FZoneGraphTagFilter UTempoIntersectionQueryComponent::GetLaneConnectionTagFilter
 	const TArray<FName>& LaneConnectionAllTagNames = ITempoRoadInterface::Execute_GetTempoLaneConnectionAllTags(SourceConnectionActor, SourceLaneConnectionInfo.LaneIndex);
 	const TArray<FName>& LaneConnectionNotTagNames = ITempoRoadInterface::Execute_GetTempoLaneConnectionNotTags(SourceConnectionActor, SourceLaneConnectionInfo.LaneIndex);
 
-	return GenerateTagFilter(LaneConnectionAnyTagNames, LaneConnectionAllTagNames, LaneConnectionNotTagNames);
-}
-
-FZoneGraphTagFilter UTempoIntersectionQueryComponent::GenerateTagFilter(const TArray<FName>& AnyTags, const TArray<FName>& AllTags, const TArray<FName>& NotTags) const
-{
-	const FZoneGraphTagMask AnyTagsMask = GenerateTagMaskFromTagNames(AnyTags);
-	const FZoneGraphTagMask AllTagsMask = GenerateTagMaskFromTagNames(AllTags);
-	const FZoneGraphTagMask NotTagsMask = GenerateTagMaskFromTagNames(NotTags);
-
-	return FZoneGraphTagFilter{AnyTagsMask, AllTagsMask, NotTagsMask};
-}
-
-FZoneGraphTagMask UTempoIntersectionQueryComponent::GenerateTagMaskFromTagNames(const TArray<FName>& TagNames) const
-{
-	const UZoneGraphSubsystem* ZoneGraphSubsystem = UWorld::GetSubsystem<UZoneGraphSubsystem>(GetWorld());
-	if (ZoneGraphSubsystem == nullptr)
-	{
-		UE_LOG(LogTempoAgentsShared, Error, TEXT("Lane Filtering - GenerateTagMaskFromTagNames - Can't access ZoneGraphSubsystem."));
-		return FZoneGraphTagMask::None;
-	}
-
-	FZoneGraphTagMask ZoneGraphTagMask;
-	
-	for (const auto& TagName : TagNames)
-	{
-		FZoneGraphTag Tag = ZoneGraphSubsystem->GetTagByName(TagName);
-		ZoneGraphTagMask.Add(Tag);
-	}
-
-	return ZoneGraphTagMask;
+	return UTempoZoneGraphUtils::GenerateTagFilter(this, LaneConnectionAnyTagNames, LaneConnectionAllTagNames, LaneConnectionNotTagNames);
 }
 
 bool UTempoIntersectionQueryComponent::TryGetMinLaneIndexInLaneConnections(const TArray<FTempoLaneConnectionInfo>& LaneConnectionInfos, int32& OutMinLaneIndex) const

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoRoadQueryComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoRoadQueryComponent.cpp
@@ -1,4 +1,4 @@
-// Copyright Vayu Robotics, Inc. All Rights Reserved
+// Copyright Tempo Simulation, LLC. All Rights Reserved
 
 
 #include "TempoRoadQueryComponent.h"
@@ -78,15 +78,15 @@ bool UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap(const AActor* R
 
 	const TArray<AActor*> CrosswalkRoadModules = GetCrosswalkRoadModules();
 
-	if (CrosswalkRoadModules.Num() < 2)
-	{
-		return false;
-	}
-
-	if (!ensureMsgf(CrosswalkRoadModules.Num() == 2, TEXT("Only roads with 2 crosswalk road modules are handled by UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap.")))
-	{
-		return false;
-	}
+	// if (CrosswalkRoadModules.Num() < 2)
+	// {
+	// 	return false;
+	// }
+	//
+	// if (!ensureMsgf(CrosswalkRoadModules.Num() == 2, TEXT("Only roads with 2 crosswalk road modules are handled by UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap.")))
+	// {
+	// 	return false;
+	// }
 
 	const FVector RoadStartLocation = ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad(RoadQueryActor, 0.0, ETempoCoordinateSpace::World);
 	const FVector RoadStartRight = ITempoRoadInterface::Execute_GetRightVectorAtDistanceAlongTempoRoad(RoadQueryActor, 0.0, ETempoCoordinateSpace::World);
@@ -116,16 +116,16 @@ bool UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap(const AActor* R
 	AActor* LeftCrosswalkRoadModule = GetCrosswalkRoadModuleInLateralDirection(-1.0f);
 	AActor* RightCrosswalkRoadModule = GetCrosswalkRoadModuleInLateralDirection(1.0f);
 
-	if (!(LeftCrosswalkRoadModule && RightCrosswalkRoadModule))
-	{
-		// Roads must have at least one crosswalk road module on the left and the right to have crosswalk connections.
-		return false;
-	}
-
 	TMap<int32, AActor*> CrosswalkRoadModuleMap;
 	// Convention: left road module is index 0, right road module is index 1
-	CrosswalkRoadModuleMap.Add(0, LeftCrosswalkRoadModule);
-	CrosswalkRoadModuleMap.Add(1, RightCrosswalkRoadModule);
+	if (LeftCrosswalkRoadModule)
+	{
+		CrosswalkRoadModuleMap.Add(0, LeftCrosswalkRoadModule);
+	}
+	if (RightCrosswalkRoadModule)
+	{
+		CrosswalkRoadModuleMap.Add(1, RightCrosswalkRoadModule);
+	}
 
 	OutCrosswalkRoadModuleMap = CrosswalkRoadModuleMap;
 
@@ -225,35 +225,6 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLocation(const
 		}
 
 		const FVector CrosswalkEntranceLocation = ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
-
-		FColor Color;
-		if (CrosswalkIntersectionIndex == 0)
-		{
-			Color = FColor::Red;
-		}
-		if (CrosswalkIntersectionIndex == 1)
-		{
-			Color = FColor::Magenta;
-		}
-		if (CrosswalkIntersectionIndex == 2)
-		{
-			Color = FColor::Green;
-		}
-		if (CrosswalkIntersectionIndex == 3)
-		{
-			Color = FColor::Emerald;
-		}
-		if (CrosswalkIntersectionIndex == 4)
-		{
-			Color = FColor::Blue;
-		}
-		if (CrosswalkIntersectionIndex == 5)
-		{
-			Color = FColor::Cyan;
-		}
-
-		// DrawDebugPoint(CrosswalkRoadModuleActor->GetWorld(), CrosswalkEntranceLocation + 100.0 * FVector::UpVector, 60.0, Color, false, 20.0, 0);
-
 		OutCrosswalkIntersectionEntranceLocation = CrosswalkEntranceLocation;
 	}
 
@@ -288,7 +259,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent(const 
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
 		const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
-		const float DirectionScalar = !bIsLeftSide ? 1.0f : -1.0f;
+		const float DirectionScalar = bIsLeftSide ? -1.0f : 1.0f;
 
 		// The actual CrosswalkIntersection's entrance tangent is based on the road's right vector at the crosswalk.
 		const float DistanceAlongRoad = GetDistanceAlongTempoRoadAtCrosswalk(RoadQueryActor, CrosswalkIndex);

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoRoadQueryComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoRoadQueryComponent.cpp
@@ -78,15 +78,10 @@ bool UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap(const AActor* R
 
 	const TArray<AActor*> CrosswalkRoadModules = GetCrosswalkRoadModules();
 
-	// if (CrosswalkRoadModules.Num() < 2)
-	// {
-	// 	return false;
-	// }
-	//
-	// if (!ensureMsgf(CrosswalkRoadModules.Num() == 2, TEXT("Only roads with 2 crosswalk road modules are handled by UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap.")))
-	// {
-	// 	return false;
-	// }
+	if (!ensureMsgf(CrosswalkRoadModules.Num() == 2, TEXT("Only roads with 2 crosswalk road modules are handled by UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap.")))
+	{
+		return false;
+	}
 
 	const FVector RoadStartLocation = ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad(RoadQueryActor, 0.0, ETempoCoordinateSpace::World);
 	const FVector RoadStartRight = ITempoRoadInterface::Execute_GetRightVectorAtDistanceAlongTempoRoad(RoadQueryActor, 0.0, ETempoCoordinateSpace::World);
@@ -164,21 +159,21 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry(con
 	}
 
 	const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
-	const FCrosswalkIntersectionConnectorSegmentInfo* CrosswalkIntersectionConnectorSegmentInfoBefore =
+	const FCrosswalkIntersectionConnectorSegmentInfo* CrosswalkIntersectionConnectorSegmentInfoPrevious =
 		CrosswalkIntersectionConnectorInfo->CrosswalkIntersectionConnectorSegmentInfos.FindByPredicate([CrosswalkIndex](const auto& Elem) { return Elem.CrosswalkIndexAtEnd == CrosswalkIndex; });
-	const FCrosswalkIntersectionConnectorSegmentInfo* CrosswalkIntersectionConnectorSegmentInfoAfter =
+	const FCrosswalkIntersectionConnectorSegmentInfo* CrosswalkIntersectionConnectorSegmentInfoNext =
 		CrosswalkIntersectionConnectorInfo->CrosswalkIntersectionConnectorSegmentInfos.FindByPredicate([CrosswalkIndex](const auto& Elem) { return Elem.CrosswalkIndexAtStart == CrosswalkIndex; });
-	const float EndDistanceBefore = CrosswalkIntersectionConnectorSegmentInfoBefore->CrosswalkIntersectionConnectorEndDistance;
-	const float StartDistanceAfter = CrosswalkIntersectionConnectorSegmentInfoAfter->CrosswalkIntersectionConnectorStartDistance;
+	const float EndDistancePrevious = CrosswalkIntersectionConnectorSegmentInfoPrevious->CrosswalkIntersectionConnectorEndDistance;
+	const float StartDistanceNext = CrosswalkIntersectionConnectorSegmentInfoNext->CrosswalkIntersectionConnectorStartDistance;
 
 	OutCrosswalkRoadModule = CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule;
 
 	// Connection indexing is clockwise from above with 0 at the crosswalk entrance.
-	// So on the left side CrosswalkIntersectionConnectionIndex 1 is the start and 2 is the end.
-	// And on the left side CrosswalkIntersectionConnectionIndex 2 is the start and 1 is the end.
+	// So on the left side CrosswalkIntersectionConnectionIndex 1 is the end of the previous connector and 2 is the start of the next connector.
+	// And on the right side CrosswalkIntersectionConnectionIndex 2 is the end of the previous connector and 1 is the start of the next connector.
 	// RoadModule index 0 is left by convention.
 	const bool bIsLeftSide = CrosswalkRoadModuleIndex == 0;
-	OutCrosswalkIntersectionConnectorDistance = CrosswalkIntersectionConnectionIndex == (bIsLeftSide ? 1 : 2) ? EndDistanceBefore : StartDistanceAfter;
+	OutCrosswalkIntersectionConnectorDistance = CrosswalkIntersectionConnectionIndex == (bIsLeftSide ? 1 : 2) ? EndDistancePrevious : StartDistanceNext;
 
 	return true;
 }
@@ -277,8 +272,8 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent(const 
 		}
 
 		// Connection indexing is clockwise from above with 0 at the crosswalk entrance.
-		// So on the left side CrosswalkIntersectionConnectionIndex 1 is the start and 2 is the end.
-		// And on the left side CrosswalkIntersectionConnectionIndex 2 is the start and 1 is the end.
+		// So on the left side CrosswalkIntersectionConnectionIndex 1 is the start of the crosswalk intersection and 2 is the end.
+		// And on the right side CrosswalkIntersectionConnectionIndex 2 is the start of the crosswalk intersection and 1 is the end.
 		const float DirectionScalar = CrosswalkIntersectionConnectionIndex == (bIsLeftSide ? 1 : 2) ? 1.0f : -1.0f;
 		const FVector CrosswalkIntersectionEntranceTangent = ITempoRoadModuleInterface::Execute_GetTangentAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
 
@@ -384,8 +379,8 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector(co
 		}
 
 		// Connection indexing is clockwise from above with 0 at the crosswalk entrance.
-		// So on the left side CrosswalkIntersectionConnectionIndex 1 is the start and 2 is the end.
-		// And on the left side CrosswalkIntersectionConnectionIndex 2 is the start and 1 is the end.
+		// So on the left side CrosswalkIntersectionConnectionIndex 1 is the start of the crosswalk intersection and 2 is the end.
+		// And on the right side CrosswalkIntersectionConnectionIndex 2 is the start of the crosswalk intersection and 1 is the end.
 		const float DirectionScalar = CrosswalkIntersectionConnectionIndex == (bIsLeftSide ? 1 : 2) ? 1.0f : -1.0f;
 		const FVector CrosswalkIntersectionEntranceRightVector = ITempoRoadModuleInterface::Execute_GetRightVectorAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
 

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoRoadQueryComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoRoadQueryComponent.cpp
@@ -1,0 +1,821 @@
+// Copyright Vayu Robotics, Inc. All Rights Reserved
+
+
+#include "TempoRoadQueryComponent.h"
+
+#include "TempoAgentsShared.h"
+#include "TempoCrosswalkInterface.h"
+#include "TempoRoadInterface.h"
+#include "TempoRoadModuleInterface.h"
+#include "TempoZoneGraphUtils.h"
+
+#include "ZoneGraphTypes.h"
+
+float GetDistanceAlongTempoRoadAtCrosswalk(const AActor* RoadQueryActor, int32 CrosswalkIndex)
+{
+	const FVector CrosswalkCenterLineLeft = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation(RoadQueryActor, CrosswalkIndex, 0, ETempoCoordinateSpace::World);
+	const FVector CrosswalkCenterLineRight = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation(RoadQueryActor, CrosswalkIndex, 1, ETempoCoordinateSpace::World);
+	const FVector CrosswalkCenter = (CrosswalkCenterLineLeft + CrosswalkCenterLineRight) / 2.0;
+	return ITempoRoadInterface::Execute_GetDistanceAlongTempoRoadClosestToWorldLocation(RoadQueryActor, CrosswalkCenter);
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorInfo(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, FCrosswalkIntersectionConnectorInfo& OutCrosswalkIntersectionConnectorInfo) const
+{
+	ensureMsgf(false, TEXT("UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorInfo not implemented."));
+	return false;
+}
+
+bool UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap(const AActor* RoadQueryActor, const TArray<FName>& CrosswalkRoadModuleAnyTags, const TArray<FName>& CrosswalkRoadModuleAllTags, const TArray<FName>& CrosswalkRoadModuleNotTags, TMap<int32, AActor*>& OutCrosswalkRoadModuleMap) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap.")))
+	{
+		return false;
+	}
+
+	const FZoneGraphTagFilter CrosswalkRoadModuleTagFilter = UTempoZoneGraphUtils::GenerateTagFilter(this, CrosswalkRoadModuleAnyTags, CrosswalkRoadModuleAllTags, CrosswalkRoadModuleNotTags);
+
+	const auto& GetCrosswalkRoadModules = [this, &RoadQueryActor, &CrosswalkRoadModuleTagFilter]()
+	{
+		TArray<AActor*> CrosswalkRoadModules;
+
+		const int32 NumConnectedRoadModules = ITempoRoadInterface::Execute_GetNumConnectedTempoRoadModules(RoadQueryActor);
+
+		for (int32 ConnectedRoadModuleIndex = 0; ConnectedRoadModuleIndex < NumConnectedRoadModules; ++ConnectedRoadModuleIndex)
+		{
+			AActor* ConnectedRoadModule = ITempoRoadInterface::Execute_GetConnectedTempoRoadModuleActor(RoadQueryActor, ConnectedRoadModuleIndex);
+
+			if (ConnectedRoadModule == nullptr)
+			{
+				continue;
+			}
+
+			if (!ConnectedRoadModule->Implements<UTempoRoadModuleInterface>())
+			{
+				UE_LOG(LogTempoAgentsShared, Warning, TEXT("ConnectedRoadModule %s did not implement RoadModuleInterface"), *ConnectedRoadModule->GetName());
+				continue;
+			}
+
+			const int32 NumRoadModuleLanes = ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes(ConnectedRoadModule);
+
+			for (int32 RoadModuleLaneIndex = 0; RoadModuleLaneIndex < NumRoadModuleLanes; ++RoadModuleLaneIndex)
+			{
+				const TArray<FName>& RoadModuleLaneTags = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags(ConnectedRoadModule, RoadModuleLaneIndex);
+
+				const FZoneGraphTagMask& RoadModuleLaneTagMask = UTempoZoneGraphUtils::GenerateTagMaskFromTagNames(this, RoadModuleLaneTags);
+
+				// Should we generate crosswalks for this road module (according to tags)?
+				if (CrosswalkRoadModuleTagFilter.Pass(RoadModuleLaneTagMask))
+				{
+					// Then, add it to the list of crosswalk road modules.
+					CrosswalkRoadModules.Add(ConnectedRoadModule);
+					break;
+				}
+			}
+		}
+
+		return CrosswalkRoadModules;
+	};
+
+	const TArray<AActor*> CrosswalkRoadModules = GetCrosswalkRoadModules();
+
+	if (CrosswalkRoadModules.Num() < 2)
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkRoadModules.Num() == 2, TEXT("Only roads with 2 crosswalk road modules are handled by UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap.")))
+	{
+		return false;
+	}
+
+	const FVector RoadStartLocation = ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad(RoadQueryActor, 0.0, ETempoCoordinateSpace::World);
+	const FVector RoadStartRight = ITempoRoadInterface::Execute_GetRightVectorAtDistanceAlongTempoRoad(RoadQueryActor, 0.0, ETempoCoordinateSpace::World);
+	const float RoadWidth = ITempoRoadInterface::Execute_GetTempoRoadWidth(RoadQueryActor);
+
+	const auto& GetCrosswalkRoadModuleInLateralDirection = [&CrosswalkRoadModules, &RoadStartLocation, &RoadStartRight, &RoadWidth](const float LateralDirectionScalar) -> AActor*
+	{
+		AActor* NearestRoadModule = nullptr;
+		float NearestDistance = TNumericLimits<float>::Max();
+		for (AActor* CrosswalkRoadModule : CrosswalkRoadModules)
+		{
+			const float RoadModuleWidth = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleWidth(CrosswalkRoadModule);
+			const FVector QueryPoint = RoadStartLocation + RoadStartRight * (RoadWidth * 0.5 + RoadModuleWidth * 0.5) * LateralDirectionScalar;
+			const float DistanceAlongRoadModule = ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleClosestToWorldLocation(CrosswalkRoadModule, QueryPoint);
+			const FVector PointOnRoadModule = ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule(CrosswalkRoadModule, DistanceAlongRoadModule, ETempoCoordinateSpace::World);
+			const float Distance = FVector::Distance(PointOnRoadModule, QueryPoint);
+			if (Distance < NearestDistance)
+			{
+				NearestDistance = Distance;
+				NearestRoadModule = CrosswalkRoadModule;
+			}
+		}
+
+		return NearestRoadModule;
+	};
+
+	AActor* LeftCrosswalkRoadModule = GetCrosswalkRoadModuleInLateralDirection(-1.0f);
+	AActor* RightCrosswalkRoadModule = GetCrosswalkRoadModuleInLateralDirection(1.0f);
+
+	if (!(LeftCrosswalkRoadModule && RightCrosswalkRoadModule))
+	{
+		// Roads must have at least one crosswalk road module on the left and the right to have crosswalk connections.
+		return false;
+	}
+
+	TMap<int32, AActor*> CrosswalkRoadModuleMap;
+	// Convention: left road module is index 0, right road module is index 1
+	CrosswalkRoadModuleMap.Add(0, LeftCrosswalkRoadModule);
+	CrosswalkRoadModuleMap.Add(1, RightCrosswalkRoadModule);
+
+	OutCrosswalkRoadModuleMap = CrosswalkRoadModuleMap;
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, AActor*& OutCrosswalkRoadModule, float &OutCrosswalkIntersectionConnectorDistance) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry.")))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry.")))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry.")))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex == 1 || CrosswalkIntersectionConnectionIndex == 2, TEXT("CrosswalkIntersectionConnectionIndex must be 1 or 2 in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry.  Currently, CrosswalkIntersectionConnectionIndex is: %d"), CrosswalkIntersectionConnectionIndex))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(!CrosswalkIntersectionConnectorInfo->CrosswalkIntersectionConnectorSegmentInfos.IsEmpty(), TEXT("CrosswalkIntersectionConnectorSegmentInfos must not be empty UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry.  Currently, it has %d elements."), CrosswalkIntersectionConnectorInfo->CrosswalkIntersectionConnectorSegmentInfos.Num()))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+	const FCrosswalkIntersectionConnectorSegmentInfo* CrosswalkIntersectionConnectorSegmentInfoBefore =
+		CrosswalkIntersectionConnectorInfo->CrosswalkIntersectionConnectorSegmentInfos.FindByPredicate([CrosswalkIndex](const auto& Elem) { return Elem.CrosswalkIndexAtEnd == CrosswalkIndex; });
+	const FCrosswalkIntersectionConnectorSegmentInfo* CrosswalkIntersectionConnectorSegmentInfoAfter =
+		CrosswalkIntersectionConnectorInfo->CrosswalkIntersectionConnectorSegmentInfos.FindByPredicate([CrosswalkIndex](const auto& Elem) { return Elem.CrosswalkIndexAtStart == CrosswalkIndex; });
+	const float EndDistanceBefore = CrosswalkIntersectionConnectorSegmentInfoBefore->CrosswalkIntersectionConnectorEndDistance;
+	const float StartDistanceAfter = CrosswalkIntersectionConnectorSegmentInfoAfter->CrosswalkIntersectionConnectorStartDistance;
+
+	OutCrosswalkRoadModule = CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule;
+
+	// Connection indexing is clockwise from above with 0 at the crosswalk entrance.
+	// So on the left side CrosswalkIntersectionConnectionIndex 1 is the start and 2 is the end.
+	// And on the left side CrosswalkIntersectionConnectionIndex 2 is the start and 1 is the end.
+	// RoadModule index 0 is left by convention.
+	const bool bIsLeftSide = CrosswalkRoadModuleIndex == 0;
+	OutCrosswalkIntersectionConnectorDistance = CrosswalkIntersectionConnectionIndex == (bIsLeftSide ? 1 : 2) ? EndDistanceBefore : StartDistanceAfter;
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLocation(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceLocation) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		const int32 CrosswalkControlPointIndex = CrosswalkIntersectionIndex % 2;
+
+		const FVector CrosswalkEntranceLocation = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation(RoadQueryActor, CrosswalkIndex, CrosswalkControlPointIndex, CoordinateSpace);
+
+		OutCrosswalkIntersectionEntranceLocation = CrosswalkEntranceLocation;
+	}
+	else
+	{
+		AActor* CrosswalkRoadModuleActor = nullptr;
+		float CrosswalkIntersectionConnectorDistance = 0.0f;
+
+		if (!TryGetCrosswalkIntersectionConnectorInfoEntry(RoadQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, CrosswalkIntersectionConnectorInfoMap, CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance))
+		{
+			ensureMsgf(false, TEXT("Failed to get CrosswalkIntersectionConnectorInfo entry in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  RoadQueryActor: %s CrosswalkIntersectionIndex: %d CrosswalkIntersectionConnectionIndex: %d."), *RoadQueryActor->GetName(), CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
+			return false;
+		}
+
+		const FVector CrosswalkEntranceLocation = ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
+
+		FColor Color;
+		if (CrosswalkIntersectionIndex == 0)
+		{
+			Color = FColor::Red;
+		}
+		if (CrosswalkIntersectionIndex == 1)
+		{
+			Color = FColor::Magenta;
+		}
+		if (CrosswalkIntersectionIndex == 2)
+		{
+			Color = FColor::Green;
+		}
+		if (CrosswalkIntersectionIndex == 3)
+		{
+			Color = FColor::Emerald;
+		}
+		if (CrosswalkIntersectionIndex == 4)
+		{
+			Color = FColor::Blue;
+		}
+		if (CrosswalkIntersectionIndex == 5)
+		{
+			Color = FColor::Cyan;
+		}
+
+		// DrawDebugPoint(CrosswalkRoadModuleActor->GetWorld(), CrosswalkEntranceLocation + 100.0 * FVector::UpVector, 60.0, Color, false, 20.0, 0);
+
+		OutCrosswalkIntersectionEntranceLocation = CrosswalkEntranceLocation;
+	}
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceTangent) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	// Even crosswalk intersections indices are on the left.
+	const bool bIsLeftSide = CrosswalkIntersectionIndex % 2 == 0;
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		const float DirectionScalar = !bIsLeftSide ? 1.0f : -1.0f;
+
+		// The actual CrosswalkIntersection's entrance tangent is based on the road's right vector at the crosswalk.
+		const float DistanceAlongRoad = GetDistanceAlongTempoRoadAtCrosswalk(RoadQueryActor, CrosswalkIndex);
+		OutCrosswalkIntersectionEntranceTangent = ITempoRoadInterface::Execute_GetRightVectorAtDistanceAlongTempoRoad(RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::World) * DirectionScalar;
+	}
+	else
+	{
+		AActor* CrosswalkRoadModuleActor = nullptr;
+		float CrosswalkIntersectionConnectorDistance = 0.0f;
+
+		if (!TryGetCrosswalkIntersectionConnectorInfoEntry(RoadQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, CrosswalkIntersectionConnectorInfoMap, CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance))
+		{
+			ensureMsgf(false, TEXT("Failed to get CrosswalkIntersectionConnectorInfo entry in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  RoadQueryActor: %s CrosswalkIntersectionIndex: %d CrosswalkIntersectionConnectionIndex: %d."), *RoadQueryActor->GetName(), CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
+			return false;
+		}
+
+		// Connection indexing is clockwise from above with 0 at the crosswalk entrance.
+		// So on the left side CrosswalkIntersectionConnectionIndex 1 is the start and 2 is the end.
+		// And on the left side CrosswalkIntersectionConnectionIndex 2 is the start and 1 is the end.
+		const float DirectionScalar = CrosswalkIntersectionConnectionIndex == (bIsLeftSide ? 1 : 2) ? 1.0f : -1.0f;
+		const FVector CrosswalkIntersectionEntranceTangent = ITempoRoadModuleInterface::Execute_GetTangentAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
+
+		OutCrosswalkIntersectionEntranceTangent = CrosswalkIntersectionEntranceTangent;
+	}
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceUpVector) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+
+		// The actual CrosswalkIntersection's entrance up vector is based on the road's up vector at the crosswalk.
+		const float DistanceAlongRoad = GetDistanceAlongTempoRoadAtCrosswalk(RoadQueryActor, CrosswalkIndex);
+		OutCrosswalkIntersectionEntranceUpVector = ITempoRoadInterface::Execute_GetUpVectorAtDistanceAlongTempoRoad(RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::World);
+	}
+	else
+	{
+		AActor* CrosswalkRoadModuleActor = nullptr;
+		float CrosswalkIntersectionConnectorDistance = 0.0f;
+
+		if (!TryGetCrosswalkIntersectionConnectorInfoEntry(RoadQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, CrosswalkIntersectionConnectorInfoMap, CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance))
+		{
+			ensureMsgf(false, TEXT("Failed to get CrosswalkIntersectionConnectorInfo entry in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  RoadQueryActor: %s CrosswalkIntersectionIndex: %d CrosswalkIntersectionConnectionIndex: %d."), *RoadQueryActor->GetName(), CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
+			return false;
+		}
+
+		const FVector CrosswalkIntersectionEntranceUpVector = ITempoRoadModuleInterface::Execute_GetUpVectorAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
+
+		OutCrosswalkIntersectionEntranceUpVector = CrosswalkIntersectionEntranceUpVector;
+	}
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceRightVector) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	// Even crosswalk intersections indices are on the left.
+	const bool bIsLeftSide = CrosswalkIntersectionIndex % 2 == 0;
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+
+		const float DirectionScalar = bIsLeftSide ? 1.0f : -1.0f;
+
+		// The actual Crosswalk's Intersection Entrance right vector is based on the Road's forward vector.
+		const float DistanceAlongRoad = GetDistanceAlongTempoRoadAtCrosswalk(RoadQueryActor, CrosswalkIndex);
+		OutCrosswalkIntersectionEntranceRightVector = ITempoRoadInterface::Execute_GetTangentAtDistanceAlongTempoRoad(RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::World) * DirectionScalar;
+	}
+	else
+	{
+		AActor* CrosswalkRoadModuleActor = nullptr;
+		float CrosswalkIntersectionConnectorDistance = 0.0f;
+
+		if (!TryGetCrosswalkIntersectionConnectorInfoEntry(RoadQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, CrosswalkIntersectionConnectorInfoMap, CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance))
+		{
+			ensureMsgf(false, TEXT("Failed to get CrosswalkIntersectionConnectorInfo entry in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  RoadQueryActor: %s CrosswalkIntersectionIndex: %d CrosswalkIntersectionConnectionIndex: %d."), *RoadQueryActor->GetName(), CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
+			return false;
+		}
+
+		// Connection indexing is clockwise from above with 0 at the crosswalk entrance.
+		// So on the left side CrosswalkIntersectionConnectionIndex 1 is the start and 2 is the end.
+		// And on the left side CrosswalkIntersectionConnectionIndex 2 is the start and 1 is the end.
+		const float DirectionScalar = CrosswalkIntersectionConnectionIndex == (bIsLeftSide ? 1 : 2) ? 1.0f : -1.0f;
+		const FVector CrosswalkIntersectionEntranceRightVector = ITempoRoadModuleInterface::Execute_GetRightVectorAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
+
+		OutCrosswalkIntersectionEntranceRightVector = CrosswalkIntersectionEntranceRightVector;
+	}
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, int32& OutNumCrosswalkIntersectionEntranceLanes) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const int32 NumCrosswalkIntersectionEntranceLanes = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkLanes(RoadQueryActor, CrosswalkIndex);
+
+		OutNumCrosswalkIntersectionEntranceLanes = NumCrosswalkIntersectionEntranceLanes;
+	}
+	else
+	{
+		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
+		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
+		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		if (!TryGetNumCrosswalkIntersectionConnectorLanes(RoadQueryActor, CrosswalkRoadModuleIndex, CrosswalkIntersectionConnectorInfoMap, OutNumCrosswalkIntersectionEntranceLanes))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FName& OutCrosswalkIntersectionEntranceLaneProfileOverrideName) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const FName LaneProfileOverrideNameForTempoCrosswalk = ITempoCrosswalkInterface::Execute_GetLaneProfileOverrideNameForTempoCrosswalk(RoadQueryActor, CrosswalkIndex);
+
+		OutCrosswalkIntersectionEntranceLaneProfileOverrideName = LaneProfileOverrideNameForTempoCrosswalk;
+	}
+	else
+	{
+		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
+		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
+		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		if (!TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName(RoadQueryActor, CrosswalkRoadModuleIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneProfileOverrideName))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, float& OutCrosswalkIntersectionEntranceLaneWidth) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const float CrosswalkLaneWidth = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneWidth(RoadQueryActor, CrosswalkIndex, LaneIndex);
+
+		OutCrosswalkIntersectionEntranceLaneWidth = CrosswalkLaneWidth;
+	}
+	else
+	{
+		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
+		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
+		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		if (!TryGetCrosswalkIntersectionConnectorLaneWidth(RoadQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneWidth))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, EZoneLaneDirection& OutCrosswalkIntersectionEntranceLaneDirection) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const EZoneLaneDirection CrosswalkLaneDirection = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneDirection(RoadQueryActor, CrosswalkIndex, LaneIndex);
+
+		OutCrosswalkIntersectionEntranceLaneDirection = CrosswalkLaneDirection;
+	}
+	else
+	{
+		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
+		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
+		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		if (!TryGetCrosswalkIntersectionConnectorLaneDirection(RoadQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneDirection))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, TArray<FName>& OutCrosswalkIntersectionEntranceLaneTags) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+
+	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
+	if (CrosswalkIntersectionConnectionIndex == 0)
+	{
+		const TArray<FName> CrosswalkLaneTags = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneTags(RoadQueryActor, CrosswalkIndex, LaneIndex);
+
+		OutCrosswalkIntersectionEntranceLaneTags = CrosswalkLaneTags;
+	}
+	else
+	{
+		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
+		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
+		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		if (!TryGetCrosswalkIntersectionConnectorLaneTags(RoadQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneTags))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, int32& OutNumCrosswalkIntersectionConnectorLanes) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.")))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkIntersectionConnectorLanes = ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule);
+
+	OutNumCrosswalkIntersectionConnectorLanes = NumCrosswalkIntersectionConnectorLanes;
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FName& OutCrosswalkIntersectionConnectorLaneProfileOverrideName) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName.")))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName.")))
+	{
+		return false;
+	}
+
+	const FName CrosswalkRoadModuleLaneProfileOverrideName = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneProfileOverrideName(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule);
+
+	OutCrosswalkIntersectionConnectorLaneProfileOverrideName = CrosswalkRoadModuleLaneProfileOverrideName;
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, float& OutCrosswalkIntersectionConnectorLaneWidth) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth.")))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth.")))
+	{
+		return false;
+	}
+
+	const float CrosswalkRoadModuleLaneWidth = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneWidth(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+
+	OutCrosswalkIntersectionConnectorLaneWidth = CrosswalkRoadModuleLaneWidth;
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, EZoneLaneDirection& OutCrosswalkIntersectionConnectorLaneDirection) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection.")))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection.")))
+	{
+		return false;
+	}
+
+	const EZoneLaneDirection CrosswalkRoadModuleLaneDirection = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneDirection(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+
+	OutCrosswalkIntersectionConnectorLaneDirection = CrosswalkRoadModuleLaneDirection;
+
+	return true;
+}
+
+bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneTags(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, TArray<FName>& OutCrosswalkIntersectionConnectorLaneTags) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection.")))
+	{
+		return false;
+	}
+
+	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(RoadQueryActor);
+
+	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *RoadQueryActor->GetName()))
+	{
+		return false;
+	}
+
+	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo != nullptr, TEXT("Must get valid CrosswalkIntersectionConnectorInfo in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneTags.")))
+	{
+		return false;
+	}
+
+	if (!ensureMsgf(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneTags.")))
+	{
+		return false;
+	}
+
+	const TArray<FName> CrosswalkRoadModuleLaneTags = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+
+	OutCrosswalkIntersectionConnectorLaneTags = CrosswalkRoadModuleLaneTags;
+
+	return true;
+}
+
+int32 UTempoRoadQueryComponent::GetCrosswalkIndexFromCrosswalkIntersectionIndex(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex) const
+{
+	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("RoadQueryActor must be valid in UTempoRoadQueryComponent::GetCrosswalkIndexFromCrosswalkIntersectionIndex.")))
+	{
+		return 0;
+	}
+
+	// Two crosswalk intersections per crosswalk (the left and right sides of the road)
+	return CrosswalkIntersectionIndex / 2;
+}

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoZoneGraphUtils.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoZoneGraphUtils.cpp
@@ -1,0 +1,36 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#include "TempoZoneGraphUtils.h"
+
+#include "TempoAgentsShared.h"
+
+#include "ZoneGraphSubsystem.h"
+
+FZoneGraphTagMask UTempoZoneGraphUtils::GenerateTagMaskFromTagNames(const UObject* WorldContextObject, const TArray<FName>& TagNames)
+{
+	const UZoneGraphSubsystem* ZoneGraphSubsystem = UWorld::GetSubsystem<UZoneGraphSubsystem>(WorldContextObject->GetWorld());
+	if (ZoneGraphSubsystem == nullptr)
+	{
+		UE_LOG(LogTempoAgentsShared, Error, TEXT("TempoZoneGraphUtils - GenerateTagMaskFromTagNames - Can't access ZoneGraphSubsystem."));
+		return FZoneGraphTagMask::None;
+	}
+
+	FZoneGraphTagMask ZoneGraphTagMask;
+
+	for (const auto& TagName : TagNames)
+	{
+		const FZoneGraphTag Tag = ZoneGraphSubsystem->GetTagByName(TagName);
+		ZoneGraphTagMask.Add(Tag);
+	}
+
+	return ZoneGraphTagMask;
+}
+
+FZoneGraphTagFilter UTempoZoneGraphUtils::GenerateTagFilter(const UObject* WorldContextObject, const TArray<FName>& AnyTags, const TArray<FName>& AllTags, const TArray<FName>& NotTags)
+{
+	const FZoneGraphTagMask AnyTagsMask = UTempoZoneGraphUtils::GenerateTagMaskFromTagNames(WorldContextObject, AnyTags);
+	const FZoneGraphTagMask AllTagsMask = UTempoZoneGraphUtils::GenerateTagMaskFromTagNames(WorldContextObject, AllTags);
+	const FZoneGraphTagMask NotTagsMask = UTempoZoneGraphUtils::GenerateTagMaskFromTagNames(WorldContextObject, NotTags);
+
+	return FZoneGraphTagFilter{AnyTagsMask, AllTagsMask, NotTagsMask};
+}

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoCrosswalkInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoCrosswalkInterface.h
@@ -29,6 +29,14 @@ struct FCrosswalkIntersectionConnectorSegmentInfo
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tempo Agents|Road Lane Graph|Lane Connection Info")
 	float CrosswalkIntersectionConnectorEndDistance = 0.0f;
+
+	// Keep track of which crosswalk corresponds to the start of this connector. Currently only used by roads.
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tempo Agents|Road Lane Graph|Lane Connection Info")
+	int32 CrosswalkIndexAtStart = -1;
+
+	// Keep track of which crosswalk corresponds to the end of this connector. Currently only used by roads.
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tempo Agents|Road Lane Graph|Lane Connection Info")
+	int32 CrosswalkIndexAtEnd = -1;
 };
 
 USTRUCT(BlueprintType)
@@ -65,6 +73,9 @@ public:
 	// Crosswalk Queries
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Crosswalk Interface|Queries")
+	int32 GetNumTempoCrosswalks() const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Crosswalk Interface|Queries")
 	bool ShouldGenerateZoneShapesForTempoCrosswalk(int32 ConnectionIndex) const;
 	
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Crosswalk Interface|Queries")
@@ -78,7 +89,7 @@ public:
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Crosswalk Interface|Queries")
 	TArray<FName> GetTempoCrosswalkTags(int32 ConnectionIndex) const;
-	
+
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Crosswalk Interface|Queries")
 	int32 GetNumTempoCrosswalkLanes(int32 ConnectionIndex) const;
 	
@@ -172,9 +183,14 @@ public:
 
 	// Crosswalk Indexing Conversion Queries
 
+	// Internal - and unused?
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Crosswalk Interface|Queries")
 	int32 GetTempoCrosswalkIntersectionIndexFromCrosswalkRoadModuleIndex(int32 CrosswalkRoadModuleIndex) const;
-	
+
+	// Internal
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Crosswalk Interface|Queries")
 	int32 GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(int32 CrosswalkIntersectionIndex) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Crosswalk Interface|Commands")
+	void SetupTempoCrosswalkData();
 };

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
@@ -114,9 +114,7 @@ protected:
 	virtual TempoZoneGraphTagMaskGroups GroupLaneConnectionsByTags(const AActor* SourceConnectionActor, const TArray<FTempoLaneConnectionInfo>& SourceLaneConnectionInfos, const TArray<FTempoLaneConnectionInfo>& DestLaneConnectionInfos) const;
 
 	virtual FZoneGraphTagFilter GetLaneConnectionTagFilter(const AActor* SourceConnectionActor, const FTempoLaneConnectionInfo& SourceLaneConnectionInfo) const;
-	virtual FZoneGraphTagFilter GenerateTagFilter(const TArray<FName>& AnyTags, const TArray<FName>& AllTags, const TArray<FName>& NotTags) const;
-	virtual FZoneGraphTagMask GenerateTagMaskFromTagNames(const TArray<FName>& TagNames) const;
-	
+
 	virtual bool TryGetMinLaneIndexInLaneConnections(const TArray<FTempoLaneConnectionInfo>& LaneConnectionInfos, int32& OutMinLaneIndex) const;
 	virtual bool TryGetMaxLaneIndexInLaneConnections(const TArray<FTempoLaneConnectionInfo>& LaneConnectionInfos, int32& OutMaxLaneIndex) const;
 

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadInterface.h
@@ -133,4 +133,12 @@ public:
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
 	FRotator GetTempoParkingRotation(const FName ParkingLocationAnchorName, const float NormalizedDistanceAlongRoad, const float NormalizedAngularVariationScalar, const ETempoCoordinateSpace CoordinateSpace) const;
+
+	// Connected Road Module Queries
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
+	int32 GetNumConnectedTempoRoadModules() const;
+
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Road Interface|Queries")
+	AActor* GetConnectedTempoRoadModuleActor(int32 ConnectedRoadModuleIndex) const;
 };

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadQueryComponent.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoRoadQueryComponent.h
@@ -1,0 +1,70 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "TempoRoadQueryComponent.generated.h"
+
+
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class TEMPOAGENTSSHARED_API UTempoRoadQueryComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionConnectorInfo(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, FCrosswalkIntersectionConnectorInfo& OutCrosswalkIntersectionConnectorInfo) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGenerateCrosswalkRoadModuleMap(const AActor* RoadQueryActor, const TArray<FName>& CrosswalkRoadModuleAnyTags, const TArray<FName>& CrosswalkRoadModuleAllTags, const TArray<FName>& CrosswalkRoadModuleNotTags, TMap<int32, AActor*>& OutCrosswalkRoadModuleMap) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionConnectorInfoEntry(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, AActor*& OutCrosswalkRoadModule, float &OutCrosswalkIntersectionConnectorDistance) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionEntranceLocation(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceLocation) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionEntranceTangent(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceTangent) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionEntranceUpVector(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceUpVector) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionEntranceRightVector(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace CoordinateSpace, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FVector& OutCrosswalkIntersectionEntranceRightVector) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetNumCrosswalkIntersectionEntranceLanes(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, int32& OutNumCrosswalkIntersectionEntranceLanes) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FName& OutCrosswalkIntersectionEntranceLaneProfileOverrideName) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionEntranceLaneWidth(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, float& OutCrosswalkIntersectionEntranceLaneWidth) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionEntranceLaneDirection(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, EZoneLaneDirection& OutCrosswalkIntersectionEntranceLaneDirection) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionEntranceLaneTags(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, TArray<FName>& OutCrosswalkIntersectionEntranceLaneTags) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetNumCrosswalkIntersectionConnectorLanes(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, int32& OutNumCrosswalkIntersectionConnectorLanes) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, FName& OutCrosswalkIntersectionConnectorLaneProfileOverrideName) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionConnectorLaneWidth(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, float& OutCrosswalkIntersectionConnectorLaneWidth) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionConnectorLaneDirection(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, EZoneLaneDirection& OutCrosswalkIntersectionConnectorLaneDirection) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual bool TryGetCrosswalkIntersectionConnectorLaneTags(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, int32 LaneIndex, const TMap<int32, FCrosswalkIntersectionConnectorInfo>& CrosswalkIntersectionConnectorInfoMap, TArray<FName>& OutCrosswalkIntersectionConnectorLaneTags) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Tempo Roads")
+	virtual int32 GetCrosswalkIndexFromCrosswalkIntersectionIndex(const AActor* RoadQueryActor, int32 CrosswalkIntersectionIndex) const;
+};

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoZoneGraphUtils.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoZoneGraphUtils.h
@@ -1,0 +1,22 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "ZoneGraphTypes.h"
+
+#include "TempoZoneGraphUtils.generated.h"
+
+UCLASS()
+class TEMPOCORESHARED_API UTempoZoneGraphUtils : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, Category="TempoZoneGraphUtils", meta=(WorldContext="WorldContextObject"))
+	static FZoneGraphTagMask GenerateTagMaskFromTagNames(const UObject* WorldContextObject, const TArray<FName>& TagNames);
+
+	UFUNCTION(BlueprintCallable, Category="TempoZoneGraphUtils", meta=(WorldContext="WorldContextObject"))
+	static FZoneGraphTagFilter GenerateTagFilter(const UObject* WorldContextObject, const TArray<FName>& AnyTags, const TArray<FName>& AllTags, const TArray<FName>& NotTags);
+};

--- a/TempoAgents/Source/TempoAgentsShared/TempoAgentsShared.Build.cs
+++ b/TempoAgents/Source/TempoAgentsShared/TempoAgentsShared.Build.cs
@@ -14,6 +14,7 @@ public class TempoAgentsShared : ModuleRules
                 "Core",
                 "Engine",
                 "RenderCore",
+                "ZoneGraph",
             }
         );
 
@@ -25,7 +26,6 @@ public class TempoAgentsShared : ModuleRules
                 "DeveloperSettings",
                 "Slate",
                 "SlateCore",
-                "ZoneGraph",
                 "MassCommon",
                 "MassTraffic",
                 "MassRepresentation",


### PR DESCRIPTION
Enables generating ZoneShapes for crosswalks on roads. The TempoRoadQueryComponent, which is analogous to the TempoIntersectionQueryComponent, is introduced to make the implementation of TempoCrosswalkInterface on roads more convenient.