### PR TITLE
Wrap all Blueprint Calls from CPP in CallBlueprintFunction Utility

### DIFF
--- a/TempoAgents/Source/TempoAgentsEditor/Private/TempoAgentsEditorUtils.cpp
+++ b/TempoAgents/Source/TempoAgentsEditor/Private/TempoAgentsEditorUtils.cpp
@@ -9,8 +9,6 @@
 
 void UTempoAgentsEditorUtils::RunTempoZoneGraphBuilderPipeline()
 {
-	FEditorScriptExecutionGuard ScriptGuard;
-
 	if (UTempoRoadLaneGraphSubsystem* TempoRoadLaneGraphSubsystem = GEditor ? GEditor->GetEditorSubsystem<UTempoRoadLaneGraphSubsystem>() : nullptr)
 	{
 		TempoRoadLaneGraphSubsystem->SetupZoneGraphBuilder();

--- a/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
+++ b/TempoAgents/Source/TempoAgentsEditor/Private/TempoRoadLaneGraphSubsystem.cpp
@@ -13,6 +13,7 @@
 #include "ZoneGraphSubsystem.h"
 #include "ZoneGraphDelegates.h"
 #include "DrawDebugHelpers.h"
+#include "TempoCoreUtils.h"
 #include "TempoRoadModuleInterface.h"
 #include "VectorTypes.h"
 
@@ -42,14 +43,12 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateZoneShapeComponents() const
 
 		if (Actor->Implements<UTempoIntersectionInterface>())
 		{
-			FEditorScriptExecutionGuard ScriptGuard;
-			ITempoIntersectionInterface::Execute_SetupTempoIntersectionData(Actor);
+			UTempoCoreUtils::CallBlueprintFunction(Actor, ITempoIntersectionInterface::Execute_SetupTempoIntersectionData);
 		}
 
 		if (Actor->Implements<UTempoCrosswalkInterface>())
 		{
-			FEditorScriptExecutionGuard ScriptGuard;
-			ITempoCrosswalkInterface::Execute_SetupTempoCrosswalkData(Actor);
+			UTempoCoreUtils::CallBlueprintFunction(Actor, ITempoCrosswalkInterface::Execute_SetupTempoCrosswalkData);
 		}
 	}
 	
@@ -95,8 +94,7 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateZoneShapeComponents() const
 		else if (Actor->Implements<UTempoRoadModuleInterface>())
 		{
 			DestroyZoneShapeComponents(*Actor);
-			
-			const AActor* RoadModuleParentActor = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleParentActor(Actor);
+			const AActor* RoadModuleParentActor = UTempoCoreUtils::CallBlueprintFunction(Actor, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleParentActor);
 			if (RoadModuleParentActor == nullptr)
 			{
 				UE_LOG(LogTempoAgentsEditor, Error, TEXT("Tempo Lane Graph - Failed to create Road Module ZoneShapeComponents for Actor: %s.  It must have a valid parent."), *Actor->GetName());
@@ -164,8 +162,8 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForR
 	TArray<UZoneShapeComponent*> ZoneShapeComponents;
 
 	const bool bShouldGenerateZoneShapes = bQueryActorIsRoadModule
-		? ITempoRoadModuleInterface::Execute_ShouldGenerateZoneShapesForTempoRoadModule(&RoadQueryActor)
-		: ITempoRoadInterface::Execute_ShouldGenerateZoneShapesForTempoRoad(&RoadQueryActor);
+		? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_ShouldGenerateZoneShapesForTempoRoadModule)
+		: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_ShouldGenerateZoneShapesForTempoRoad);
 
 	if (!bShouldGenerateZoneShapes)
 	{
@@ -182,16 +180,16 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForR
 	}
 
 	const int32 NumControlPoints = bQueryActorIsRoadModule
-		? ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleControlPoints(&RoadQueryActor)
-		: ITempoRoadInterface::Execute_GetNumTempoControlPoints(&RoadQueryActor);
+		? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleControlPoints)
+		: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetNumTempoControlPoints);
 	
 	const bool bIsClosedLoop = bQueryActorIsRoadModule
-		? ITempoRoadModuleInterface::Execute_IsTempoRoadModuleClosedLoop(&RoadQueryActor)
-		: ITempoRoadInterface::Execute_IsTempoLaneClosedLoop(&RoadQueryActor);
+		? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_IsTempoRoadModuleClosedLoop)
+		: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_IsTempoLaneClosedLoop);
 	
 	const float SampleDistanceStepSize = bQueryActorIsRoadModule
-		? ITempoRoadModuleInterface::Execute_GetTempoRoadModuleSampleDistanceStepSize(&RoadQueryActor)
-		: ITempoRoadInterface::Execute_GetTempoRoadSampleDistanceStepSize(&RoadQueryActor);
+		? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleSampleDistanceStepSize)
+		: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetTempoRoadSampleDistanceStepSize);
 
 	// Generate ZoneShapeComponents and Setup their Points.
 	if (bIsClosedLoop)
@@ -208,12 +206,12 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForR
 			const int32 NextControlPointIndex = CurrentControlPointIndex + 1;
 
 			const float CurrentControlPointDistanceAlongRoad = bQueryActorIsRoadModule
-				? ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleAtControlPoint(&RoadQueryActor, CurrentControlPointIndex)
-				: ITempoRoadInterface::Execute_GetDistanceAlongTempoRoadAtControlPoint(&RoadQueryActor, CurrentControlPointIndex);
+				? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleAtControlPoint, CurrentControlPointIndex)
+				: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetDistanceAlongTempoRoadAtControlPoint, CurrentControlPointIndex);
 		
 			const float NextControlPointDistanceAlongRoad = bQueryActorIsRoadModule
-				? ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleAtControlPoint(&RoadQueryActor, NextControlPointIndex)
-				: ITempoRoadInterface::Execute_GetDistanceAlongTempoRoadAtControlPoint(&RoadQueryActor, NextControlPointIndex);
+				? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleAtControlPoint, NextControlPointIndex)
+				: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetDistanceAlongTempoRoadAtControlPoint, NextControlPointIndex);
 
 			UZoneShapeComponent* ZoneShapeComponent = nullptr;
 
@@ -285,19 +283,19 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForR
 		
 		const int32 ControlPointStartIndex = bQueryActorIsRoadModule
 			? 0
-			: ITempoRoadInterface::Execute_GetTempoStartEntranceLocationControlPointIndex(&RoadQueryActor);
+			: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetTempoStartEntranceLocationControlPointIndex);
 		
 		const int32 ControlPointEndIndex = bQueryActorIsRoadModule
 			? NumControlPoints - 1
-			: ITempoRoadInterface::Execute_GetTempoEndEntranceLocationControlPointIndex(&RoadQueryActor);
+			: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetTempoEndEntranceLocationControlPointIndex);
 
 		const float StartDistanceAlongRoad = bQueryActorIsRoadModule
-			? ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleAtControlPoint(&RoadQueryActor, ControlPointStartIndex)
-			: ITempoRoadInterface::Execute_GetDistanceAlongTempoRoadAtControlPoint(&RoadQueryActor, ControlPointStartIndex);
+			? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleAtControlPoint, ControlPointStartIndex)
+			: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetDistanceAlongTempoRoadAtControlPoint, ControlPointStartIndex);
 		
 		const float EndDistanceAlongRoad = bQueryActorIsRoadModule
-			? ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleAtControlPoint(&RoadQueryActor, ControlPointEndIndex)
-			: ITempoRoadInterface::Execute_GetDistanceAlongTempoRoadAtControlPoint(&RoadQueryActor, ControlPointEndIndex);
+			? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleAtControlPoint, ControlPointEndIndex)
+			: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetDistanceAlongTempoRoadAtControlPoint, ControlPointEndIndex);
 
 		UZoneShapeComponent* ZoneShapeComponent = nullptr;
 
@@ -362,12 +360,12 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateZoneShapeComponentBetweenDistances
 		const float NextSampleDistance = FMath::Min(CurrentSampleDistance + SampleDistanceStepSize, EndDistanceAlongRoad);
 		
 		const FVector PrevSampleLocation = bQueryActorIsRoadModule
-			? ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule(&RoadQueryActor, PrevSampleDistance, ETempoCoordinateSpace::Local)
-			: ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad(&RoadQueryActor, PrevSampleDistance, ETempoCoordinateSpace::Local);
+			? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule, PrevSampleDistance, ETempoCoordinateSpace::Local)
+			: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad, PrevSampleDistance, ETempoCoordinateSpace::Local);
 		
 		const FVector NextSampleLocation = bQueryActorIsRoadModule
-			? ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule(&RoadQueryActor, NextSampleDistance, ETempoCoordinateSpace::Local)
-			: ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad(&RoadQueryActor, NextSampleDistance, ETempoCoordinateSpace::Local);
+			? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule, NextSampleDistance, ETempoCoordinateSpace::Local)
+			: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad, NextSampleDistance, ETempoCoordinateSpace::Local);
 		
 		const FVector CurrentSampleTangent = (NextSampleLocation - PrevSampleLocation) * 0.5f / 3.0f;
 		const float CurrentSampleTangentLength = CurrentSampleTangent.Size();
@@ -398,12 +396,12 @@ FZoneShapePoint UTempoRoadLaneGraphSubsystem::CreateZoneShapePointAtDistanceAlon
 	FZoneShapePoint ZoneShapePoint;
 	
 	const FVector ZoneShapePointLocation = bQueryActorIsRoadModule
-		? ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule(&RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::Local)
-		: ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad(&RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::Local);
+		? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule, DistanceAlongRoad, ETempoCoordinateSpace::Local)
+		: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad, DistanceAlongRoad, ETempoCoordinateSpace::Local);
 
 	const FRotator ZoneShapePointRotation = bQueryActorIsRoadModule
-		? ITempoRoadModuleInterface::Execute_GetRotationAtDistanceAlongTempoRoadModule(&RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::Local)
-		: ITempoRoadInterface::Execute_GetRotationAtDistanceAlongTempoRoad(&RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::Local);
+		? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetRotationAtDistanceAlongTempoRoadModule, DistanceAlongRoad, ETempoCoordinateSpace::Local)
+		: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetRotationAtDistanceAlongTempoRoad, DistanceAlongRoad, ETempoCoordinateSpace::Local);
 
 	ZoneShapePoint.Position = ZoneShapePointLocation;
 	ZoneShapePoint.Rotation = ZoneShapePointRotation;
@@ -419,8 +417,8 @@ FZoneLaneProfile UTempoRoadLaneGraphSubsystem::CreateDynamicLaneProfile(const AA
 	FZoneLaneProfile LaneProfile;
 
 	const int32 NumLanes = bQueryActorIsRoadModule
-		? ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes(&RoadQueryActor)
-		: ITempoRoadInterface::Execute_GetNumTempoLanes(&RoadQueryActor);
+		? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes)
+		: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetNumTempoLanes);
 
 	for (int32 LaneIndex = 0; LaneIndex < NumLanes; ++LaneIndex)
 	{
@@ -428,16 +426,16 @@ FZoneLaneProfile UTempoRoadLaneGraphSubsystem::CreateDynamicLaneProfile(const AA
 		const int32 LaneProfileLaneIndex = NumLanes - 1 - LaneIndex;
 		
 		const float LaneWidth = bQueryActorIsRoadModule
-			? ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneWidth(&RoadQueryActor, LaneProfileLaneIndex)
-			: ITempoRoadInterface::Execute_GetTempoLaneWidth(&RoadQueryActor, LaneProfileLaneIndex);
+			? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneWidth, LaneProfileLaneIndex)
+			: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetTempoLaneWidth, LaneProfileLaneIndex);
 		
 		const EZoneLaneDirection LaneDirection = bQueryActorIsRoadModule
-			? ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneDirection(&RoadQueryActor, LaneProfileLaneIndex)
-			: ITempoRoadInterface::Execute_GetTempoLaneDirection(&RoadQueryActor, LaneProfileLaneIndex);
+			? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneDirection, LaneProfileLaneIndex)
+			: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetTempoLaneDirection, LaneProfileLaneIndex);
 		
 		const TArray<FName> LaneTags = bQueryActorIsRoadModule
-			? ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags(&RoadQueryActor, LaneProfileLaneIndex)
-			: ITempoRoadInterface::Execute_GetTempoLaneTags(&RoadQueryActor, LaneProfileLaneIndex);
+			? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags, LaneProfileLaneIndex)
+			: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetTempoLaneTags, LaneProfileLaneIndex);
 
 		FZoneLaneDesc LaneDesc = CreateZoneLaneDesc(LaneWidth, LaneDirection, LaneTags);
 		LaneProfile.Lanes.Add(LaneDesc);
