### PR TITLE
Get and Set FEnumProperty Value Correctly

### DIFF
--- a/TempoWorld/Source/TempoWorld/Private/TempoActorControlServiceSubsystem.cpp
+++ b/TempoWorld/Source/TempoWorld/Private/TempoActorControlServiceSubsystem.cpp
@@ -587,9 +587,10 @@ void GetObjectProperties(const UObject* Object, GetPropertiesResponse& Response)
 			Type = EnumName;
 			if (Value)
 			{
-				int64 ValueIndex;
-				EnumProperty->GetValue_InContainer(Container, &ValueIndex);
-				*Value = EnumProperty->GetEnum()->GetAuthoredNameStringByIndex(ValueIndex);
+				const FNumericProperty* EnumIntProperty = EnumProperty->GetUnderlyingProperty();
+				const void* ValuePtr = EnumProperty->ContainerPtrToValuePtr<void>(Container);
+				int64 IntValue = EnumIntProperty->GetSignedIntPropertyValue(ValuePtr);
+				*Value = EnumProperty->GetEnum()->GetAuthoredNameStringByValue(IntValue);
 			}
 		}
 		else if (const FByteProperty* ByteProperty = CastField<FByteProperty>(Property))
@@ -904,7 +905,8 @@ grpc::Status SetSinglePropertyValue<FEnumProperty, FString>(void* ValuePtr, FEnu
 	{
 		return grpc::Status(grpc::INVALID_ARGUMENT, "Invalid enum value");
 	}
-	*static_cast<int64*>(ValuePtr) = Value;
+	const FNumericProperty* EnumIntProperty = Property->GetUnderlyingProperty();
+	EnumIntProperty->SetIntPropertyValue(ValuePtr, Value);
 	return grpc::Status_OK;
 }
 


### PR DESCRIPTION
The way we are accessing values of FEnumProperties is not correct and results in incorrect values for some enums. This changes it to copy the way it's done in engine code, using `FEnumProperty::GetUnderlyingProperty` (for example `Engine/Source/Runtime/MovieScene/Private/MovieSceneCommonHelpers.cpp`).

Also changes the way we set FEnumProperties to use `FEnumProperty::GetUnderlyingProperty`, removing the `*static_cast<int64*>` (which was effectively a `reinterpret_cast<int64>`).