### PR TITLE
Avoid Warnings from Pip

### DIFF
--- a/TempoCore/Scripts/GenAPI.sh
+++ b/TempoCore/Scripts/GenAPI.sh
@@ -66,7 +66,7 @@ pip install grpcio==1.62.2 --quiet --retries 0 # One --quiet to suppress warning
 set -e
 
 # Finally build and install the Tempo API (and its dependencies) to the virtual environment.
-if (pip list | grep tempo) &> /dev/null; then
+if pip show tempo &> /dev/null; then
   # Uninstall tempo if a previous version was installed
   pip uninstall tempo --yes --quiet # Uninstall first to remove any stale files
 fi


### PR DESCRIPTION
Avoids two warnings from pip that confuse users:
- We were trying to suppress warnings about upgrading to the latest pip version by automatically upgrading pip. This was working on Mac and Linux but not on Windows. I've reconsidered now. We don't want to automatically upgrade, we want to keep the version that came with Unreal, and simply suppress the warning. We can do that with a local pip configuration file. This adds that file in the correct location on each platform.
- We try to uninstall any existing tempo package, so we can be sure there is no stale content. But if the user doesn't already have tempo installed (for example the first time they build) they'll get a warning. This checks if tempo is installed before attempting to uninstall.