@@ -540,8 +538,8 @@ bool UTempoRoadLaneGraphSubsystem::TryGetDynamicLaneProfileFromSettings(const FZ
 FZoneLaneProfile UTempoRoadLaneGraphSubsystem::GetLaneProfile(const AActor& RoadQueryActor, bool bQueryActorIsRoadModule) const
 {
 	const FName LaneProfileOverrideName = bQueryActorIsRoadModule
-		? ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneProfileOverrideName(&RoadQueryActor)
-		: ITempoRoadInterface::Execute_GetTempoLaneProfileOverrideName(&RoadQueryActor);
+		? UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneProfileOverrideName)
+		: UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetTempoLaneProfileOverrideName);
 
 	if (LaneProfileOverrideName != NAME_None)
 	{
@@ -609,14 +607,14 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForI
 	ZoneShapeComponent->SetPolygonRoutingType(EZoneShapePolygonRoutingType::Bezier);
 
 	// Apply intersection tags.
-	TArray<FName> IntersectionTagNames = ITempoIntersectionInterface::Execute_GetTempoIntersectionTags(&IntersectionQueryActor);
+	TArray<FName> IntersectionTagNames = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionTags);
 	for (FName IntersectionTagName : IntersectionTagNames)
 	{
 		const FZoneGraphTag IntersectionTag = GetTagByName(IntersectionTagName);
 		ZoneShapeComponent->GetMutableTags().Add(IntersectionTag);
 	}
 	
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(&IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 
 	// Create and Setup Points.
 	for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
@@ -641,7 +639,7 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForI
 
 bool UTempoRoadLaneGraphSubsystem::TryCreateZoneShapePointForIntersectionEntranceLocation(const AActor& IntersectionQueryActor, int32 ConnectionIndex, UZoneShapeComponent& ZoneShapeComponent, FZoneShapePoint& OutZoneShapePoint) const
 {
-	const FVector IntersectionEntranceLocationInWorldFrame = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(&IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+	const FVector IntersectionEntranceLocationInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation, ConnectionIndex, ETempoCoordinateSpace::World);
 	
 	DrawDebugSphere(GetWorld(), IntersectionEntranceLocationInWorldFrame, 50.0f, 32, FColor::Green, false, 5.0f);
 
@@ -671,8 +669,8 @@ bool UTempoRoadLaneGraphSubsystem::TryCreateZoneShapePointForIntersectionEntranc
 	ZoneShapePoint.LaneProfile = PerPointLaneProfileIndex;
 	ZoneShapePoint.TangentLength = LaneProfile.GetLanesTotalWidth() * 0.5f;
 
-	const FVector IntersectionEntranceTangentInWorldFrame = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(&IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
-	const FVector IntersectionEntranceUpVectorInWorldFrame = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector(&IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+	const FVector IntersectionEntranceTangentInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, ConnectionIndex, ETempoCoordinateSpace::World);
+	const FVector IntersectionEntranceUpVectorInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector, ConnectionIndex, ETempoCoordinateSpace::World);
 
 	ZoneShapePoint.SetRotationFromForwardAndUp(ZoneShapeComponent.GetComponentToWorld().InverseTransformPosition(IntersectionEntranceTangentInWorldFrame),
 		ZoneShapeComponent.GetComponentToWorld().InverseTransformPosition(IntersectionEntranceUpVectorInWorldFrame));
@@ -680,8 +678,8 @@ bool UTempoRoadLaneGraphSubsystem::TryCreateZoneShapePointForIntersectionEntranc
 	DrawDebugDirectionalArrow(GetWorld(), IntersectionQueryActor.ActorToWorld().TransformPosition(ZoneShapePoint.GetInControlPoint()), IntersectionQueryActor.ActorToWorld().TransformPosition(ZoneShapePoint.Position), 10000.0f, FColor::Blue, false, 10.0f, 0, 10.0f);
 	DrawDebugDirectionalArrow(GetWorld(), IntersectionQueryActor.ActorToWorld().TransformPosition(ZoneShapePoint.Position), IntersectionQueryActor.ActorToWorld().TransformPosition(ZoneShapePoint.GetOutControlPoint()), 10000.0f, FColor::Red, false, 10.0f, 0, 10.0f);
 
-	const int32 IntersectionEntranceControlPointIndex = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceControlPointIndex(&IntersectionQueryActor, ConnectionIndex);
-	const FVector RoadTangentAtIntersectionEntranceInWorldFrame = ITempoRoadInterface::Execute_GetTempoControlPointTangent(RoadQueryActor, IntersectionEntranceControlPointIndex, ETempoCoordinateSpace::World);
+	const int32 IntersectionEntranceControlPointIndex = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceControlPointIndex, ConnectionIndex);
+	const FVector RoadTangentAtIntersectionEntranceInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTempoControlPointTangent, IntersectionEntranceControlPointIndex, ETempoCoordinateSpace::World);
 	
 	const bool bIsRoadLeavingIntersection = RoadTangentAtIntersectionEntranceInWorldFrame.Dot(IntersectionEntranceTangentInWorldFrame) < 0.0f;
 	if (bIsRoadLeavingIntersection)
@@ -696,7 +694,7 @@ bool UTempoRoadLaneGraphSubsystem::TryCreateZoneShapePointForIntersectionEntranc
 
 AActor* UTempoRoadLaneGraphSubsystem::GetConnectedRoadActor(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const
 {
-	AActor* RoadActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(&IntersectionQueryActor, ConnectionIndex);
+	AActor* RoadActor = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor, ConnectionIndex);
 			
 	if (RoadActor == nullptr)
 	{
@@ -717,11 +715,11 @@ AActor* UTempoRoadLaneGraphSubsystem::GetConnectedRoadActor(const AActor& Inters
 
 bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForCrosswalksAtIntersections(AActor& CrosswalkQueryActor) const
 {
-	const int32 NumConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalks(&CrosswalkQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalks);
 	
 	for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
 	{
-		const bool bShouldGenerateZoneShapesForCrosswalk = ITempoCrosswalkInterface::Execute_ShouldGenerateZoneShapesForTempoCrosswalk(&CrosswalkQueryActor, ConnectionIndex);
+		const bool bShouldGenerateZoneShapesForCrosswalk = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_ShouldGenerateZoneShapesForTempoCrosswalk, ConnectionIndex);
 
 		if (!bShouldGenerateZoneShapesForCrosswalk)
 		{
@@ -749,15 +747,15 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForC
 		ZoneShapeComponent->SetCommonLaneProfile(LaneProfileRef);
 
 		// Apply crosswalk tags.
-		TArray<FName> CrosswalkTagNames = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkTags(&CrosswalkQueryActor, ConnectionIndex);
+		TArray<FName> CrosswalkTagNames = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkTags, ConnectionIndex);
 		for (const FName& CrosswalkTagName : CrosswalkTagNames)
 		{
 			const FZoneGraphTag CrosswalkTag = GetTagByName(CrosswalkTagName);
 			ZoneShapeComponent->GetMutableTags().Add(CrosswalkTag);
 		}
 
-		const int32 CrosswalkControlPointStartIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(&CrosswalkQueryActor, ConnectionIndex);
-		const int32 CrosswalkControlPointEndIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(&CrosswalkQueryActor, ConnectionIndex);
+		const int32 CrosswalkControlPointStartIndex = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex, ConnectionIndex);
+		const int32 CrosswalkControlPointEndIndex = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex, ConnectionIndex);
 		
 		for (int32 CrosswalkControlPointIndex = CrosswalkControlPointStartIndex; CrosswalkControlPointIndex <= CrosswalkControlPointEndIndex; ++CrosswalkControlPointIndex)
 		{
@@ -791,16 +789,16 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForC
 			return 0;
 		}
 
-		const float RoadModuleLength = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLength(&RoadModuleQueryActor);
+		const float RoadModuleLength = UTempoCoreUtils::CallBlueprintFunction(&RoadModuleQueryActor, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLength);
 
 		StartDistance = FMath::Clamp(StartDistance, 0.0f, RoadModuleLength);
 		EndDistance = FMath::Clamp(EndDistance, 0.0f, RoadModuleLength);
 
-		const int32 NumRoadModuleControlPoints = ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleControlPoints(&RoadModuleQueryActor);
+		const int32 NumRoadModuleControlPoints = UTempoCoreUtils::CallBlueprintFunction(&RoadModuleQueryActor, ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleControlPoints);
 
 		for (int32 RoadModuleControlPointIndex = 0; RoadModuleControlPointIndex < NumRoadModuleControlPoints; ++RoadModuleControlPointIndex)
 		{
-			const float DistanceAlongRoadModule = ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleAtControlPoint(&RoadModuleQueryActor, RoadModuleControlPointIndex);
+			const float DistanceAlongRoadModule = UTempoCoreUtils::CallBlueprintFunction(&RoadModuleQueryActor, ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleAtControlPoint, RoadModuleControlPointIndex);
 
 			if (DistanceAlongRoadModule >= StartDistance && DistanceAlongRoadModule <= EndDistance)
 			{
@@ -811,11 +809,11 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForC
 		return RoadModuleControlPointIndexes.Num();
 	};
 	
-	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(&CrosswalkQueryActor);
+	const int32 NumCrosswalkRoadModules = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules);
 
 	for (int32 CrosswalkRoadModuleIndex = 0; CrosswalkRoadModuleIndex < NumCrosswalkRoadModules; ++CrosswalkRoadModuleIndex)
 	{
-		const FCrosswalkIntersectionConnectorInfo& CrosswalkIntersectionConnectorInfo = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionConnectorInfo(&CrosswalkQueryActor, CrosswalkRoadModuleIndex);
+		const FCrosswalkIntersectionConnectorInfo& CrosswalkIntersectionConnectorInfo = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionConnectorInfo, CrosswalkRoadModuleIndex);
 
 		if (!ensureMsgf(CrosswalkIntersectionConnectorInfo.CrosswalkRoadModule != nullptr, TEXT("Must get valid CrosswalkRoadModule in UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersectionConnectorSegments.")))
 		{
@@ -872,7 +870,7 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForC
 
 bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForCrosswalkIntersections(AActor& CrosswalkQueryActor) const
 {
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(&CrosswalkQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	for (int32 CrosswalkIntersectionIndex = 0; CrosswalkIntersectionIndex < NumCrosswalkIntersections; ++CrosswalkIntersectionIndex)
 	{
@@ -890,14 +888,14 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForC
 		ZoneShapeComponent->SetPolygonRoutingType(EZoneShapePolygonRoutingType::Bezier);
 
 		// Apply crosswalk intersection tags.
-		TArray<FName> IntersectionTagNames = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionTags(&CrosswalkQueryActor, CrosswalkIntersectionIndex);
+		TArray<FName> IntersectionTagNames = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionTags, CrosswalkIntersectionIndex);
 		for (FName IntersectionTagName : IntersectionTagNames)
 		{
 			const FZoneGraphTag IntersectionTag = GetTagByName(IntersectionTagName);
 			ZoneShapeComponent->GetMutableTags().Add(IntersectionTag);
 		}
 	
-		const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(&CrosswalkQueryActor, CrosswalkIntersectionIndex);
+		const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 		// Create and Setup Points.
 		for (int32 CrosswalkIntersectionConnectionIndex = 0; CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections; ++CrosswalkIntersectionConnectionIndex)
@@ -923,8 +921,8 @@ bool UTempoRoadLaneGraphSubsystem::TryGenerateAndRegisterZoneShapeComponentsForC
 
 bool UTempoRoadLaneGraphSubsystem::TryCreateZoneShapePointForCrosswalkIntersectionEntranceLocation(const AActor& CrosswalkQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex, UZoneShapeComponent& ZoneShapeComponent, FZoneShapePoint& OutZoneShapePoint) const
 {
-	const FVector CrosswalkIntersectionEntranceLocationInWorldFrame = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceLocation(&CrosswalkQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace::World);
-	
+	const FVector CrosswalkIntersectionEntranceLocationInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceLocation, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace::World);
+
 	DrawDebugSphere(GetWorld(), CrosswalkIntersectionEntranceLocationInWorldFrame, 25.0f, 16, FColor::Green, false, 5.0f);
 
 	const FZoneLaneProfile LaneProfile = GetCrosswalkIntersectionEntranceLaneProfile(CrosswalkQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
@@ -945,8 +943,8 @@ bool UTempoRoadLaneGraphSubsystem::TryCreateZoneShapePointForCrosswalkIntersecti
 	ZoneShapePoint.LaneProfile = PerPointLaneProfileIndex;
 	ZoneShapePoint.TangentLength = LaneProfile.GetLanesTotalWidth() * 0.5f;
 
-	const FVector CrosswalkIntersectionEntranceTangentInWorldFrame = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceTangent(&CrosswalkQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace::World);
-	const FVector CrosswalkIntersectionEntranceUpVectorInWorldFrame = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceUpVector(&CrosswalkQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace::World);
+	const FVector CrosswalkIntersectionEntranceTangentInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceTangent, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace::World);
+	const FVector CrosswalkIntersectionEntranceUpVectorInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceUpVector, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, ETempoCoordinateSpace::World);
 
 	ZoneShapePoint.SetRotationFromForwardAndUp(ZoneShapeComponent.GetComponentToWorld().InverseTransformPosition(CrosswalkIntersectionEntranceTangentInWorldFrame),
 		ZoneShapeComponent.GetComponentToWorld().InverseTransformPosition(CrosswalkIntersectionEntranceUpVectorInWorldFrame));
@@ -963,11 +961,11 @@ bool UTempoRoadLaneGraphSubsystem::TryCreateZoneShapePointForCrosswalkControlPoi
 {
 	FZoneShapePoint ZoneShapePoint;
 	
-	const FVector CrosswalkControlPointLocation = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation(&CrosswalkQueryActor, ConnectionIndex, CrosswalkControlPointIndex, ETempoCoordinateSpace::World);
-	const FVector CrosswalkControlPointTangent = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointTangent(&CrosswalkQueryActor, ConnectionIndex, CrosswalkControlPointIndex, ETempoCoordinateSpace::World);
+	const FVector CrosswalkControlPointLocation = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation, ConnectionIndex, CrosswalkControlPointIndex, ETempoCoordinateSpace::World);
+	const FVector CrosswalkControlPointTangent = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointTangent, ConnectionIndex, CrosswalkControlPointIndex, ETempoCoordinateSpace::World);
 
 	const FVector CrosswalkControlPointForwardVector = CrosswalkControlPointTangent.GetSafeNormal();
-	const FVector CrosswalkControlPointUpVector = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointUpVector(&CrosswalkQueryActor, ConnectionIndex, CrosswalkControlPointIndex, ETempoCoordinateSpace::World);
+	const FVector CrosswalkControlPointUpVector = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointUpVector, ConnectionIndex, CrosswalkControlPointIndex, ETempoCoordinateSpace::World);
 
 	ZoneShapePoint.Position = CrosswalkQueryActor.GetTransform().InverseTransformPosition(CrosswalkControlPointLocation);
 	ZoneShapePoint.Type = FZoneShapePointType::Bezier;
@@ -985,16 +983,16 @@ FZoneLaneProfile UTempoRoadLaneGraphSubsystem::CreateDynamicLaneProfileForCrossw
 {
 	FZoneLaneProfile LaneProfile;
 	
-	const int32 NumLanes = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkLanes(&CrosswalkQueryActor, ConnectionIndex);
+	const int32 NumLanes = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkLanes, ConnectionIndex);
 
 	for (int32 LaneIndex = 0; LaneIndex < NumLanes; ++LaneIndex)
 	{
 		// ZoneGraph's LaneProfiles specify lanes from right to left.
 		const int32 LaneProfileLaneIndex = NumLanes - 1 - LaneIndex;
 		
-		const float LaneWidth = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneWidth(&CrosswalkQueryActor, ConnectionIndex, LaneProfileLaneIndex);
-		const EZoneLaneDirection LaneDirection = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneDirection(&CrosswalkQueryActor, ConnectionIndex, LaneProfileLaneIndex);
-		const TArray<FName> LaneTags = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneTags(&CrosswalkQueryActor, ConnectionIndex, LaneProfileLaneIndex);
+		const float LaneWidth = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneWidth, ConnectionIndex, LaneProfileLaneIndex);
+		const EZoneLaneDirection LaneDirection = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneDirection, ConnectionIndex, LaneProfileLaneIndex);
+		const TArray<FName> LaneTags = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneTags, ConnectionIndex, LaneProfileLaneIndex);
 
 		FZoneLaneDesc LaneDesc = CreateZoneLaneDesc(LaneWidth, LaneDirection, LaneTags);
 		LaneProfile.Lanes.Add(LaneDesc);
