### PR TITLE
Add PreBeginPlay Event on Register Mass Agent Components On It

### DIFF
--- a/TempoAgents/Source/TempoAgentsShared/Private/TempoMassSpawner.cpp
+++ b/TempoAgents/Source/TempoAgentsShared/Private/TempoMassSpawner.cpp
@@ -2,15 +2,24 @@
 
 #include "TempoMassSpawner.h"
 
+#include "TempoGameMode.h"
+
+#include "Kismet/GameplayStatics.h"
 #include "MassSimulationSubsystem.h"
 
-void UTempoMassSpawnerSubSystem::OnWorldBeginPlay(UWorld& World)
+void UTempoMassSpawnerSubSystem::OnWorldBeginPlay(UWorld& InWorld)
 {
-	// Wait for level streaming completed so that all Actors with MassAgent components will be loaded.
-	GEngine->BlockTillLevelStreamingCompleted(&World);
-	
+	// Hook up to TempoGameMode's PreBeginPlayEvent to register MassAgent components *right* before BeginPlay
+	if (ATempoGameMode* TempoGameMode = Cast<ATempoGameMode>(UGameplayStatics::GetGameMode(&InWorld)))
+	{
+		TempoGameMode->PreBeginPlayEvent.AddUObject(this, &UTempoMassSpawnerSubSystem::OnPreBeginPlay);
+	}
+}
+
+void UTempoMassSpawnerSubSystem::OnPreBeginPlay(UWorld* World)
+{
 	// Cause MassAgentSubsystem to initialize MassAgent components with the PrePhysics ProcessingPhaseStarted delegate.
-	UMassSimulationSubsystem* MassSimulationSubsystem = UWorld::GetSubsystem<UMassSimulationSubsystem>(&World);
+	UMassSimulationSubsystem* MassSimulationSubsystem = UWorld::GetSubsystem<UMassSimulationSubsystem>(World);
 	if (ensureMsgf(MassSimulationSubsystem != nullptr, TEXT("MassSimulationSubsystem was null in UTempoMassSpawnerSubSystem::OnWorldBeginPlay")))
 	{
 		MassSimulationSubsystem->GetOnProcessingPhaseStarted(EMassProcessingPhase::PrePhysics).Broadcast(0.0);

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoMassSpawner.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoMassSpawner.h
@@ -37,7 +37,10 @@ class TEMPOAGENTSSHARED_API UTempoMassSpawnerSubSystem : public UTempoGameWorldS
 	GENERATED_BODY()
 
 public:
-	virtual void OnWorldBeginPlay(UWorld& World) override;
+	virtual void OnWorldBeginPlay(UWorld& InWorld) override;
+
+protected:
+	void OnPreBeginPlay(UWorld* World);
 };
 
 /*

--- a/TempoCore/Source/TempoCore/Private/TempoGameMode.cpp
+++ b/TempoCore/Source/TempoCore/Private/TempoGameMode.cpp
@@ -23,6 +23,7 @@ void ATempoGameMode::StartPlay()
 		}
 	}
 
+	PreBeginPlayEvent.Broadcast(GetWorld());
 	Super::StartPlay();
 
 	if (TempoCoreServiceSubsystem)

--- a/TempoCore/Source/TempoCore/Public/TempoGameMode.h
+++ b/TempoCore/Source/TempoCore/Public/TempoGameMode.h
@@ -9,6 +9,8 @@
 
 #include "TempoGameMode.generated.h"
 
+DECLARE_MULTICAST_DELEGATE_OneParam(FPreBeginPlay, UWorld*);
+
 UCLASS(Blueprintable, Abstract)
 class TEMPOCORE_API ATempoGameMode : public AGameModeBase
 {
@@ -20,6 +22,9 @@ public:
 	virtual void StartPlay() override;
 
 	bool BeginPlayDeferred() const { return bBeginPlayDeferred; }
+
+	// An event that fires *right* before BeginPlay
+	FPreBeginPlay PreBeginPlayEvent;
 
 protected:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta=(MustImplement="/Script/TempoCore.ActorClassificationInterface"))


### PR DESCRIPTION
https://github.com/tempo-sim/Tempo/pull/230 successfully allowed agents saved in the level to be recognized by MassSpawners on BeginPlay. However agents spawned during the deferred load state will still not be recognized, as OnWorldBeginPlay runs a little too early. This fixes that by moving the registration even closer to BeginPlay, by adding a new delegate to TempoGameMode.