### PR TITLE
Add Workarounds for Mass Spawn Issues

### DIFF
--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoMassSpawner.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoMassSpawner.cpp
@@ -1,0 +1,27 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved.
+
+#include "TempoMassSpawner.h"
+
+#include "MassSimulationSubsystem.h"
+
+void UTempoMassSpawnerSubSystem::OnWorldBeginPlay(UWorld& World)
+{
+	// Wait for level streaming completed so that all Actors with MassAgent components will be loaded.
+	GEngine->BlockTillLevelStreamingCompleted(&World);
+	
+	// Cause MassAgentSubsystem to initialize MassAgent components with the PrePhysics ProcessingPhaseStarted delegate.
+	UMassSimulationSubsystem* MassSimulationSubsystem = UWorld::GetSubsystem<UMassSimulationSubsystem>(&World);
+	if (ensureMsgf(MassSimulationSubsystem != nullptr, TEXT("MassSimulationSubsystem was null in UTempoMassSpawnerSubSystem::OnWorldBeginPlay")))
+	{
+		MassSimulationSubsystem->GetOnProcessingPhaseStarted(EMassProcessingPhase::PrePhysics).Broadcast(0.0);
+	}
+}
+
+void ATempoMassSpawner::BeginPlay()
+{
+	// Ensure all EntityConfigs are loaded before the call to Super::BeginPlay()
+	// Otherwise they will be loaded asynchronously and the spawn will be delayed
+	RegisterEntityTemplates();
+
+	Super::BeginPlay();
+}

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoMassSpawner.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoMassSpawner.h
@@ -18,8 +18,7 @@
  *
  * The second issue is that MassSpawner checks IsLoaded on all its EntityConfigs and, if they are not loaded, calls
  * FStreamableManager::RequestAsyncLoad. That will lead to at least a one-frame delay any time EntityConfigs were not
- * loaded before BeginPlay (which seems to always be the case; whatever they're doing in
- * AMassSpawner::PostRegisterAllComponents does not seem to be working).
+ * loaded before BeginPlay.
  *
  * It just so happens that, in practice, these two issues "cancel out": the agents are not initialized until the first
  * Tick, but the spawn doesn't actually happen until the first Tick anyhow.
@@ -41,6 +40,10 @@ public:
 	virtual void OnWorldBeginPlay(UWorld& World) override;
 };
 
+/*
+ * A MassSpawner that is guaranteed to spawn on BeginPlay when bAutoSpawnOnBeginPlay is true,
+ * unlike its parent which may spawn some ticks after.
+ */
 UCLASS()
 class TEMPOAGENTSSHARED_API ATempoMassSpawner : public AMassSpawner
 {

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoMassSpawner.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoMassSpawner.h
@@ -1,0 +1,51 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved.
+
+#pragma once
+
+#include "TempoSubsystems.h"
+
+#include "CoreMinimal.h"
+#include "MassSpawner.h"
+#include "TempoMassSpawner.generated.h"
+
+/*
+ * These two classes (UTempoMassSpawnerSubSystem and ATempoMassSpawner) exist to work around two issues in
+ * MassAgentSubsystem and MassSpawner.
+ *
+ * The first issue is that MassAgentSubsystem only handles pending MassAgent component registrations on Tick, meaning
+ * any spawns that happen on BeginPlay will not take into account fragments created by MassAgent components (for
+ * example, obstacle locations).
+ *
+ * The second issue is that MassSpawner checks IsLoaded on all its EntityConfigs and, if they are not loaded, calls
+ * FStreamableManager::RequestAsyncLoad. That will lead to at least a one-frame delay any time EntityConfigs were not
+ * loaded before BeginPlay (which seems to always be the case; whatever they're doing in
+ * AMassSpawner::PostRegisterAllComponents does not seem to be working).
+ *
+ * It just so happens that, in practice, these two issues "cancel out": the agents are not initialized until the first
+ * Tick, but the spawn doesn't actually happen until the first Tick anyhow.
+ *
+ * However, during deferred level loading (see ATempoGameMode::StartPlay), we call
+ * UEngine::BlockTillLevelStreamingCompleted, which causes the EntityConfigs to load and the spawn to happen on
+ * BeginPlay, exposing the consequences of the first issue above.
+ *
+ * We could have intentionally delayed the spawn until the first tick, but we would rather the spawn happen during
+ * BeginPlay, so we added a workaround for each of the above issues here.
+ */
+
+UCLASS()
+class TEMPOAGENTSSHARED_API UTempoMassSpawnerSubSystem : public UTempoGameWorldSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void OnWorldBeginPlay(UWorld& World) override;
+};
+
+UCLASS()
+class TEMPOAGENTSSHARED_API ATempoMassSpawner : public AMassSpawner
+{
+	GENERATED_BODY()
+
+protected:
+	virtual void BeginPlay() override;
+};

--- a/TempoAgents/Source/TempoAgentsShared/TempoAgentsShared.Build.cs
+++ b/TempoAgents/Source/TempoAgentsShared/TempoAgentsShared.Build.cs
@@ -42,8 +42,10 @@ public class TempoAgentsShared : ModuleRules
                 "MassAIBehavior",
                 "StateTreeModule",
                 "MassSignals",
+                "MassSimulation",
                 // Tempo
                 "TempoCore",
+                "TempoCoreShared",
             }
         );
     }


### PR DESCRIPTION
There is a pair of issues between MassSpawner and MassAgentSubsystem that just so happen to "cancel out" in normal operation. Deferred level loading happens to hide one of them, revealing the other. This adds workarounds for both. Refer to the comments in the code for a detailed explanation of the issues and workarounds.