@@ -1007,7 +1005,7 @@ FZoneLaneProfile UTempoRoadLaneGraphSubsystem::CreateDynamicLaneProfileForCrossw
 
 FZoneLaneProfile UTempoRoadLaneGraphSubsystem::GetLaneProfileForCrosswalk(const AActor& CrosswalkQueryActor, int32 ConnectionIndex) const
 {
-	const FName LaneProfileOverrideName = ITempoCrosswalkInterface::Execute_GetLaneProfileOverrideNameForTempoCrosswalk(&CrosswalkQueryActor, ConnectionIndex);
+	const FName LaneProfileOverrideName = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetLaneProfileOverrideNameForTempoCrosswalk, ConnectionIndex);
 
 	if (LaneProfileOverrideName != NAME_None)
 	{
@@ -1040,16 +1038,16 @@ FZoneLaneProfile UTempoRoadLaneGraphSubsystem::CreateCrosswalkIntersectionConnec
 {
 	FZoneLaneProfile LaneProfile;
 	
-	const int32 NumLanes = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnectorLanes(&CrosswalkQueryActor, CrosswalkRoadModuleIndex);
+	const int32 NumLanes = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnectorLanes, CrosswalkRoadModuleIndex);
 
 	for (int32 LaneIndex = 0; LaneIndex < NumLanes; ++LaneIndex)
 	{
 		// ZoneGraph's LaneProfiles specify lanes from right to left.
 		const int32 LaneProfileLaneIndex = NumLanes - 1 - LaneIndex;
 		
-		const float LaneWidth = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionConnectorLaneWidth(&CrosswalkQueryActor, CrosswalkRoadModuleIndex, LaneProfileLaneIndex);
-		const EZoneLaneDirection LaneDirection = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionConnectorLaneDirection(&CrosswalkQueryActor, CrosswalkRoadModuleIndex, LaneProfileLaneIndex);
-		const TArray<FName> LaneTags = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionConnectorLaneTags(&CrosswalkQueryActor, CrosswalkRoadModuleIndex, LaneProfileLaneIndex);
+		const float LaneWidth = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionConnectorLaneWidth, CrosswalkRoadModuleIndex, LaneProfileLaneIndex);
+		const EZoneLaneDirection LaneDirection = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionConnectorLaneDirection, CrosswalkRoadModuleIndex, LaneProfileLaneIndex);
+		const TArray<FName> LaneTags = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionConnectorLaneTags, CrosswalkRoadModuleIndex, LaneProfileLaneIndex);
 
 		FZoneLaneDesc LaneDesc = CreateZoneLaneDesc(LaneWidth, LaneDirection, LaneTags);
 		LaneProfile.Lanes.Add(LaneDesc);
@@ -1062,7 +1060,7 @@ FZoneLaneProfile UTempoRoadLaneGraphSubsystem::CreateCrosswalkIntersectionConnec
 
 FZoneLaneProfile UTempoRoadLaneGraphSubsystem::GetCrosswalkIntersectionConnectorLaneProfile(const AActor& CrosswalkQueryActor, int32 CrosswalkRoadModuleIndex) const
 {
-	const FName LaneProfileOverrideName = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionConnectorLaneProfileOverrideName(&CrosswalkQueryActor, CrosswalkRoadModuleIndex);
+	const FName LaneProfileOverrideName = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionConnectorLaneProfileOverrideName, CrosswalkRoadModuleIndex);
 
 	if (LaneProfileOverrideName != NAME_None)
 	{
@@ -1095,16 +1093,16 @@ FZoneLaneProfile UTempoRoadLaneGraphSubsystem::CreateCrosswalkIntersectionEntran
 {
 	FZoneLaneProfile LaneProfile;
 	
-	const int32 NumLanes = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionEntranceLanes(&CrosswalkQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
+	const int32 NumLanes = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionEntranceLanes, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
 
 	for (int32 LaneIndex = 0; LaneIndex < NumLanes; ++LaneIndex)
 	{
 		// ZoneGraph's LaneProfiles specify lanes from right to left.
 		const int32 LaneProfileLaneIndex = NumLanes - 1 - LaneIndex;
 		
-		const float LaneWidth = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceLaneWidth(&CrosswalkQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, LaneProfileLaneIndex);
-		const EZoneLaneDirection LaneDirection = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceLaneDirection(&CrosswalkQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, LaneProfileLaneIndex);
-		const TArray<FName> LaneTags = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceLaneTags(&CrosswalkQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, LaneProfileLaneIndex);
+		const float LaneWidth = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceLaneWidth, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, LaneProfileLaneIndex);
+		const EZoneLaneDirection LaneDirection = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceLaneDirection, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, LaneProfileLaneIndex);
+		const TArray<FName> LaneTags = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceLaneTags, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex, LaneProfileLaneIndex);
 
 		FZoneLaneDesc LaneDesc = CreateZoneLaneDesc(LaneWidth, LaneDirection, LaneTags);
 		LaneProfile.Lanes.Add(LaneDesc);
@@ -1117,7 +1115,7 @@ FZoneLaneProfile UTempoRoadLaneGraphSubsystem::CreateCrosswalkIntersectionEntran
 
 FZoneLaneProfile UTempoRoadLaneGraphSubsystem::GetCrosswalkIntersectionEntranceLaneProfile(const AActor& CrosswalkQueryActor, int32 CrosswalkIntersectionIndex, int32 CrosswalkIntersectionConnectionIndex) const
 {
-	const FName LaneProfileOverrideName = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceLaneProfileOverrideName(&CrosswalkQueryActor, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
+	const FName LaneProfileOverrideName = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkIntersectionEntranceLaneProfileOverrideName, CrosswalkIntersectionIndex, CrosswalkIntersectionConnectionIndex);
 
 	if (LaneProfileOverrideName != NAME_None)
 	{

--- a/TempoAgents/Source/TempoAgentsEditor/Private/TempoZoneGraphBuilder.cpp
+++ b/TempoAgents/Source/TempoAgentsEditor/Private/TempoZoneGraphBuilder.cpp
@@ -6,6 +6,8 @@
 #include "TempoRoadInterface.h"
 #include "ZoneShapeUtilities.h"
 
+#include "TempoCoreUtils.h"
+
 bool FTempoZoneGraphBuilder::ShouldFilterLaneConnection(const UZoneShapeComponent& PolygonShapeComp, const UZoneShapeComponent& SourceShapeComp, const TArray<FLaneConnectionSlot>& SourceSlots, const int32 SourceSlotQueryIndex, const UZoneShapeComponent& DestShapeComp, const TArray<FLaneConnectionSlot>& DestSlots, const int32 DestSlotQueryIndex) const
 {
 	const AActor* IntersectionQueryActor = GetIntersectionQueryActor(PolygonShapeComp);
@@ -23,8 +25,7 @@ bool FTempoZoneGraphBuilder::ShouldFilterLaneConnection(const UZoneShapeComponen
 
 	bool bShouldFilterLaneConnection;
 	{
-		FEditorScriptExecutionGuard ScriptGuard;
-		bShouldFilterLaneConnection = ITempoIntersectionInterface::Execute_ShouldFilterTempoLaneConnection(IntersectionQueryActor, SourceRoadQueryActor, SourceLaneConnectionInfos, SourceSlotQueryIndex, DestRoadQueryActor, DestLaneConnectionInfos, DestSlotQueryIndex);
+		bShouldFilterLaneConnection = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_ShouldFilterTempoLaneConnection, SourceRoadQueryActor, SourceLaneConnectionInfos, SourceSlotQueryIndex, DestRoadQueryActor, DestLaneConnectionInfos, DestSlotQueryIndex);
 	}
 
 	return bShouldFilterLaneConnection;

--- a/TempoAgents/Source/TempoAgentsEditor/TempoAgentsEditor.Build.cs
+++ b/TempoAgents/Source/TempoAgentsEditor/TempoAgentsEditor.Build.cs
@@ -51,6 +51,7 @@ public class TempoAgentsEditor : TempoModuleRules
 				"TempoAgentsShared",
 				"TempoAgents",
 				"TempoScripting",
+				"TempoCoreShared",
 			}
 			);
 		

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoAgentsWorldSubsystem.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoAgentsWorldSubsystem.cpp
@@ -2,17 +2,18 @@
 
 #include "TempoAgentsWorldSubsystem.h"
 
-#include "EngineUtils.h"
-#include "MassTrafficLightRegistrySubsystem.h"
-#include "MassTrafficSubsystem.h"
 #include "TempoAgentsShared.h"
 #include "TempoBrightnessMeter.h"
-#include "TempoBrightnessMeterComponent.h"
+#include "TempoCoreUtils.h"
 #include "TempoCrosswalkInterface.h"
 #include "TempoIntersectionInterface.h"
 #include "TempoRoadInterface.h"
-#include "TempoRoadModuleInterface.h"
+
+#include "MassTrafficLightRegistrySubsystem.h"
+#include "MassTrafficSubsystem.h"
 #include "ZoneGraphQuery.h"
+
+#include "EngineUtils.h"
 #include "Kismet/GameplayStatics.h"
 
 void UTempoAgentsWorldSubsystem::SetupTrafficControllers()
@@ -42,7 +43,7 @@ void UTempoAgentsWorldSubsystem::SetupTrafficControllers()
 			continue;
 		}
 
-		ITempoIntersectionInterface::Execute_SetupTempoTrafficControllers(Actor);
+		UTempoCoreUtils::CallBlueprintFunction(Actor, ITempoIntersectionInterface::Execute_SetupTempoTrafficControllers);
 	}
 }
 
@@ -88,14 +89,14 @@ void UTempoAgentsWorldSubsystem::SetupBrightnessMeter()
 
 	AActor& AnchorRoadActor = *RoadActors[0];
 
-	const int32 RoadStartEntranceLocationControlPointIndex = ITempoRoadInterface::Execute_GetTempoStartEntranceLocationControlPointIndex(&AnchorRoadActor);
+	const int32 RoadStartEntranceLocationControlPointIndex = UTempoCoreUtils::CallBlueprintFunction(&AnchorRoadActor, ITempoRoadInterface::Execute_GetTempoStartEntranceLocationControlPointIndex);
 	
-	const FVector RoadStartLocation = ITempoRoadInterface::Execute_GetTempoControlPointLocation(&AnchorRoadActor, RoadStartEntranceLocationControlPointIndex, ETempoCoordinateSpace::World);
-	const FVector RoadForwardVector = ITempoRoadInterface::Execute_GetTempoControlPointTangent(&AnchorRoadActor, RoadStartEntranceLocationControlPointIndex, ETempoCoordinateSpace::World).GetSafeNormal();
-	const FVector RoadRightVector = ITempoRoadInterface::Execute_GetTempoControlPointRightVector(&AnchorRoadActor, RoadStartEntranceLocationControlPointIndex, ETempoCoordinateSpace::World);
-	const FVector RoadUpVector = ITempoRoadInterface::Execute_GetTempoControlPointUpVector(&AnchorRoadActor, RoadStartEntranceLocationControlPointIndex, ETempoCoordinateSpace::World);
+	const FVector RoadStartLocation = UTempoCoreUtils::CallBlueprintFunction(&AnchorRoadActor, ITempoRoadInterface::Execute_GetTempoControlPointLocation, RoadStartEntranceLocationControlPointIndex, ETempoCoordinateSpace::World);
+	const FVector RoadForwardVector = UTempoCoreUtils::CallBlueprintFunction(&AnchorRoadActor, ITempoRoadInterface::Execute_GetTempoControlPointTangent, RoadStartEntranceLocationControlPointIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+	const FVector RoadRightVector = UTempoCoreUtils::CallBlueprintFunction(&AnchorRoadActor, ITempoRoadInterface::Execute_GetTempoControlPointRightVector, RoadStartEntranceLocationControlPointIndex, ETempoCoordinateSpace::World);
+	const FVector RoadUpVector = UTempoCoreUtils::CallBlueprintFunction(&AnchorRoadActor, ITempoRoadInterface::Execute_GetTempoControlPointUpVector, RoadStartEntranceLocationControlPointIndex, ETempoCoordinateSpace::World);
 
-	const float RoadWidth = ITempoRoadInterface::Execute_GetTempoRoadWidth(&AnchorRoadActor);
+	const float RoadWidth = UTempoCoreUtils::CallBlueprintFunction(&AnchorRoadActor, ITempoRoadInterface::Execute_GetTempoRoadWidth);
 	const float TotalLateralOffset = RoadWidth * 0.5f + BrightnessMeterLateralOffset;
 	
 	const FVector SpawnLocation = RoadStartLocation + RoadForwardVector * BrightnessMeterLongitudinalOffset + RoadRightVector * TotalLateralOffset + RoadUpVector * BrightnessMeterVerticalOffset;
@@ -132,11 +133,11 @@ void UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap()
 	{
 		TArray<FName> AggregateRoadLaneTags;
 		
-		const int32 NumLanes = ITempoRoadInterface::Execute_GetNumTempoLanes(&RoadQueryActor);
+		const int32 NumLanes = UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetNumTempoLanes);
 
 		for (int32 LaneIndex = 0; LaneIndex < NumLanes; ++LaneIndex)
 		{
-			const TArray<FName> RoadLaneTags = ITempoRoadInterface::Execute_GetTempoLaneTags(&RoadQueryActor, LaneIndex);
+			const TArray<FName> RoadLaneTags = UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetTempoLaneTags, LaneIndex);
 
 			for (const FName& RoadLaneTag : RoadLaneTags)
 			{
@@ -179,26 +180,26 @@ void UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap()
 
 		const AActor& IntersectionQueryActor = *Actor;
 
-		const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(&IntersectionQueryActor);
+		const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 		
 		for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
 		{
-			const AActor* RoadQueryActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(&IntersectionQueryActor, ConnectionIndex);
+			const AActor* RoadQueryActor = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor, ConnectionIndex);
 			if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("Couldn't get valid Connected Road Actor for Actor: %s at ConnectionIndex: %d in UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap."), *IntersectionQueryActor.GetName(), ConnectionIndex))
 			{
 				return;
 			}
 			
-			const int32 CrosswalkStartControlPointIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(&IntersectionQueryActor, ConnectionIndex);
-			const int32 CrosswalkEndControlPointIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(&IntersectionQueryActor, ConnectionIndex);
+			const int32 CrosswalkStartControlPointIndex = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex, ConnectionIndex);
+			const int32 CrosswalkEndControlPointIndex = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex, ConnectionIndex);
 			
-			const FVector CrosswalkStartControlPointLocation = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation(&IntersectionQueryActor, ConnectionIndex, CrosswalkStartControlPointIndex, ETempoCoordinateSpace::World);
-			const FVector CrosswalkEndControlPointLocation = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation(&IntersectionQueryActor, ConnectionIndex, CrosswalkEndControlPointIndex, ETempoCoordinateSpace::World);
+			const FVector CrosswalkStartControlPointLocation = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation, ConnectionIndex, CrosswalkStartControlPointIndex, ETempoCoordinateSpace::World);
+			const FVector CrosswalkEndControlPointLocation = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation, ConnectionIndex, CrosswalkEndControlPointIndex, ETempoCoordinateSpace::World);
 
