### PR TITLE
Remove -n from curl Commands

### DIFF
--- a/Scripts/SyncDeps.sh
+++ b/Scripts/SyncDeps.sh
@@ -90,7 +90,7 @@ SYNC_THIRD_PARTY_DEPS () {
   PULL_DEPENDENCIES () {
     TARGET_PLATFORM=$1
     
-    RELEASE_INFO=$(curl -n -L -J \
+    RELEASE_INFO=$(curl -L -J \
                    -H "Accept: application/vnd.github+json" \
                    -H "X-GitHub-Api-Version: 2022-11-28" \
                    https://api.github.com/repos/tempo-sim/TempoThirdParty/releases)
@@ -105,7 +105,7 @@ SYNC_THIRD_PARTY_DEPS () {
     
     echo -e "\nDownloading TempoThirdParty release $RELEASE_NAME for platform $TARGET_PLATFORM from $URL\n"
     
-    curl -n -L -J -O --output-dir "$TEMP" \
+    curl -L -J -O --output-dir "$TEMP" \
     -H "Accept: application/octet-stream" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "$URL"


### PR DESCRIPTION
We no longer require a netrc file to pull third party dependencies (as we did when TempoThirdParty was private). A user reported the error `curl: (26) .netrc error: no such file` when running Setup.sh. This removes the `-n` from the curl commands, since it is no longer required.