### PR TITLE
Correct GH Actions Runner Name

### DIFF
--- a/.github/workflows/build_and_package.yml
+++ b/.github/workflows/build_and_package.yml
@@ -131,7 +131,7 @@ jobs:
           fi
         fi
     - name: Free Disk Space (if using GitHub-hosted runner)
-      if: ${{ contains(runner.name, 'Github Actions') }}
+      if: ${{ contains(runner.name, 'Github') && contains(runner.name, 'Actions') }}
       uses: jlumbroso/free-disk-space@main
       with:
         tool-cache: true
@@ -226,7 +226,7 @@ jobs:
       run: |
         ${{ github.workspace }}/${{ inputs.tempo_root }}/Scripts/ExtractReleasePaks.sh ${{ github.workspace }}/.base_release ${{ github.workspace }}/.releases/${{ inputs.release_id }} ${{ github.workspace }}/.base_release/Metadata
     - name: Relocate Docker Daemon Data Root (if using GitHub-hosted runner)
-      if: ${{ contains(runner.name, 'Github Actions') }}
+      if: ${{ contains(runner.name, 'Github') && contains(runner.name, 'Actions') }}
       run: |
         # Credit to https://github.com/orgs/community/discussions/26357
         # The drive mounted at /mnt has a lot more free space than the main volume.
@@ -409,6 +409,7 @@ jobs:
           .engine-ddc-cache/**
         key: ${{ steps.repo_lowercase.outputs.REPO_LOWERCASE }}-build-${{ env.UNREAL_VERSION }}-${{ github.sha }}
     - name: Check Free Space (if using GitHub-hosted runner)
+      if: ${{ contains(runner.name, 'Github') && contains(runner.name, 'Actions') }}
       run: df -h / && df -h /mnt
     - name: Reset Source File Permissions
       if: always()  # This ensures it runs even if previous steps fail


### PR DESCRIPTION
Github changed the naming of runners. They used to be `Github Actions...`, now they are `Github-Actions...`. Update accordingly (and detect both, in case it's not universal).