-			const FVector IntersectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(&IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
-			const FVector IntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(&IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+			const FVector IntersectionEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation, ConnectionIndex, ETempoCoordinateSpace::World);
+			const FVector IntersectionEntranceRightVector = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector, ConnectionIndex, ETempoCoordinateSpace::World);
 
-			const float RoadWidth = ITempoRoadInterface::Execute_GetTempoRoadWidth(RoadQueryActor);
+			const float RoadWidth = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTempoRoadWidth);
 			const float LateralDistanceToIntersectionExitCenter = RoadWidth / 4.0f;
 
 			const FVector IntersectionQueryLocation = IntersectionEntranceLocation - IntersectionEntranceRightVector * LateralDistanceToIntersectionExitCenter;
@@ -207,7 +208,7 @@ void UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap()
 			const float QueryRadius = FMath::Max(LateralDistanceToIntersectionExitCenter, DistanceToCrosswalkCenter);
 
 			const TArray<FName> RoadLaneTags = GetRoadLaneTags(*RoadQueryActor);
-			const TArray<FName> CrosswalkTags = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkTags(&IntersectionQueryActor, ConnectionIndex);
+			const TArray<FName> CrosswalkTags = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkTags, ConnectionIndex);
 
 			const FZoneGraphTagMask RoadLaneAnyTagMask = GenerateTagMaskFromTagNames(RoadLaneTags);
 			const FZoneGraphTagMask CrosswalkAllTagMask = GenerateTagMaskFromTagNames(CrosswalkTags);
@@ -273,7 +274,7 @@ void UTempoAgentsWorldSubsystem::SetupIntersectionLaneMap()
 
 					const FVector LastLaneTangent = ZoneGraphStorage->LaneTangentVectors[LastLanePointsIndex];
 
-					const FVector IntersectionEntranceForwardVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(&IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+					const FVector IntersectionEntranceForwardVector = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
 
 					const bool bLaneIsExitingIntersection = FVector::DotProduct(IntersectionEntranceForwardVector, LastLaneTangent) < 0.0f;
 					

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionControlComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionControlComponent.cpp
@@ -8,6 +8,8 @@
 #include "TempoAgentsShared.h"
 #include "TempoRoadInterface.h"
 
+#include "TempoCoreUtils.h"
+
 void UTempoIntersectionControlComponent::SetupTrafficControllers()
 {
 	UWorld* World = GetWorld();
@@ -51,7 +53,7 @@ void UTempoIntersectionControlComponent::SetupTrafficControllerMeshData()
 
 	DestroyTrafficControllerMeshData();
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(OwnerActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(OwnerActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
 	{
@@ -64,11 +66,11 @@ void UTempoIntersectionControlComponent::SetupTrafficControllerMeshData()
 			return;
 		}
 
-		const ETempoTrafficControllerType TrafficControllerType = ITempoIntersectionInterface::Execute_GetTempoTrafficControllerType(OwnerActor);
+		const ETempoTrafficControllerType TrafficControllerType = UTempoCoreUtils::CallBlueprintFunction(OwnerActor, ITempoIntersectionInterface::Execute_GetTempoTrafficControllerType);
 		
-		FTempoTrafficControllerMeshInfo TrafficControllerMeshInfo = ITempoIntersectionInterface::Execute_GetTempoTrafficControllerMeshInfo(OwnerActor, ConnectionIndex, TrafficControllerType);
-		const FVector TrafficControllerLocation = ITempoIntersectionInterface::Execute_GetTempoTrafficControllerLocation(OwnerActor, ConnectionIndex, TrafficControllerType, ETempoCoordinateSpace::World);
-		const FRotator TrafficControllerRotation = ITempoIntersectionInterface::Execute_GetTempoTrafficControllerRotation(OwnerActor, ConnectionIndex, TrafficControllerType, ETempoCoordinateSpace::World);
+		FTempoTrafficControllerMeshInfo TrafficControllerMeshInfo = UTempoCoreUtils::CallBlueprintFunction(OwnerActor, ITempoIntersectionInterface::Execute_GetTempoTrafficControllerMeshInfo, ConnectionIndex, TrafficControllerType);
+		const FVector TrafficControllerLocation = UTempoCoreUtils::CallBlueprintFunction(OwnerActor, ITempoIntersectionInterface::Execute_GetTempoTrafficControllerLocation, ConnectionIndex, TrafficControllerType, ETempoCoordinateSpace::World);
+		const FRotator TrafficControllerRotation = UTempoCoreUtils::CallBlueprintFunction(OwnerActor, ITempoIntersectionInterface::Execute_GetTempoTrafficControllerRotation, ConnectionIndex, TrafficControllerType, ETempoCoordinateSpace::World);
 
 		MeshComponent->SetWorldLocation(TrafficControllerLocation);
 		MeshComponent->SetWorldRotation(TrafficControllerRotation);
@@ -106,7 +108,7 @@ void UTempoIntersectionControlComponent::SetupTrafficControllerRuntimeData()
 		return;
 	}
 
-	const ETempoTrafficControllerType TrafficControllerType = ITempoIntersectionInterface::Execute_GetTempoTrafficControllerType(OwnerActor);
+	const ETempoTrafficControllerType TrafficControllerType = UTempoCoreUtils::CallBlueprintFunction(OwnerActor, ITempoIntersectionInterface::Execute_GetTempoTrafficControllerType);
 	if (TrafficControllerType != ETempoTrafficControllerType::TrafficLight)
 	{
 		// Currently, only Traffic Lights require additional runtime setup.
@@ -128,15 +130,15 @@ void UTempoIntersectionControlComponent::SetupTrafficControllerRuntimeData()
 		return;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(OwnerActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(OwnerActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
 	{
-		FTempoTrafficControllerMeshInfo TrafficControllerMeshInfo = ITempoIntersectionInterface::Execute_GetTempoTrafficControllerMeshInfo(OwnerActor, ConnectionIndex, TrafficControllerType);
-		const FVector TrafficControllerLocation = ITempoIntersectionInterface::Execute_GetTempoTrafficControllerLocation(OwnerActor, ConnectionIndex, TrafficControllerType, ETempoCoordinateSpace::World);
-		const FRotator TrafficControllerRotation = ITempoIntersectionInterface::Execute_GetTempoTrafficControllerRotation(OwnerActor, ConnectionIndex, TrafficControllerType, ETempoCoordinateSpace::World);
+		FTempoTrafficControllerMeshInfo TrafficControllerMeshInfo = UTempoCoreUtils::CallBlueprintFunction(OwnerActor, ITempoIntersectionInterface::Execute_GetTempoTrafficControllerMeshInfo, ConnectionIndex, TrafficControllerType);
+		const FVector TrafficControllerLocation = UTempoCoreUtils::CallBlueprintFunction(OwnerActor, ITempoIntersectionInterface::Execute_GetTempoTrafficControllerLocation, ConnectionIndex, TrafficControllerType, ETempoCoordinateSpace::World);
+		const FRotator TrafficControllerRotation = UTempoCoreUtils::CallBlueprintFunction(OwnerActor, ITempoIntersectionInterface::Execute_GetTempoTrafficControllerRotation, ConnectionIndex, TrafficControllerType, ETempoCoordinateSpace::World);
 		
-		const FVector IntersectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(OwnerActor, ConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector IntersectionEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(OwnerActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation, ConnectionIndex, ETempoCoordinateSpace::World);
 		
 		const AActor* RoadQueryActor = GetConnectedRoadActor(*OwnerActor, ConnectionIndex);
 		if (RoadQueryActor == nullptr)
@@ -153,7 +155,7 @@ void UTempoIntersectionControlComponent::SetupTrafficControllerRuntimeData()
 		FMassStaticMeshInstanceVisualizationMeshDesc& MeshDesc = StaticMeshInstanceVisualizationDesc.Meshes.AddDefaulted_GetRef();
 		MeshDesc.Mesh = TrafficControllerMeshInfo.TrafficControllerMesh;
 
-		const int32 NumLanes = ITempoRoadInterface::Execute_GetNumTempoLanes(RoadQueryActor);
+		const int32 NumLanes = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetNumTempoLanes);
 		
 		FMassTrafficLightTypeData TrafficLightType(TrafficControllerMeshInfo.TrafficControllerMesh->GetFName(), StaticMeshInstanceVisualizationDesc, NumLanes);
 
@@ -206,12 +208,12 @@ bool UTempoIntersectionControlComponent::TryGetIntersectionTrafficControllerLoca
 			return false;
 		}
 		
-		const FVector CurrentIntersectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
-		const FVector TrafficLightAnchorIntersectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(IntersectionQueryActor, TrafficLightAnchorConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector CurrentIntersectionEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation, ConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector TrafficLightAnchorIntersectionEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation, TrafficLightAnchorConnectionIndex, ETempoCoordinateSpace::World);
 
-		const FVector TrafficLightAnchorIntersectionEntranceForwardVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, TrafficLightAnchorConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
-		const FVector TrafficLightAnchorIntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, TrafficLightAnchorConnectionIndex, ETempoCoordinateSpace::World);
-		const FVector TrafficLightAnchorIntersectionEntranceUpVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector(IntersectionQueryActor, TrafficLightAnchorConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector TrafficLightAnchorIntersectionEntranceForwardVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, TrafficLightAnchorConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+		const FVector TrafficLightAnchorIntersectionEntranceRightVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector, TrafficLightAnchorConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector TrafficLightAnchorIntersectionEntranceUpVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector, TrafficLightAnchorConnectionIndex, ETempoCoordinateSpace::World);
 		
 		const FVector LongitudinalOffset = TrafficLightAnchorIntersectionEntranceForwardVector * TrafficControllerMeshInfo.LongitudinalOffset;
 		
@@ -240,11 +242,11 @@ bool UTempoIntersectionControlComponent::TryGetIntersectionTrafficControllerLoca
 			return false;
 		}
 		
-		const FVector CurrentIntersectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector CurrentIntersectionEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation, ConnectionIndex, ETempoCoordinateSpace::World);
 		
-		const FVector CurrentIntersectionEntranceForwardVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
-		const FVector CurrentIntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
-		const FVector CurrentIntersectionEntranceUpVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector CurrentIntersectionEntranceForwardVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+		const FVector CurrentIntersectionEntranceRightVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector, ConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector CurrentIntersectionEntranceUpVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector, ConnectionIndex, ETempoCoordinateSpace::World);
 		
 		const FVector LongitudinalOffset = CurrentIntersectionEntranceForwardVector * TrafficControllerMeshInfo.LongitudinalOffset;
 
@@ -269,9 +271,9 @@ bool UTempoIntersectionControlComponent::TryGetIntersectionTrafficControllerRota
 		return false;
 	}
 
-	const FVector TrafficControllerForwardVector = -ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
-	const FVector TrafficControllerRightVector = -ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
-	const FVector TrafficControllerUpVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+	const FVector TrafficControllerForwardVector = -UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+	const FVector TrafficControllerRightVector = -UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector, ConnectionIndex, ETempoCoordinateSpace::World);
+	const FVector TrafficControllerUpVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector, ConnectionIndex, ETempoCoordinateSpace::World);
 
 	const FRotator TrafficControllerBaseRotation = FMatrix(TrafficControllerForwardVector, TrafficControllerRightVector, TrafficControllerUpVector, FVector::ZeroVector).Rotator();
 	const FRotator RotationOffset = FRotator(0.0f, TrafficControllerMeshInfo.YawOffset, 0.0f);
@@ -319,9 +321,9 @@ bool UTempoIntersectionControlComponent::TryGetRoadConfigurationInfoForIntersect
 		const float MaxThroughRoadAngleDegrees = TempoAgentsSettings != nullptr ? TempoAgentsSettings->GetMaxThroughRoadAngleDegrees() : 15.0f;
 		const float MaxThroughRoadAngleRadians = FMath::DegreesToRadians(MaxThroughRoadAngleDegrees);
 		
-		const FVector SourceEntranceTangentInWorldFrame = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, SourceConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+		const FVector SourceEntranceTangentInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, SourceConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
 
-		const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+		const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 
 		for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
 		{
@@ -331,7 +333,7 @@ bool UTempoIntersectionControlComponent::TryGetRoadConfigurationInfoForIntersect
 				continue;
 			}
 
-			const FVector DestinationEntranceTangentInWorldFrame = -ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+			const FVector DestinationEntranceTangentInWorldFrame = -UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
 
 			const float ForwardDotProduct = SourceEntranceTangentInWorldFrame.Dot(DestinationEntranceTangentInWorldFrame);
 			const bool bIsThroughRoad = ForwardDotProduct > FMath::Cos(MaxThroughRoadAngleRadians);
@@ -346,7 +348,7 @@ bool UTempoIntersectionControlComponent::TryGetRoadConfigurationInfoForIntersect
 					// Intentional fallthrough.
 				case ETempoRoadConfigurationDescriptor::RightTurn:
 					{
-						const FVector SourceEntranceRightVectorInWorldFrame = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, SourceConnectionIndex, ETempoCoordinateSpace::World);
+						const FVector SourceEntranceRightVectorInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector, SourceConnectionIndex, ETempoCoordinateSpace::World);
 						const float RightDotProduct = SourceEntranceRightVectorInWorldFrame.Dot(DestinationEntranceTangentInWorldFrame);
 						
 						return !bIsThroughRoad && ((RoadConfigurationDescriptor == ETempoRoadConfigurationDescriptor::RightTurn && RightDotProduct > 0.0f) || (RoadConfigurationDescriptor == ETempoRoadConfigurationDescriptor::LeftTurn && RightDotProduct < 0.0f));
@@ -385,9 +387,9 @@ bool UTempoIntersectionControlComponent::TryGetStraightestConnectionIndexForInte
     float MaxDotProduct = -1.0f;
     int32 StraightestRoadActorConnectionIndex = -1;
 
-    const FVector SourceEntranceTangentInWorldFrame = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, SourceConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+    const FVector SourceEntranceTangentInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, SourceConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
 
-    const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+    const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 
     for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
     {
@@ -397,7 +399,7 @@ bool UTempoIntersectionControlComponent::TryGetStraightestConnectionIndexForInte
 		    continue;
 		}
 
-		const FVector DestinationEntranceTangentInWorldFrame = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+		const FVector DestinationEntranceTangentInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
 
 		const float DotProduct = SourceEntranceTangentInWorldFrame.Dot(-DestinationEntranceTangentInWorldFrame);
 
@@ -455,7 +457,7 @@ FTempoRoadConfigurationInfo UTempoIntersectionControlComponent::GetPrioritizedRo
 {
 	for (const auto PrioritizedRoadConfigurationDescriptor : PrioritizedRoadConfigurationDescriptors)
 	{
-		TArray<FTempoRoadConfigurationInfo> RoadConfigurationInfos = ITempoIntersectionInterface::Execute_GetTempoRoadConfigurationInfo(&IntersectionQueryActor, SourceConnectionIndex, PrioritizedRoadConfigurationDescriptor);
+		TArray<FTempoRoadConfigurationInfo> RoadConfigurationInfos = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoRoadConfigurationInfo, SourceConnectionIndex, PrioritizedRoadConfigurationDescriptor);
 		if (!RoadConfigurationInfos.IsEmpty())
 		{
 			RoadConfigurationInfos.Sort(SortPredicate);
@@ -468,7 +470,7 @@ FTempoRoadConfigurationInfo UTempoIntersectionControlComponent::GetPrioritizedRo
 
 float UTempoIntersectionControlComponent::GetLateralOffsetFromControlPoint(const AActor& RoadQueryActor, ETempoRoadOffsetOrigin LateralOffsetOrigin, float InLateralOffset) const
 {
-	const float RoadWidth = ITempoRoadInterface::Execute_GetTempoRoadWidth(&RoadQueryActor);
+	const float RoadWidth = UTempoCoreUtils::CallBlueprintFunction(&RoadQueryActor, ITempoRoadInterface::Execute_GetTempoRoadWidth);
 	const float LateralOriginSign = LateralOffsetOrigin == ETempoRoadOffsetOrigin::LeftRoadEdge ? -1.0f : 1.0f;
 	const float AdjustedLateralOrigin = LateralOffsetOrigin == ETempoRoadOffsetOrigin::LeftRoadEdge || LateralOffsetOrigin == ETempoRoadOffsetOrigin::RightRoadEdge ? RoadWidth * 0.5f : 0.0f;
 
@@ -479,7 +481,7 @@ float UTempoIntersectionControlComponent::GetLateralOffsetFromControlPoint(const
 
 AActor* UTempoIntersectionControlComponent::GetConnectedRoadActor(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const
 {
-	AActor* RoadActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(&IntersectionQueryActor, ConnectionIndex);
+	AActor* RoadActor = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor, ConnectionIndex);
 			
 	if (RoadActor == nullptr)
 	{

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoIntersectionQueryComponent.cpp
@@ -10,6 +10,8 @@
 #include "TempoRoadModuleInterface.h"
 #include "TempoZoneGraphUtils.h"
 
+#include "TempoCoreUtils.h"
+
 #include "ZoneGraphSettings.h"
 
 bool UTempoIntersectionQueryComponent::TryGetIntersectionEntranceControlPointIndex(const AActor* IntersectionQueryActor, int32 ConnectionIndex, int32& OutIntersectionEntranceControlPointIndex) const
@@ -55,7 +57,7 @@ bool UTempoIntersectionQueryComponent::TryGetIntersectionEntranceLocation(const 
 		return false;
 	}
 	
-	const FVector IntersectionEntranceLocation = ITempoRoadInterface::Execute_GetTempoControlPointLocation(RoadActor, IntersectionEntranceControlPointIndex, CoordinateSpace);
+	const FVector IntersectionEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(RoadActor, ITempoRoadInterface::Execute_GetTempoControlPointLocation, IntersectionEntranceControlPointIndex, CoordinateSpace);
 
 	OutIntersectionEntranceLocation = IntersectionEntranceLocation;
 
@@ -82,7 +84,7 @@ bool UTempoIntersectionQueryComponent::TryGetIntersectionEntranceTangent(const A
 		return false;
 	}
 	
-	const FVector ControlPointTangent = ITempoRoadInterface::Execute_GetTempoControlPointTangent(RoadQueryActor, IntersectionEntranceControlPointIndex, CoordinateSpace);
+	const FVector ControlPointTangent = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTempoControlPointTangent, IntersectionEntranceControlPointIndex, CoordinateSpace);
 
 	// Invert the control point tangent when the connected road is "leaving" the intersection.
 	const bool bRoadIsLeavingIntersection = IntersectionEntranceControlPointIndex == GetIntersectionEntranceStartOffsetIndex();
@@ -111,7 +113,7 @@ bool UTempoIntersectionQueryComponent::TryGetIntersectionEntranceUpVector(const 
 		return false;
 	}
 	
-	const FVector ControlPointUpVector = ITempoRoadInterface::Execute_GetTempoControlPointUpVector(RoadQueryActor, IntersectionEntranceControlPointIndex, CoordinateSpace);
+	const FVector ControlPointUpVector = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTempoControlPointUpVector, IntersectionEntranceControlPointIndex, CoordinateSpace);
 	
 	OutIntersectionEntranceUpVector = ControlPointUpVector;
 
@@ -138,7 +140,7 @@ bool UTempoIntersectionQueryComponent::TryGetIntersectionEntranceRightVector(con
 		return false;
 	}
 	
-	const FVector ControlPointRightVector = ITempoRoadInterface::Execute_GetTempoControlPointRightVector(RoadQueryActor, IntersectionEntranceControlPointIndex, CoordinateSpace);
+	const FVector ControlPointRightVector = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTempoControlPointRightVector, IntersectionEntranceControlPointIndex, CoordinateSpace);
 
 	// Invert the control point right vector when the connected road is "leaving" the intersection.
 	const bool bRoadIsLeavingIntersection = IntersectionEntranceControlPointIndex == GetIntersectionEntranceStartOffsetIndex();
@@ -270,22 +272,22 @@ bool UTempoIntersectionQueryComponent::TryGenerateCrosswalkRoadModuleMap(const A
 	{
 		TArray<AActor*> CrosswalkRoadModules;
 
-		const int32 NumConnectedRoadModules = ITempoIntersectionInterface::Execute_GetNumConnectedTempoRoadModules(IntersectionQueryActor);
+		const int32 NumConnectedRoadModules = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumConnectedTempoRoadModules);
 
 		for (int32 ConnectedRoadModuleIndex = 0; ConnectedRoadModuleIndex < NumConnectedRoadModules; ++ConnectedRoadModuleIndex)
 		{
-			AActor* ConnectedRoadModule = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadModuleActor(IntersectionQueryActor, ConnectedRoadModuleIndex);
+			AActor* ConnectedRoadModule = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetConnectedTempoRoadModuleActor, ConnectedRoadModuleIndex);
 
 			if (ConnectedRoadModule == nullptr)
 			{
 				continue;
 			}
 
-			const int32 NumRoadModuleLanes = ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes(ConnectedRoadModule);
+			const int32 NumRoadModuleLanes = UTempoCoreUtils::CallBlueprintFunction(ConnectedRoadModule, ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes);
 
 			for (int32 RoadModuleLaneIndex = 0; RoadModuleLaneIndex < NumRoadModuleLanes; ++RoadModuleLaneIndex)
 			{
-				const TArray<FName>& RoadModuleLaneTags = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags(ConnectedRoadModule, RoadModuleLaneIndex);
+				const TArray<FName>& RoadModuleLaneTags = UTempoCoreUtils::CallBlueprintFunction(ConnectedRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags, RoadModuleLaneIndex);
 
 				const FZoneGraphTagMask& RoadModuleLaneTagMask = UTempoZoneGraphUtils::GenerateTagMaskFromTagNames(this, RoadModuleLaneTags);
 
@@ -316,28 +318,28 @@ bool UTempoIntersectionQueryComponent::TryGenerateCrosswalkRoadModuleMap(const A
 
 	TMap<int32, AActor*> CrosswalkRoadModuleMap;
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
 	{
-		const FVector ConnectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
-		const FVector ConnectionEntranceForward = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
-		const FVector ConnectionEntranceRight = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector ConnectionEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation, ConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector ConnectionEntranceForward = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, ConnectionIndex, ETempoCoordinateSpace::World).GetSafeNormal();
+		const FVector ConnectionEntranceRight = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector, ConnectionIndex, ETempoCoordinateSpace::World);
 		
-		const AActor* RoadQueryActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(IntersectionQueryActor, ConnectionIndex);
+		const AActor* RoadQueryActor = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor, ConnectionIndex);
 		if (RoadQueryActor == nullptr)
 		{
 			return false;
 		}
 		
-		const float RoadWidth = ITempoRoadInterface::Execute_GetTempoRoadWidth(RoadQueryActor);
-		const float CrosswalkWidth = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkWidth(IntersectionQueryActor, ConnectionIndex);
+		const float RoadWidth = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTempoRoadWidth);
+		const float CrosswalkWidth = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkWidth, ConnectionIndex);
 
 		const auto& GetCrosswalkRoadModuleInLateralDirection = [&CrosswalkRoadModules, &ConnectionEntranceLocation, &ConnectionEntranceForward, &ConnectionEntranceRight, &RoadWidth, &CrosswalkWidth, &GetCrosswalkRoadModuleBounds](const float LateralDirectionScalar) -> AActor*
 		{
 			for (AActor* CrosswalkRoadModule : CrosswalkRoadModules)
 			{
-				const float RoadModuleWidth = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleWidth(CrosswalkRoadModule);
+				const float RoadModuleWidth = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleWidth);
 		
 				const FVector CrosswalkIntersectionCenterLocation = ConnectionEntranceLocation + ConnectionEntranceForward * CrosswalkWidth * 0.5f + ConnectionEntranceRight * (RoadWidth * 0.5 + RoadModuleWidth * 0.5) * LateralDirectionScalar;
 
@@ -386,7 +388,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoE
 		return false;
 	}
 	
-	const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+	const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 	
 	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
 	
@@ -414,28 +416,28 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoE
 	{
 		const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
 
-		const AActor* RoadQueryActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(IntersectionQueryActor, ConnectionIndex);
+		const AActor* RoadQueryActor = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor, ConnectionIndex);
 		if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("Couldn't get valid Connected Road Actor for Actor: %s at ConnectionIndex: %d in UVayuIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry."), *IntersectionQueryActor->GetName(), ConnectionIndex))
 		{
 			return false;
 		}
 
-		const float RoadWidth = ITempoRoadInterface::Execute_GetTempoRoadWidth(RoadQueryActor);
-		const float CrosswalkRoadModuleWidth = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleWidth(&CrosswalkRoadModule);
+		const float RoadWidth = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTempoRoadWidth);
+		const float CrosswalkRoadModuleWidth = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleWidth);
 		
-		const FVector IntersectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
-		const FVector IntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector IntersectionEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation, ConnectionIndex, ETempoCoordinateSpace::World);
+		const FVector IntersectionEntranceRightVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector, ConnectionIndex, ETempoCoordinateSpace::World);
 		const float LateralDirectionScalar = CrosswalkIntersectionIndex % 2 == 0 ? 1.0f : -1.0f;
 
 		const FVector CrosswalkIntersectionOuterQueryLocation = IntersectionEntranceLocation + IntersectionEntranceRightVector * (RoadWidth * 0.5f + CrosswalkRoadModuleWidth * 0.5f) * LateralDirectionScalar;
-		const float CrosswalkIntersectionEntranceOuterDistance = ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleClosestToWorldLocation(&CrosswalkRoadModule, CrosswalkIntersectionOuterQueryLocation);
+		const float CrosswalkIntersectionEntranceOuterDistance = UTempoCoreUtils::CallBlueprintFunction(&CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleClosestToWorldLocation, CrosswalkIntersectionOuterQueryLocation);
 		
 		OutCrosswalkIntersectionEntranceOuterDistance = CrosswalkIntersectionEntranceOuterDistance;
 
 		return true;
 	};
 
-	const float CrosswalkRoadModuleLength = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLength(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule);
+	const float CrosswalkRoadModuleLength = UTempoCoreUtils::CallBlueprintFunction(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLength);
 
 	const FCrosswalkIntersectionConnectorSegmentInfo& CrosswalkIntersectionConnectorSegmentInfo = CrosswalkIntersectionConnectorInfo->CrosswalkIntersectionConnectorSegmentInfos[0];
 	
@@ -467,21 +469,21 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocati
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 	
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -493,7 +495,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocati
 		const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
 		const int32 CrosswalkControlPointIndex = (CrosswalkIntersectionIndex + 1) % 2;
 		
-		const FVector CrosswalkEntranceLocation = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation(IntersectionQueryActor, ConnectionIndex, CrosswalkControlPointIndex, CoordinateSpace);
+		const FVector CrosswalkEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation, ConnectionIndex, CrosswalkControlPointIndex, CoordinateSpace);
 		
 		OutCrosswalkIntersectionEntranceLocation = CrosswalkEntranceLocation;
 	}
@@ -508,7 +510,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLocati
 			return false;
 		}
 
-		const FVector CrosswalkEntranceLocation = ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
+		const FVector CrosswalkEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModuleActor, ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
 		
 		OutCrosswalkIntersectionEntranceLocation = CrosswalkEntranceLocation;
 	}
@@ -523,21 +525,21 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangen
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -551,7 +553,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangen
 		const float DirectionScalar = (CrosswalkIntersectionIndex % 2) == 0 ? 1.0f : -1.0f;
 
 		// The actual Crosswalk's Intersection Entrance tangent is based on the Intersection Connection's right vector.
-		const FVector CrosswalkIntersectionEntranceTangent = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace) * DirectionScalar;
+		const FVector CrosswalkIntersectionEntranceTangent = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector, ConnectionIndex, CoordinateSpace) * DirectionScalar;
 
 		OutCrosswalkIntersectionEntranceTangent = CrosswalkIntersectionEntranceTangent;
 	}
@@ -567,7 +569,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceTangen
 		}
 		
 		const float DirectionScalar = CrosswalkIntersectionConnectionIndex == 1 ? 1.0f : -1.0f;
-		const FVector CrosswalkIntersectionEntranceTangent = ITempoRoadModuleInterface::Execute_GetTangentAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
+		const FVector CrosswalkIntersectionEntranceTangent = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModuleActor, ITempoRoadModuleInterface::Execute_GetTangentAtDistanceAlongTempoRoadModule, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
 		
 		OutCrosswalkIntersectionEntranceTangent = CrosswalkIntersectionEntranceTangent;
 	}
@@ -582,21 +584,21 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVect
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -608,7 +610,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVect
 	{
 		const int32 ConnectionIndex = GetConnectionIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
 		
-		const FVector CrosswalkIntersectionEntranceUpVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+		const FVector CrosswalkIntersectionEntranceUpVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector, ConnectionIndex, CoordinateSpace);
 
 		OutCrosswalkIntersectionEntranceUpVector = CrosswalkIntersectionEntranceUpVector;
 	}
@@ -623,7 +625,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceUpVect
 			return false;
 		}
 
-		const FVector CrosswalkIntersectionEntranceUpVector = ITempoRoadModuleInterface::Execute_GetUpVectorAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
+		const FVector CrosswalkIntersectionEntranceUpVector = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModuleActor, ITempoRoadModuleInterface::Execute_GetUpVectorAtDistanceAlongTempoRoadModule, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
 		
 		OutCrosswalkIntersectionEntranceUpVector = CrosswalkIntersectionEntranceUpVector;
 	}
@@ -638,21 +640,21 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightV
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -667,7 +669,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightV
 		const float DirectionScalar = (CrosswalkIntersectionIndex % 2) == 0 ? 1.0f : -1.0f;
 
 		// The actual Crosswalk's Intersection Entrance right vector is based on the Intersection Connection's forward vector.
-		const FVector CrosswalkIntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace).GetSafeNormal() * DirectionScalar * -1.0f;
+		const FVector CrosswalkIntersectionEntranceRightVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, ConnectionIndex, CoordinateSpace).GetSafeNormal() * DirectionScalar * -1.0f;
 
 		OutCrosswalkIntersectionEntranceRightVector = CrosswalkIntersectionEntranceRightVector;
 	}
@@ -683,7 +685,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceRightV
 		}
 		
 		const float DirectionScalar = CrosswalkIntersectionConnectionIndex == 1 ? 1.0f : -1.0f;
-		const FVector CrosswalkIntersectionEntranceRightVector = ITempoRoadModuleInterface::Execute_GetRightVectorAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
+		const FVector CrosswalkIntersectionEntranceRightVector = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModuleActor, ITempoRoadModuleInterface::Execute_GetRightVectorAtDistanceAlongTempoRoadModule, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
 		
 		OutCrosswalkIntersectionEntranceRightVector = CrosswalkIntersectionEntranceRightVector;
 	}
@@ -698,21 +700,21 @@ bool UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionEntranceLan
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -724,7 +726,7 @@ bool UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionEntranceLan
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const int32 NumCrosswalkIntersectionEntranceLanes = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkLanes(IntersectionQueryActor, ConnectionIndex);
+		const int32 NumCrosswalkIntersectionEntranceLanes = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkLanes, ConnectionIndex);
 		
 		OutNumCrosswalkIntersectionEntranceLanes = NumCrosswalkIntersectionEntranceLanes;
 	}
@@ -732,7 +734,7 @@ bool UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionEntranceLan
 	{
 		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
 		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
-		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+		const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 		if (!TryGetNumCrosswalkIntersectionConnectorLanes(IntersectionQueryActor, CrosswalkRoadModuleIndex, CrosswalkIntersectionConnectorInfoMap, OutNumCrosswalkIntersectionEntranceLanes))
 		{
 			return false;
@@ -749,21 +751,21 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLanePr
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -775,7 +777,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLanePr
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const FName LaneProfileOverrideNameForTempoCrosswalk = ITempoCrosswalkInterface::Execute_GetLaneProfileOverrideNameForTempoCrosswalk(IntersectionQueryActor, ConnectionIndex);
+		const FName LaneProfileOverrideNameForTempoCrosswalk = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetLaneProfileOverrideNameForTempoCrosswalk, ConnectionIndex);
 		
 		OutCrosswalkIntersectionEntranceLaneProfileOverrideName = LaneProfileOverrideNameForTempoCrosswalk;
 	}
@@ -783,7 +785,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLanePr
 	{
 		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
 		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
-		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+		const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 		if (!TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName(IntersectionQueryActor, CrosswalkRoadModuleIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneProfileOverrideName))
 		{
 			return false;
@@ -800,21 +802,21 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWi
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -826,7 +828,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWi
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const float CrosswalkLaneWidth = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneWidth(IntersectionQueryActor, ConnectionIndex, LaneIndex);
+		const float CrosswalkLaneWidth = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneWidth, ConnectionIndex, LaneIndex);
 		
 		OutCrosswalkIntersectionEntranceLaneWidth = CrosswalkLaneWidth;
 	}
@@ -834,7 +836,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWi
 	{
 		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
 		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
-		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+		const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 		if (!TryGetCrosswalkIntersectionConnectorLaneWidth(IntersectionQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneWidth))
 		{
 			return false;
@@ -851,21 +853,21 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDi
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -877,7 +879,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDi
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const EZoneLaneDirection CrosswalkLaneDirection = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneDirection(IntersectionQueryActor, ConnectionIndex, LaneIndex);
+		const EZoneLaneDirection CrosswalkLaneDirection = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneDirection, ConnectionIndex, LaneIndex);
 		
 		OutCrosswalkIntersectionEntranceLaneDirection = CrosswalkLaneDirection;
 	}
@@ -885,7 +887,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDi
 	{
 		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
 		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
-		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+		const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 		if (!TryGetCrosswalkIntersectionConnectorLaneDirection(IntersectionQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneDirection))
 		{
 			return false;
@@ -902,21 +904,21 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTa
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(IntersectionQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(IntersectionQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -928,7 +930,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTa
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by ConnectionIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const TArray<FName> CrosswalkLaneTags = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneTags(IntersectionQueryActor, ConnectionIndex, LaneIndex);
+		const TArray<FName> CrosswalkLaneTags = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneTags, ConnectionIndex, LaneIndex);
 		
 		OutCrosswalkIntersectionEntranceLaneTags = CrosswalkLaneTags;
 	}
@@ -936,7 +938,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTa
 	{
 		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
 		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
-		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(IntersectionQueryActor, CrosswalkIntersectionIndex);
+		const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 		if (!TryGetCrosswalkIntersectionConnectorLaneTags(IntersectionQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneTags))
 		{
 			return false;
@@ -953,14 +955,14 @@ bool UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLa
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(IntersectionQueryActor);
+	const int32 NumCrosswalkRoadModules = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules);
 
 	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -979,7 +981,7 @@ bool UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLa
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnectorLanes = ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule);
+	const int32 NumCrosswalkIntersectionConnectorLanes = UTempoCoreUtils::CallBlueprintFunction(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes);
 	
 	OutNumCrosswalkIntersectionConnectorLanes = NumCrosswalkIntersectionConnectorLanes;
 
@@ -993,14 +995,14 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneP
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(IntersectionQueryActor);
+	const int32 NumCrosswalkRoadModules = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules);
 
 	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -1019,7 +1021,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneP
 		return false;
 	}
 
-	const FName CrosswalkRoadModuleLaneProfileOverrideName = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneProfileOverrideName(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule);
+	const FName CrosswalkRoadModuleLaneProfileOverrideName = UTempoCoreUtils::CallBlueprintFunction(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneProfileOverrideName);
 		
 	OutCrosswalkIntersectionConnectorLaneProfileOverrideName = CrosswalkRoadModuleLaneProfileOverrideName;
 
@@ -1033,14 +1035,14 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneW
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(IntersectionQueryActor);
+	const int32 NumCrosswalkRoadModules = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules);
 
 	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -1059,7 +1061,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneW
 		return false;
 	}
 
-	const float CrosswalkRoadModuleLaneWidth = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneWidth(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+	const float CrosswalkRoadModuleLaneWidth = UTempoCoreUtils::CallBlueprintFunction(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneWidth, LaneIndex);
 		
 	OutCrosswalkIntersectionConnectorLaneWidth = CrosswalkRoadModuleLaneWidth;
 
@@ -1073,14 +1075,14 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneD
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(IntersectionQueryActor);
+	const int32 NumCrosswalkRoadModules = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules);
 
 	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -1099,7 +1101,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneD
 		return false;
 	}
 
-	const EZoneLaneDirection CrosswalkRoadModuleLaneDirection = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneDirection(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+	const EZoneLaneDirection CrosswalkRoadModuleLaneDirection = UTempoCoreUtils::CallBlueprintFunction(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneDirection, LaneIndex);
 		
 	OutCrosswalkIntersectionConnectorLaneDirection = CrosswalkRoadModuleLaneDirection;
 
@@ -1113,14 +1115,14 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneT
 		return false;
 	}
 
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneTags.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(IntersectionQueryActor);
+	const int32 NumCrosswalkRoadModules = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules);
 
 	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoIntersectionQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *IntersectionQueryActor->GetName()))
 	{
@@ -1139,7 +1141,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkIntersectionConnectorLaneT
 		return false;
 	}
 
-	const TArray<FName> CrosswalkRoadModuleLaneTags = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+	const TArray<FName> CrosswalkRoadModuleLaneTags = UTempoCoreUtils::CallBlueprintFunction(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags, LaneIndex);
 		
 	OutCrosswalkIntersectionConnectorLaneTags = CrosswalkRoadModuleLaneTags;
 
@@ -1153,21 +1155,21 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation(const
 		return false;
 	}
 
-	const int32 CrosswalkControlPointStartIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
-	const int32 CrosswalkControlPointEndIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+	const int32 CrosswalkControlPointStartIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex, ConnectionIndex);
+	const int32 CrosswalkControlPointEndIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex, ConnectionIndex);
 
 	if (!ensureMsgf(CrosswalkControlPointIndex >= CrosswalkControlPointStartIndex && CrosswalkControlPointIndex <= CrosswalkControlPointEndIndex, TEXT("CrosswalkControlPointIndex must be in range [%d..%d] in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation.  Currently, it is: %d.  IntersectionQueryActor: %s."), CrosswalkControlPointStartIndex, CrosswalkControlPointEndIndex, CrosswalkControlPointIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 	
-	const FVector IntersectionEntranceLocation = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
-	const FVector IntersectionEntranceTangent = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+	const FVector IntersectionEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceLocation, ConnectionIndex, CoordinateSpace);
+	const FVector IntersectionEntranceTangent = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, ConnectionIndex, CoordinateSpace);
 
 	const FVector IntersectionEntranceForwardVector = IntersectionEntranceTangent.GetSafeNormal();
-	const FVector IntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+	const FVector IntersectionEntranceRightVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector, ConnectionIndex, CoordinateSpace);
 
-	const AActor* RoadQueryActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(IntersectionQueryActor, ConnectionIndex);
+	const AActor* RoadQueryActor = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor, ConnectionIndex);
 	if (!ensureMsgf(RoadQueryActor != nullptr, TEXT("Couldn't get valid Connected Road Actor for Actor: %s at ConnectionIndex: %d in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation."), *IntersectionQueryActor->GetName(), ConnectionIndex))
 	{
 		return false;
@@ -1175,17 +1177,17 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation(const
 
 	const auto& GetLateralOffset = [&IntersectionQueryActor, &RoadQueryActor, &IntersectionEntranceRightVector, ConnectionIndex, CrosswalkControlPointIndex, CoordinateSpace]()
 	{
-		const int32 NumLanes = ITempoRoadInterface::Execute_GetNumTempoLanes(RoadQueryActor);
+		const int32 NumLanes = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetNumTempoLanes);
 		
 		float TotalLanesWidth = 0.0f;
 		for (int32 LaneIndex = 0; LaneIndex < NumLanes; ++LaneIndex)
 		{
-			const float LaneWidth = ITempoRoadInterface::Execute_GetTempoLaneWidth(RoadQueryActor, LaneIndex);
+			const float LaneWidth = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTempoLaneWidth, LaneIndex);
 			TotalLanesWidth += LaneWidth;
 		}
 
-		const int32 IntersectionEntranceControlPointIndex = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceControlPointIndex(IntersectionQueryActor, ConnectionIndex);
-		const FVector ControlPointRightVector = ITempoRoadInterface::Execute_GetTempoControlPointRightVector(RoadQueryActor, IntersectionEntranceControlPointIndex, CoordinateSpace);
+		const int32 IntersectionEntranceControlPointIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceControlPointIndex, ConnectionIndex);
+		const FVector ControlPointRightVector = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTempoControlPointRightVector, IntersectionEntranceControlPointIndex, CoordinateSpace);
 		
 		const float DotProduct = FVector::DotProduct(IntersectionEntranceRightVector, ControlPointRightVector);
 
@@ -1193,7 +1195,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation(const
 			? DotProduct >= 0.0f ? ETempoRoadLateralDirection::Left : ETempoRoadLateralDirection::Right
 			: DotProduct >= 0.0f ? ETempoRoadLateralDirection::Right : ETempoRoadLateralDirection::Left;
 		
-		const float ShoulderWidth = ITempoRoadInterface::Execute_GetTempoRoadShoulderWidth(RoadQueryActor, RoadRelativeLateralQueryDirection);
+		const float ShoulderWidth = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTempoRoadShoulderWidth, RoadRelativeLateralQueryDirection);
 		
 		const float LateralOffset = TotalLanesWidth * 0.5f + ShoulderWidth;
 
@@ -1203,7 +1205,7 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointLocation(const
 	const float LateralOffset = GetLateralOffset();
 	const float LateralDirectionScalar = CrosswalkControlPointIndex == 0 ? -1.0f : 1.0f;
 	
-	const float CrosswalkWidth = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkWidth(IntersectionQueryActor, ConnectionIndex);
+	const float CrosswalkWidth = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkWidth, ConnectionIndex);
 	
 	const FVector CrosswalkControlPointLocation = IntersectionEntranceLocation + IntersectionEntranceForwardVector * CrosswalkWidth * 0.5f + IntersectionEntranceRightVector * LateralOffset * LateralDirectionScalar;
 
@@ -1219,15 +1221,15 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointTangent(const 
 		return false;
 	}
 
-	const int32 CrosswalkControlPointStartIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
-	const int32 CrosswalkControlPointEndIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+	const int32 CrosswalkControlPointStartIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex, ConnectionIndex);
+	const int32 CrosswalkControlPointEndIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex, ConnectionIndex);
 
 	if (!ensureMsgf(CrosswalkControlPointIndex >= CrosswalkControlPointStartIndex && CrosswalkControlPointIndex <= CrosswalkControlPointEndIndex, TEXT("CrosswalkControlPointIndex must be in range [%d..%d] in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointTangent.  Currently, it is: %d.  IntersectionQueryActor: %s."), CrosswalkControlPointStartIndex, CrosswalkControlPointEndIndex, CrosswalkControlPointIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 	
-	const FVector IntersectionEntranceRightVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+	const FVector IntersectionEntranceRightVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceRightVector, ConnectionIndex, CoordinateSpace);
 
 	// Crosswalk tangent points to the Intersection Entrance's right.
 	OutCrosswalkControlPointTangent = IntersectionEntranceRightVector;
@@ -1242,15 +1244,15 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointUpVector(const
 		return false;
 	}
 
-	const int32 CrosswalkControlPointStartIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
-	const int32 CrosswalkControlPointEndIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+	const int32 CrosswalkControlPointStartIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex, ConnectionIndex);
+	const int32 CrosswalkControlPointEndIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex, ConnectionIndex);
 
 	if (!ensureMsgf(CrosswalkControlPointIndex >= CrosswalkControlPointStartIndex && CrosswalkControlPointIndex <= CrosswalkControlPointEndIndex, TEXT("CrosswalkControlPointIndex must be in range [%d..%d] in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointUpVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), CrosswalkControlPointStartIndex, CrosswalkControlPointEndIndex, CrosswalkControlPointIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 	
-	const FVector IntersectionEntranceUpVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector(IntersectionQueryActor, ConnectionIndex, CoordinateSpace);
+	const FVector IntersectionEntranceUpVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceUpVector, ConnectionIndex, CoordinateSpace);
 	
 	OutCrosswalkControlPointUpVector = IntersectionEntranceUpVector;
 
@@ -1264,15 +1266,15 @@ bool UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointRightVector(co
 		return false;
 	}
 
-	const int32 CrosswalkControlPointStartIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
-	const int32 CrosswalkControlPointEndIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex(IntersectionQueryActor, ConnectionIndex);
+	const int32 CrosswalkControlPointStartIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkStartEntranceLocationControlPointIndex, ConnectionIndex);
+	const int32 CrosswalkControlPointEndIndex = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkEndEntranceLocationControlPointIndex, ConnectionIndex);
 
 	if (!ensureMsgf(CrosswalkControlPointIndex >= CrosswalkControlPointStartIndex && CrosswalkControlPointIndex <= CrosswalkControlPointEndIndex, TEXT("CrosswalkControlPointIndex must be in range [%d..%d] in UTempoIntersectionQueryComponent::TryGetCrosswalkControlPointRightVector.  Currently, it is: %d.  IntersectionQueryActor: %s."), CrosswalkControlPointStartIndex, CrosswalkControlPointEndIndex, CrosswalkControlPointIndex, *IntersectionQueryActor->GetName()))
 	{
 		return false;
 	}
 	
-	const FVector IntersectionEntranceForwardVector = ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent(IntersectionQueryActor, ConnectionIndex, CoordinateSpace).GetSafeNormal();
+	const FVector IntersectionEntranceForwardVector = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetTempoIntersectionEntranceTangent, ConnectionIndex, CoordinateSpace).GetSafeNormal();
 
 	// Crosswalk right vector points opposite the Intersection Entrance's forward vector.
 	OutCrosswalkControlPointRightVector = -IntersectionEntranceForwardVector;
@@ -1293,11 +1295,11 @@ bool UTempoIntersectionQueryComponent::IsConnectedRoadActor(const AActor* RoadQu
 		return false;
 	}
 	
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(OwnerIntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(OwnerIntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 
 	for (int32 ConnectionIndex = 0; ConnectionIndex < NumConnections; ++ConnectionIndex)
 	{
-		const AActor* ConnectedRoadActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(OwnerIntersectionQueryActor, ConnectionIndex);
+		const AActor* ConnectedRoadActor = UTempoCoreUtils::CallBlueprintFunction(OwnerIntersectionQueryActor, ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor, ConnectionIndex);
 		if (ConnectedRoadActor == RoadQueryActor)
 		{
 			return true;
@@ -1314,7 +1316,7 @@ int32 UTempoIntersectionQueryComponent::GetConnectionIndexFromCrosswalkIntersect
 		return 0;
 	}
 	
-	const int32 NumConnections = ITempoIntersectionInterface::Execute_GetNumTempoConnections(IntersectionQueryActor);
+	const int32 NumConnections = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetNumTempoConnections);
 	
 	if (!ensureMsgf(NumConnections > 0, TEXT("NumConnections must be greater than 0 in UTempoIntersectionQueryComponent::GetConnectionIndexFromCrosswalkIntersectionIndex.  Currently, it is: %d.  IntersectionQueryActor: %s."), NumConnections, *IntersectionQueryActor->GetName()))
 	{
@@ -1346,11 +1348,11 @@ bool UTempoIntersectionQueryComponent::TryGetNearestRoadControlPointIndex(const 
 	float MinDistanceToIntersectionLocation = TNumericLimits<float>::Max();
 	int32 NearestRoadControlPointIndex = -1;
 
-	const int32 NumControlPoints = ITempoRoadInterface::Execute_GetNumTempoControlPoints(RoadActor);
+	const int32 NumControlPoints = UTempoCoreUtils::CallBlueprintFunction(RoadActor, ITempoRoadInterface::Execute_GetNumTempoControlPoints);
 
 	for (int32 ControlPointIndex = 0; ControlPointIndex < NumControlPoints; ++ControlPointIndex)
 	{
-		const FVector RoadControlPointLocationInWorldFrame = ITempoRoadInterface::Execute_GetTempoControlPointLocation(RoadActor, ControlPointIndex, ETempoCoordinateSpace::World);
+		const FVector RoadControlPointLocationInWorldFrame = UTempoCoreUtils::CallBlueprintFunction(RoadActor, ITempoRoadInterface::Execute_GetTempoControlPointLocation, ControlPointIndex, ETempoCoordinateSpace::World);
 		const float DistanceToIntersectionLocation = FVector::Distance(RoadControlPointLocationInWorldFrame, IntersectionLocationInWorldFrame);
 
 		if (DistanceToIntersectionLocation < MinDistanceToIntersectionLocation)
@@ -1373,7 +1375,7 @@ bool UTempoIntersectionQueryComponent::TryGetNearestRoadControlPointIndex(const 
 
 AActor* UTempoIntersectionQueryComponent::GetConnectedRoadActor(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const
 {
-	AActor* RoadActor = ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor(&IntersectionQueryActor, ConnectionIndex);
+	AActor* RoadActor = UTempoCoreUtils::CallBlueprintFunction(&IntersectionQueryActor, ITempoIntersectionInterface::Execute_GetConnectedTempoRoadActor, ConnectionIndex);
 			
 	if (RoadActor == nullptr)
 	{
@@ -1430,9 +1432,9 @@ TempoZoneGraphTagMaskGroups UTempoIntersectionQueryComponent::GroupLaneConnectio
 
 FZoneGraphTagFilter UTempoIntersectionQueryComponent::GetLaneConnectionTagFilter(const AActor* SourceConnectionActor, const FTempoLaneConnectionInfo& SourceLaneConnectionInfo) const
 {
-	const TArray<FName>& LaneConnectionAnyTagNames = ITempoRoadInterface::Execute_GetTempoLaneConnectionAnyTags(SourceConnectionActor, SourceLaneConnectionInfo.LaneIndex);
-	const TArray<FName>& LaneConnectionAllTagNames = ITempoRoadInterface::Execute_GetTempoLaneConnectionAllTags(SourceConnectionActor, SourceLaneConnectionInfo.LaneIndex);
-	const TArray<FName>& LaneConnectionNotTagNames = ITempoRoadInterface::Execute_GetTempoLaneConnectionNotTags(SourceConnectionActor, SourceLaneConnectionInfo.LaneIndex);
+	const TArray<FName>& LaneConnectionAnyTagNames = UTempoCoreUtils::CallBlueprintFunction(SourceConnectionActor, ITempoRoadInterface::Execute_GetTempoLaneConnectionAnyTags, SourceLaneConnectionInfo.LaneIndex);
+	const TArray<FName>& LaneConnectionAllTagNames = UTempoCoreUtils::CallBlueprintFunction(SourceConnectionActor, ITempoRoadInterface::Execute_GetTempoLaneConnectionAllTags, SourceLaneConnectionInfo.LaneIndex);
+	const TArray<FName>& LaneConnectionNotTagNames = UTempoCoreUtils::CallBlueprintFunction(SourceConnectionActor, ITempoRoadInterface::Execute_GetTempoLaneConnectionNotTags, SourceLaneConnectionInfo.LaneIndex);
 
 	return UTempoZoneGraphUtils::GenerateTagFilter(this, LaneConnectionAnyTagNames, LaneConnectionAllTagNames, LaneConnectionNotTagNames);
 }

--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoRoadQueryComponent.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoRoadQueryComponent.cpp
@@ -9,14 +9,16 @@
 #include "TempoRoadModuleInterface.h"
 #include "TempoZoneGraphUtils.h"
 
+#include "TempoCoreUtils.h"
+
 #include "ZoneGraphTypes.h"
 
 float GetDistanceAlongTempoRoadAtCrosswalk(const AActor* RoadQueryActor, int32 CrosswalkIndex)
 {
-	const FVector CrosswalkCenterLineLeft = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation(RoadQueryActor, CrosswalkIndex, 0, ETempoCoordinateSpace::World);
-	const FVector CrosswalkCenterLineRight = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation(RoadQueryActor, CrosswalkIndex, 1, ETempoCoordinateSpace::World);
+	const FVector CrosswalkCenterLineLeft = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation, CrosswalkIndex, 0, ETempoCoordinateSpace::World);
+	const FVector CrosswalkCenterLineRight = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation, CrosswalkIndex, 1, ETempoCoordinateSpace::World);
 	const FVector CrosswalkCenter = (CrosswalkCenterLineLeft + CrosswalkCenterLineRight) / 2.0;
-	return ITempoRoadInterface::Execute_GetDistanceAlongTempoRoadClosestToWorldLocation(RoadQueryActor, CrosswalkCenter);
+	return UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetDistanceAlongTempoRoadClosestToWorldLocation, CrosswalkCenter);
 }
 
 bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorInfo(const AActor* RoadQueryActor, int32 CrosswalkRoadModuleIndex, FCrosswalkIntersectionConnectorInfo& OutCrosswalkIntersectionConnectorInfo) const
@@ -38,11 +40,11 @@ bool UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap(const AActor* R
 	{
 		TArray<AActor*> CrosswalkRoadModules;
 
-		const int32 NumConnectedRoadModules = ITempoRoadInterface::Execute_GetNumConnectedTempoRoadModules(RoadQueryActor);
+		const int32 NumConnectedRoadModules = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetNumConnectedTempoRoadModules);
 
 		for (int32 ConnectedRoadModuleIndex = 0; ConnectedRoadModuleIndex < NumConnectedRoadModules; ++ConnectedRoadModuleIndex)
 		{
-			AActor* ConnectedRoadModule = ITempoRoadInterface::Execute_GetConnectedTempoRoadModuleActor(RoadQueryActor, ConnectedRoadModuleIndex);
+			AActor* ConnectedRoadModule = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetConnectedTempoRoadModuleActor, ConnectedRoadModuleIndex);
 
 			if (ConnectedRoadModule == nullptr)
 			{
@@ -55,11 +57,11 @@ bool UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap(const AActor* R
 				continue;
 			}
 
-			const int32 NumRoadModuleLanes = ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes(ConnectedRoadModule);
+			const int32 NumRoadModuleLanes = UTempoCoreUtils::CallBlueprintFunction(ConnectedRoadModule, ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes);
 
 			for (int32 RoadModuleLaneIndex = 0; RoadModuleLaneIndex < NumRoadModuleLanes; ++RoadModuleLaneIndex)
 			{
-				const TArray<FName>& RoadModuleLaneTags = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags(ConnectedRoadModule, RoadModuleLaneIndex);
+				const TArray<FName>& RoadModuleLaneTags = UTempoCoreUtils::CallBlueprintFunction(ConnectedRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags, RoadModuleLaneIndex);
 
 				const FZoneGraphTagMask& RoadModuleLaneTagMask = UTempoZoneGraphUtils::GenerateTagMaskFromTagNames(this, RoadModuleLaneTags);
 
@@ -88,9 +90,9 @@ bool UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap(const AActor* R
 	// 	return false;
 	// }
 
-	const FVector RoadStartLocation = ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad(RoadQueryActor, 0.0, ETempoCoordinateSpace::World);
-	const FVector RoadStartRight = ITempoRoadInterface::Execute_GetRightVectorAtDistanceAlongTempoRoad(RoadQueryActor, 0.0, ETempoCoordinateSpace::World);
-	const float RoadWidth = ITempoRoadInterface::Execute_GetTempoRoadWidth(RoadQueryActor);
+	const FVector RoadStartLocation = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetLocationAtDistanceAlongTempoRoad, 0.0, ETempoCoordinateSpace::World);
+	const FVector RoadStartRight = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetRightVectorAtDistanceAlongTempoRoad, 0.0, ETempoCoordinateSpace::World);
+	const float RoadWidth = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTempoRoadWidth);
 
 	const auto& GetCrosswalkRoadModuleInLateralDirection = [&CrosswalkRoadModules, &RoadStartLocation, &RoadStartRight, &RoadWidth](const float LateralDirectionScalar) -> AActor*
 	{
@@ -98,10 +100,10 @@ bool UTempoRoadQueryComponent::TryGenerateCrosswalkRoadModuleMap(const AActor* R
 		float NearestDistance = TNumericLimits<float>::Max();
 		for (AActor* CrosswalkRoadModule : CrosswalkRoadModules)
 		{
-			const float RoadModuleWidth = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleWidth(CrosswalkRoadModule);
+			const float RoadModuleWidth = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleWidth);
 			const FVector QueryPoint = RoadStartLocation + RoadStartRight * (RoadWidth * 0.5 + RoadModuleWidth * 0.5) * LateralDirectionScalar;
-			const float DistanceAlongRoadModule = ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleClosestToWorldLocation(CrosswalkRoadModule, QueryPoint);
-			const FVector PointOnRoadModule = ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule(CrosswalkRoadModule, DistanceAlongRoadModule, ETempoCoordinateSpace::World);
+			const float DistanceAlongRoadModule = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetDistanceAlongTempoRoadModuleClosestToWorldLocation, QueryPoint);
+			const FVector PointOnRoadModule = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule, DistanceAlongRoadModule, ETempoCoordinateSpace::World);
 			const float Distance = FVector::Distance(PointOnRoadModule, QueryPoint);
 			if (Distance < NearestDistance)
 			{
@@ -139,7 +141,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorInfoEntry(con
 		return false;
 	}
 
-	const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+	const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 
 	const FCrosswalkIntersectionConnectorInfo* CrosswalkIntersectionConnectorInfo = CrosswalkIntersectionConnectorInfoMap.Find(CrosswalkRoadModuleIndex);
 
@@ -190,14 +192,14 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLocation(const
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLocation.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
 	{
@@ -209,7 +211,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLocation(const
 		const int32 CrosswalkIndex = GetCrosswalkIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
 		const int32 CrosswalkControlPointIndex = CrosswalkIntersectionIndex % 2;
 
-		const FVector CrosswalkEntranceLocation = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation(RoadQueryActor, CrosswalkIndex, CrosswalkControlPointIndex, CoordinateSpace);
+		const FVector CrosswalkEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkControlPointLocation, CrosswalkIndex, CrosswalkControlPointIndex, CoordinateSpace);
 
 		OutCrosswalkIntersectionEntranceLocation = CrosswalkEntranceLocation;
 	}
@@ -224,7 +226,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLocation(const
 			return false;
 		}
 
-		const FVector CrosswalkEntranceLocation = ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
+		const FVector CrosswalkEntranceLocation = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModuleActor, ITempoRoadModuleInterface::Execute_GetLocationAtDistanceAlongTempoRoadModule, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
 		OutCrosswalkIntersectionEntranceLocation = CrosswalkEntranceLocation;
 	}
 
@@ -238,14 +240,14 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent(const 
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
 	{
@@ -263,7 +265,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent(const 
 
 		// The actual CrosswalkIntersection's entrance tangent is based on the road's right vector at the crosswalk.
 		const float DistanceAlongRoad = GetDistanceAlongTempoRoadAtCrosswalk(RoadQueryActor, CrosswalkIndex);
-		OutCrosswalkIntersectionEntranceTangent = ITempoRoadInterface::Execute_GetRightVectorAtDistanceAlongTempoRoad(RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::World) * DirectionScalar;
+		OutCrosswalkIntersectionEntranceTangent = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetRightVectorAtDistanceAlongTempoRoad, DistanceAlongRoad, ETempoCoordinateSpace::World) * DirectionScalar;
 	}
 	else
 	{
@@ -280,7 +282,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceTangent(const 
 		// So on the left side CrosswalkIntersectionConnectionIndex 1 is the start and 2 is the end.
 		// And on the left side CrosswalkIntersectionConnectionIndex 2 is the start and 1 is the end.
 		const float DirectionScalar = CrosswalkIntersectionConnectionIndex == (bIsLeftSide ? 1 : 2) ? 1.0f : -1.0f;
-		const FVector CrosswalkIntersectionEntranceTangent = ITempoRoadModuleInterface::Execute_GetTangentAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
+		const FVector CrosswalkIntersectionEntranceTangent = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModuleActor, ITempoRoadModuleInterface::Execute_GetTangentAtDistanceAlongTempoRoadModule, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
 
 		OutCrosswalkIntersectionEntranceTangent = CrosswalkIntersectionEntranceTangent;
 	}
@@ -295,14 +297,14 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector(const
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
 	{
@@ -316,7 +318,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector(const
 
 		// The actual CrosswalkIntersection's entrance up vector is based on the road's up vector at the crosswalk.
 		const float DistanceAlongRoad = GetDistanceAlongTempoRoadAtCrosswalk(RoadQueryActor, CrosswalkIndex);
-		OutCrosswalkIntersectionEntranceUpVector = ITempoRoadInterface::Execute_GetUpVectorAtDistanceAlongTempoRoad(RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::World);
+		OutCrosswalkIntersectionEntranceUpVector = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetUpVectorAtDistanceAlongTempoRoad, DistanceAlongRoad, ETempoCoordinateSpace::World);
 	}
 	else
 	{
@@ -329,7 +331,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceUpVector(const
 			return false;
 		}
 
-		const FVector CrosswalkIntersectionEntranceUpVector = ITempoRoadModuleInterface::Execute_GetUpVectorAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
+		const FVector CrosswalkIntersectionEntranceUpVector = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModuleActor, ITempoRoadModuleInterface::Execute_GetUpVectorAtDistanceAlongTempoRoadModule, CrosswalkIntersectionConnectorDistance, CoordinateSpace);
 
 		OutCrosswalkIntersectionEntranceUpVector = CrosswalkIntersectionEntranceUpVector;
 	}
@@ -344,14 +346,14 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector(co
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
 	{
@@ -370,7 +372,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector(co
 
 		// The actual Crosswalk's Intersection Entrance right vector is based on the Road's forward vector.
 		const float DistanceAlongRoad = GetDistanceAlongTempoRoadAtCrosswalk(RoadQueryActor, CrosswalkIndex);
-		OutCrosswalkIntersectionEntranceRightVector = ITempoRoadInterface::Execute_GetTangentAtDistanceAlongTempoRoad(RoadQueryActor, DistanceAlongRoad, ETempoCoordinateSpace::World) * DirectionScalar;
+		OutCrosswalkIntersectionEntranceRightVector = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoRoadInterface::Execute_GetTangentAtDistanceAlongTempoRoad, DistanceAlongRoad, ETempoCoordinateSpace::World) * DirectionScalar;
 	}
 	else
 	{
@@ -387,7 +389,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceRightVector(co
 		// So on the left side CrosswalkIntersectionConnectionIndex 1 is the start and 2 is the end.
 		// And on the left side CrosswalkIntersectionConnectionIndex 2 is the start and 1 is the end.
 		const float DirectionScalar = CrosswalkIntersectionConnectionIndex == (bIsLeftSide ? 1 : 2) ? 1.0f : -1.0f;
-		const FVector CrosswalkIntersectionEntranceRightVector = ITempoRoadModuleInterface::Execute_GetRightVectorAtDistanceAlongTempoRoadModule(CrosswalkRoadModuleActor, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
+		const FVector CrosswalkIntersectionEntranceRightVector = UTempoCoreUtils::CallBlueprintFunction(CrosswalkRoadModuleActor, ITempoRoadModuleInterface::Execute_GetRightVectorAtDistanceAlongTempoRoadModule, CrosswalkIntersectionConnectorDistance, CoordinateSpace) * DirectionScalar;
 
 		OutCrosswalkIntersectionEntranceRightVector = CrosswalkIntersectionEntranceRightVector;
 	}
@@ -402,14 +404,14 @@ bool UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes(const
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
 	{
@@ -421,7 +423,7 @@ bool UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes(const
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const int32 NumCrosswalkIntersectionEntranceLanes = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkLanes(RoadQueryActor, CrosswalkIndex);
+		const int32 NumCrosswalkIntersectionEntranceLanes = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkLanes, CrosswalkIndex);
 
 		OutNumCrosswalkIntersectionEntranceLanes = NumCrosswalkIntersectionEntranceLanes;
 	}
@@ -429,7 +431,7 @@ bool UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionEntranceLanes(const
 	{
 		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
 		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
-		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 		if (!TryGetNumCrosswalkIntersectionConnectorLanes(RoadQueryActor, CrosswalkRoadModuleIndex, CrosswalkIntersectionConnectorInfoMap, OutNumCrosswalkIntersectionEntranceLanes))
 		{
 			return false;
@@ -446,14 +448,14 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOve
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOverrideName.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
 	{
@@ -465,7 +467,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOve
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const FName LaneProfileOverrideNameForTempoCrosswalk = ITempoCrosswalkInterface::Execute_GetLaneProfileOverrideNameForTempoCrosswalk(RoadQueryActor, CrosswalkIndex);
+		const FName LaneProfileOverrideNameForTempoCrosswalk = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetLaneProfileOverrideNameForTempoCrosswalk, CrosswalkIndex);
 
 		OutCrosswalkIntersectionEntranceLaneProfileOverrideName = LaneProfileOverrideNameForTempoCrosswalk;
 	}
@@ -473,7 +475,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneProfileOve
 	{
 		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
 		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
-		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 		if (!TryGetCrosswalkIntersectionConnectorLaneProfileOverrideName(RoadQueryActor, CrosswalkRoadModuleIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneProfileOverrideName))
 		{
 			return false;
@@ -490,14 +492,14 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth(cons
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
 	{
@@ -509,7 +511,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth(cons
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const float CrosswalkLaneWidth = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneWidth(RoadQueryActor, CrosswalkIndex, LaneIndex);
+		const float CrosswalkLaneWidth = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneWidth, CrosswalkIndex, LaneIndex);
 
 		OutCrosswalkIntersectionEntranceLaneWidth = CrosswalkLaneWidth;
 	}
@@ -517,7 +519,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneWidth(cons
 	{
 		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
 		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
-		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 		if (!TryGetCrosswalkIntersectionConnectorLaneWidth(RoadQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneWidth))
 		{
 			return false;
@@ -534,14 +536,14 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection(
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
 	{
@@ -553,7 +555,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection(
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const EZoneLaneDirection CrosswalkLaneDirection = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneDirection(RoadQueryActor, CrosswalkIndex, LaneIndex);
+		const EZoneLaneDirection CrosswalkLaneDirection = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneDirection, CrosswalkIndex, LaneIndex);
 
 		OutCrosswalkIntersectionEntranceLaneDirection = CrosswalkLaneDirection;
 	}
@@ -561,7 +563,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneDirection(
 	{
 		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
 		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
-		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 		if (!TryGetCrosswalkIntersectionConnectorLaneDirection(RoadQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneDirection))
 		{
 			return false;
@@ -578,14 +580,14 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags(const
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections(RoadQueryActor);
+	const int32 NumCrosswalkIntersections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersections);
 
 	if (!ensureMsgf(CrosswalkIntersectionIndex >= 0 && CrosswalkIntersectionIndex < NumCrosswalkIntersections, TEXT("CrosswalkIntersectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersections, CrosswalkIntersectionIndex, *RoadQueryActor->GetName()))
 	{
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnections = ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections(RoadQueryActor, CrosswalkIntersectionIndex);
+	const int32 NumCrosswalkIntersectionConnections = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumTempoCrosswalkIntersectionConnections, CrosswalkIntersectionIndex);
 
 	if (!ensureMsgf(CrosswalkIntersectionConnectionIndex >= 0 && CrosswalkIntersectionConnectionIndex < NumCrosswalkIntersectionConnections, TEXT("CrosswalkIntersectionConnectionIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkIntersectionConnections, CrosswalkIntersectionConnectionIndex, *RoadQueryActor->GetName()))
 	{
@@ -597,7 +599,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags(const
 	// CrosswalkIntersectionConnectionIndex == 0 means the actual crosswalk that goes across the road referenced by CrosswalkIndex.
 	if (CrosswalkIntersectionConnectionIndex == 0)
 	{
-		const TArray<FName> CrosswalkLaneTags = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneTags(RoadQueryActor, CrosswalkIndex, LaneIndex);
+		const TArray<FName> CrosswalkLaneTags = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkLaneTags, CrosswalkIndex, LaneIndex);
 
 		OutCrosswalkIntersectionEntranceLaneTags = CrosswalkLaneTags;
 	}
@@ -605,7 +607,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionEntranceLaneTags(const
 	{
 		// For now, we'll assume that the CrosswalkIntersectionConnector's CrosswalkRoadModule also has
 		// the lane properties of the adjacent RoadModules to avoid another layer of complexity.
-		const int32 CrosswalkRoadModuleIndex = ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex(RoadQueryActor, CrosswalkIntersectionIndex);
+		const int32 CrosswalkRoadModuleIndex = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetTempoCrosswalkRoadModuleIndexFromCrosswalkIntersectionIndex, CrosswalkIntersectionIndex);
 		if (!TryGetCrosswalkIntersectionConnectorLaneTags(RoadQueryActor, CrosswalkRoadModuleIndex, LaneIndex, CrosswalkIntersectionConnectorInfoMap, OutCrosswalkIntersectionEntranceLaneTags))
 		{
 			return false;
@@ -622,7 +624,7 @@ bool UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes(cons
 		return false;
 	}
 
-	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(RoadQueryActor);
+	const int32 NumCrosswalkRoadModules = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules);
 
 	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *RoadQueryActor->GetName()))
 	{
@@ -641,7 +643,7 @@ bool UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes(cons
 		return false;
 	}
 
-	const int32 NumCrosswalkIntersectionConnectorLanes = ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule);
+	const int32 NumCrosswalkIntersectionConnectorLanes = UTempoCoreUtils::CallBlueprintFunction(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetNumTempoRoadModuleLanes);
 
 	OutNumCrosswalkIntersectionConnectorLanes = NumCrosswalkIntersectionConnectorLanes;
 
@@ -655,7 +657,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOv
 		return false;
 	}
 
-	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(RoadQueryActor);
+	const int32 NumCrosswalkRoadModules = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules);
 
 	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *RoadQueryActor->GetName()))
 	{
@@ -674,7 +676,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneProfileOv
 		return false;
 	}
 
-	const FName CrosswalkRoadModuleLaneProfileOverrideName = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneProfileOverrideName(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule);
+	const FName CrosswalkRoadModuleLaneProfileOverrideName = UTempoCoreUtils::CallBlueprintFunction(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneProfileOverrideName);
 
 	OutCrosswalkIntersectionConnectorLaneProfileOverrideName = CrosswalkRoadModuleLaneProfileOverrideName;
 
@@ -688,7 +690,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth(con
 		return false;
 	}
 
-	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(RoadQueryActor);
+	const int32 NumCrosswalkRoadModules = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules);
 
 	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *RoadQueryActor->GetName()))
 	{
@@ -707,7 +709,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneWidth(con
 		return false;
 	}
 
-	const float CrosswalkRoadModuleLaneWidth = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneWidth(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+	const float CrosswalkRoadModuleLaneWidth = UTempoCoreUtils::CallBlueprintFunction(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneWidth, LaneIndex);
 
 	OutCrosswalkIntersectionConnectorLaneWidth = CrosswalkRoadModuleLaneWidth;
 
@@ -721,7 +723,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection
 		return false;
 	}
 
-	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(RoadQueryActor);
+	const int32 NumCrosswalkRoadModules = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules);
 
 	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *RoadQueryActor->GetName()))
 	{
@@ -740,7 +742,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneDirection
 		return false;
 	}
 
-	const EZoneLaneDirection CrosswalkRoadModuleLaneDirection = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneDirection(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+	const EZoneLaneDirection CrosswalkRoadModuleLaneDirection = UTempoCoreUtils::CallBlueprintFunction(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneDirection, LaneIndex);
 
 	OutCrosswalkIntersectionConnectorLaneDirection = CrosswalkRoadModuleLaneDirection;
 
@@ -754,7 +756,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneTags(cons
 		return false;
 	}
 
-	const int32 NumCrosswalkRoadModules = ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules(RoadQueryActor);
+	const int32 NumCrosswalkRoadModules = UTempoCoreUtils::CallBlueprintFunction(RoadQueryActor, ITempoCrosswalkInterface::Execute_GetNumConnectedTempoCrosswalkRoadModules);
 
 	if (!ensureMsgf(CrosswalkRoadModuleIndex >= 0 && CrosswalkRoadModuleIndex < NumCrosswalkRoadModules, TEXT("CrosswalkRoadModuleIndex must be in range [0..%d) in UTempoRoadQueryComponent::TryGetNumCrosswalkIntersectionConnectorLanes.  Currently, it is: %d.  RoadQueryActor: %s."), NumCrosswalkRoadModules, CrosswalkRoadModuleIndex, *RoadQueryActor->GetName()))
 	{
@@ -773,7 +775,7 @@ bool UTempoRoadQueryComponent::TryGetCrosswalkIntersectionConnectorLaneTags(cons
 		return false;
 	}
 
-	const TArray<FName> CrosswalkRoadModuleLaneTags = ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, LaneIndex);
+	const TArray<FName> CrosswalkRoadModuleLaneTags = UTempoCoreUtils::CallBlueprintFunction(CrosswalkIntersectionConnectorInfo->CrosswalkRoadModule, ITempoRoadModuleInterface::Execute_GetTempoRoadModuleLaneTags, LaneIndex);
 
 	OutCrosswalkIntersectionConnectorLaneTags = CrosswalkRoadModuleLaneTags;
 


### PR DESCRIPTION
This wraps all BP calls from CPP in a new `CallBlueprintFunction` utility, which wraps the call in an `FEditorScriptExecutionGuard` when the call is in an Editor world.