### PR TITLE
Add support for vehicles to independently yield to any other vehicle.

### DIFF
--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficCrowdYieldProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficCrowdYieldProcessor.cpp
@@ -110,7 +110,7 @@ void UMassTrafficCrowdYieldProcessor::Execute(FMassEntityManager& EntityManager,
 					// We don't have any info about vehicles on this lane.
 					// So, we don't need to yield.
 					//
-					// Note:  Due to where NumVehiclesOnLane gets updated in the frame,
+					// Note:  Due to where a lane's NumVehiclesOnLane field gets updated in the frame,
 					// relative to where CoreVehicleInfos gets updated in the frame,
 					// NumVehiclesOnLane might be greater than 0 for this lane,
 					// while CoreVehicleInfos is empty.

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficCrowdYieldProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficCrowdYieldProcessor.cpp
@@ -14,7 +14,7 @@
 #include "MassTrafficLaneChange.h"
 
 
-// Important:  UMassTrafficCrowdYieldProcessor is meant to run after UMassTrafficVehicleControlProcessor.
+// Important:  UMassTrafficCrowdYieldProcessor is meant to run before UMassTrafficVehicleControlProcessor.
 // So, this must be setup in DefaultMass.ini.
 UMassTrafficCrowdYieldProcessor::UMassTrafficCrowdYieldProcessor()
 	: EntityQuery(*this)
@@ -61,6 +61,13 @@ void UMassTrafficCrowdYieldProcessor::Execute(FMassEntityManager& EntityManager,
 		const TConstArrayView<FMassForceFragment> ForceFragments = QueryContext.GetFragmentView<FMassForceFragment>();
 		const TConstArrayView<FAgentRadiusFragment> RadiusFragments = QueryContext.GetFragmentView<FAgentRadiusFragment>();
 
+		const UWorld* World = QueryContext.GetWorld();
+
+		if (!ensureMsgf(World != nullptr, TEXT("Must get valid World in UMassTrafficCrowdYieldProcessor::Execute.")))
+		{
+			return;
+		}
+
 		const int32 NumEntities = QueryContext.GetNumEntities();
 	
 		for (int32 EntityIndex = 0; EntityIndex < NumEntities; ++EntityIndex)
@@ -95,70 +102,29 @@ void UMassTrafficCrowdYieldProcessor::Execute(FMassEntityManager& EntityManager,
 			const bool bWasAlreadyYieldingOnCrosswalk = CrosswalkLaneInfo->IsEntityOnCrosswalkYieldingToAnyLane(EntityHandle);
 			const float DesiredSpeed = bWasAlreadyYieldingOnCrosswalk ? CrosswalkLaneInfo->GetEntityYieldResumeSpeed(EntityHandle).Get() : MoveTargetFragment.DesiredSpeed.Get();
 			
-			const auto& ShouldYieldToIncomingVehicleLane = [&MassTrafficSubsystem, &LaneLocationFragment, &VelocityFragment, &ForceFragment, &RadiusFragment, &ZoneGraphStorage, bWasAlreadyYieldingOnCrosswalk, DesiredSpeed, this](const FZoneGraphTrafficLaneData& CurrentTrafficLaneData, const FZoneGraphTrafficLaneData& CrossingTrafficLaneData)
+			const auto& ShouldYieldToIncomingVehicleLane = [&MassTrafficSubsystem, &LaneLocationFragment, &VelocityFragment, &ForceFragment, &RadiusFragment, &ZoneGraphStorage, &EntityHandle, bWasAlreadyYieldingOnCrosswalk, DesiredSpeed, this](const FZoneGraphTrafficLaneData& CurrentTrafficLaneData, const FZoneGraphTrafficLaneData& CrossingTrafficLaneData, FMassEntityHandle& OutYieldTargetEntity)
 			{
-				// If there are no vehicles on this lane, we don't need to worry about yielding to them.
-				if (CurrentTrafficLaneData.NumVehiclesOnLane <= 0)
+				TSet<FMassTrafficCoreVehicleInfo> CoreVehicleInfos;
+				if (!MassTrafficSubsystem.TryGetCoreVehicleInfos(CurrentTrafficLaneData.LaneHandle, CoreVehicleInfos))
 				{
+					// We don't have any info about vehicles on this lane.
+					// So, we don't need to yield.
+					//
+					// Note:  Due to where NumVehiclesOnLane gets updated in the frame,
+					// relative to where CoreVehicleInfos gets updated in the frame,
+					// NumVehiclesOnLane might be greater than 0 for this lane,
+					// while CoreVehicleInfos is empty.
+					// However, in this case, the CoreVehicleInfos data for the lane
+					// will be populated by the next frame.
 					return false;
 				}
 
-				// Since there are vehicles on the lane (ie. CurrentTrafficLaneData.NumVehiclesOnLane > 0),
-				// we'd like to be able to ensure that all the LeadVehicle properties are set, here.
-				// But, we can't, because NumVehiclesOnLane gets updated at two different spots in the frame,
-				// depending on the vehicle's current representation.  That is, for vehicles in "Simple" representation,
-				// UMassTrafficVehicleControlProcessor calls UE::MassTraffic::MoveVehicleToNextLane,
-				// which will update NumVehiclesOnLane.  And, in "PID" representation,
-				// UMassTrafficPostPhysicsUpdateTrafficVehiclesProcessor calls UE::MassTraffic::MoveVehicleToNextLane
-				// later in the frame.
-				// So, first the "LeadVehicle" data is set on the lanes in UMassTrafficLaneMetadataProcessor,
-				// then UMassTrafficVehicleControlProcessor consumes it,
-				// then UMassTrafficCrowdYieldProcessor consumes it.  (According to the proper config in DefaultMass.ini.)
-				// However, for simple vehicles that just cross over onto their next lane,
-				// NumVehiclesOnLane will be incremented on those lanes before being evaluated
-				// by UMassTrafficCrowdYieldProcessor.
-				// But, those lanes won't have their "LeadVehicle" data set for another frame,
-				// in the case that there were no vehicles on the lane, and now there is 1 simple vehicle.
-				if (!(CurrentTrafficLaneData.LeadVehicleDistanceAlongLane.IsSet()
-					&& CurrentTrafficLaneData.LeadVehicleSpeed.IsSet()
-					&& CurrentTrafficLaneData.LeadVehicleRadius.IsSet()))
+				// If there are no vehicles on the current lane, ...
+				if (CoreVehicleInfos.IsEmpty())
 				{
-					// Since there are vehicles on the incoming vehicle lane,
-					// we would like to determine in detail if we should yield to them.
-					// However, something went wrong, so we will just yield until the vehicles clear,
-					// if they are not yielding.
-					return true;
+					// We don't need to yield to the current lane.
+					return false;
 				}
-				
-				float VehicleEnterTime;
-				float VehicleExitTime;
-
-				float VehicleEnterDistance;
-				float VehicleExitDistance;
-
-				if (!UE::MassTraffic::TryGetVehicleEnterAndExitTimesForCrossingLane(
-					MassTrafficSubsystem,
-					*MassTrafficSettings,
-					*ZoneGraphStorage,
-					CurrentTrafficLaneData,
-					CrossingTrafficLaneData,
-					LaneLocationFragment.LaneHandle,
-					CurrentTrafficLaneData.LeadVehicleDistanceAlongLane.GetValue(),
-					CurrentTrafficLaneData.LeadVehicleSpeed.GetValue(),
-					CurrentTrafficLaneData.LeadVehicleRadius.GetValue(),
-					VehicleEnterTime,
-					VehicleExitTime,
-					&VehicleEnterDistance,
-					&VehicleExitDistance))
-				{
-					// Since there are vehicles on the incoming vehicle lane,
-					// we would like to determine in detail if we should yield to them.
-					// However, something went wrong, so we will just yield until the vehicles clear,
-					// if they are not yielding.
-					return true;
-				}
-				
-				const bool bVehicleIsInCrosswalkLane = VehicleEnterDistance <= 0.0f && VehicleExitDistance > 0.0f;
 
 				FZoneGraphLaneLocation PedestrianZoneGraphLaneLocation;
 				UE::ZoneGraph::Query::CalculateLocationAlongLane(*ZoneGraphStorage, LaneLocationFragment.LaneHandle, LaneLocationFragment.DistanceAlongLane, PedestrianZoneGraphLaneLocation);
@@ -186,97 +152,137 @@ void UMassTrafficCrowdYieldProcessor::Execute(FMassEntityManager& EntityManager,
 						&PedestrianEnterDistance,
 						&PedestrianExitDistance))
 				{
-					// If there are vehicles on the incoming vehicle lane, and they are not yielding,
-					// we would like to determine in detail if we should yield to them.
-					// However, something went wrong, so we will just yield until the vehicles clear.
-					return true;
+					// Due to UMassTrafficYieldDeadlockResolutionProcessor requirements,
+					// if we're unable to determine the yield target Entity, we can't yield.
+					// So, we proceed under this error condition.
+					return false;
 				}
-				
-				const bool bInDistanceConflictWithVehicle = bVehicleIsInCrosswalkLane && PedestrianEnterDistance < MassTrafficSettings->PedestrianVehicleBufferDistanceOnCrosswalk && PedestrianEnterDistance > 0.0f;
 
-				// Pedestrians only yield to vehicles when they are in the way.
-				// Whereas, vehicles check for both "time conflicts" and "distance conflicts" with pedestrians.
-				// This effectively means that pedestrians always have the "right of way" over vehicles.
-				if (bInDistanceConflictWithVehicle)
+				// Consider each vehicle on the lane.
+				for (const FMassTrafficCoreVehicleInfo& CoreVehicleInfo : CoreVehicleInfos)
 				{
-					return true;
+					// Skip processing our yield logic if we have a yield override for this Lane-Entity Pair.
+					// This mechanism is used to prevent yield cycle deadlocks.
+					if (MassTrafficSubsystem.HasYieldOverride(
+						LaneLocationFragment.LaneHandle, EntityHandle,
+						CurrentTrafficLaneData.LaneHandle, CoreVehicleInfo.VehicleEntityHandle))
+					{
+						continue;
+					}
+					
+					// For vehicles that are not currently on the crossing lane, ...
+					if (CurrentTrafficLaneData.LaneHandle != CrossingTrafficLaneData.LaneHandle)
+					{
+						// Only consider the vehicle if it is heading into the crossing lane.
+						if (CoreVehicleInfo.VehicleNextLane == nullptr || CoreVehicleInfo.VehicleNextLane->LaneHandle != CrossingTrafficLaneData.LaneHandle)
+						{
+							continue;
+						}
+					}
+
+					float VehicleEnterTime;
+					float VehicleExitTime;
+
+					float VehicleEnterDistance;
+					float VehicleExitDistance;
+
+					if (!UE::MassTraffic::TryGetVehicleEnterAndExitTimesForCrossingLane(
+						MassTrafficSubsystem,
+						*MassTrafficSettings,
+						*ZoneGraphStorage,
+						CurrentTrafficLaneData,
+						CrossingTrafficLaneData,
+						LaneLocationFragment.LaneHandle,
+						CoreVehicleInfo.VehicleDistanceAlongLane,
+						CoreVehicleInfo.VehicleSpeed,
+						CoreVehicleInfo.VehicleRadius,
+						VehicleEnterTime,
+						VehicleExitTime,
+						&VehicleEnterDistance,
+						&VehicleExitDistance))
+					{
+						// Due to UMassTrafficYieldDeadlockResolutionProcessor requirements,
+						// if we're unable to determine the yield target Entity, we can't yield.
+						// So, we proceed under this error condition.
+						return false;
+					}
+					
+					const bool bVehicleIsInCrosswalkLane = VehicleEnterDistance <= 0.0f && VehicleExitDistance > 0.0f;
+					
+					const bool bInDistanceConflictWithVehicle = bVehicleIsInCrosswalkLane && PedestrianEnterDistance < MassTrafficSettings->PedestrianVehicleBufferDistanceOnCrosswalk && PedestrianEnterDistance > 0.0f;
+
+					// Pedestrians only yield to vehicles when they are in the way.
+					// Whereas, vehicles check for both "time conflicts" and "distance conflicts" with pedestrians.
+					// This effectively means that pedestrians always have the "right of way" over vehicles.
+					if (bInDistanceConflictWithVehicle)
+					{
+						OutYieldTargetEntity = CoreVehicleInfo.VehicleEntityHandle;
+						return true;
+					}
 				}
 
-				// No reason to yield to the lead vehicle on the current lane.
+				// No reason to yield to the current lane.
 				return false;
 			};
 
-			const auto& UpdateYieldTrackingStateForVehicleLane = [&MassTrafficSubsystem, &EntityHandle, &CrosswalkLaneInfo, &LaneLocationFragment](const FZoneGraphLaneHandle& VehicleLane, const bool bShouldYieldOnCrosswalk)
+			const auto& UpdateYieldTrackingStateForVehicleLane = [&MassTrafficSubsystem, &EntityHandle, &CrosswalkLaneInfo, &LaneLocationFragment](const FZoneGraphLaneHandle& YieldTargetVehicleLane, const FMassEntityHandle& YieldTargetEntity, const bool bShouldYieldOnCrosswalk)
 			{
 				if (bShouldYieldOnCrosswalk)
 				{
 					// We should yield to this incoming vehicle lane.
 					// So, start tracking yield state data for the lane.
-					CrosswalkLaneInfo->TrackEntityOnCrosswalkYieldingToLane(EntityHandle, VehicleLane);
+					CrosswalkLaneInfo->TrackEntityOnCrosswalkYieldingToLane(EntityHandle, YieldTargetVehicleLane);
 
-					// Add this to the global view of all yields for this frame.
-					// The yield deadlock resolution processor will use this information to find and break any yield cycle deadlocks.
-					MassTrafficSubsystem.AddYieldInfo(EntityHandle, LaneLocationFragment.LaneHandle, VehicleLane);
+					if (ensureMsgf(YieldTargetVehicleLane.IsValid() && YieldTargetEntity.IsValid(), TEXT("Expected valid YieldTargetVehicleLane and YieldTargetEntity in UpdateYieldTrackingStateForVehicleLane in UMassTrafficCrowdYieldProcessor::Execute.  YieldTargetVehicleLane.Index: %d YieldTargetEntity.Index: %d."), YieldTargetVehicleLane.Index, YieldTargetEntity.Index))
+					{
+						// Add this to the global view of all yields for this frame.
+						// The yield deadlock resolution processor will use this information to find and break any yield cycle deadlocks.
+						MassTrafficSubsystem.AddYieldInfo(LaneLocationFragment.LaneHandle, EntityHandle, YieldTargetVehicleLane, YieldTargetEntity);
+					}
 				}
 				else
 				{
 					// If we're currently tracking yield state data for this lane, ...
-					if (CrosswalkLaneInfo->IsEntityOnCrosswalkYieldingToLane(EntityHandle, VehicleLane))
+					if (CrosswalkLaneInfo->IsEntityOnCrosswalkYieldingToLane(EntityHandle, YieldTargetVehicleLane))
 					{
 						// Stop tracking yield state data for this lane.
-						CrosswalkLaneInfo->UnTrackEntityOnCrosswalkYieldingToLane(EntityHandle, VehicleLane);
+						CrosswalkLaneInfo->UnTrackEntityOnCrosswalkYieldingToLane(EntityHandle, YieldTargetVehicleLane);
 					}
 				}
 			};
 
+			FMassEntityHandle YieldTargetEntity;
 			bool bShouldYieldOnCrosswalk = false;
-
-			// Only run our yield logic, if our yield behavior isn't being overridden.  If it *is* being overridden, a deadlock is being prevented.
-			if (!MassTrafficSubsystem.IsEntityInLaneYieldOverrideMap(LaneLocationFragment.LaneHandle, EntityHandle))
+			
+			for (const FZoneGraphLaneHandle& IncomingVehicleLane : CrosswalkLaneInfo->IncomingVehicleLanes)
 			{
-				for (const FZoneGraphLaneHandle& IncomingVehicleLane : CrosswalkLaneInfo->IncomingVehicleLanes)
+				const FZoneGraphTrafficLaneData* IncomingTrafficLaneData = MassTrafficSubsystem.GetTrafficLaneData(IncomingVehicleLane);
+                    				
+				if (!ensureMsgf(IncomingTrafficLaneData != nullptr, TEXT("Must get valid IncomingTrafficLaneData from IncomingVehicleLane in UMassTrafficCrowdYieldProcessor::Execute.  IncomingVehicleLane.Index: %d IncomingVehicleLane.DataHandle.Index: %d, IncomingVehicleLane.DataHandle.Generation: %d."), IncomingVehicleLane.Index, IncomingVehicleLane.DataHandle.Index, IncomingVehicleLane.DataHandle.Generation))
 				{
-					const FZoneGraphTrafficLaneData* IncomingTrafficLaneData = MassTrafficSubsystem.GetTrafficLaneData(IncomingVehicleLane);
-                    					
-					if (!ensureMsgf(IncomingTrafficLaneData != nullptr, TEXT("Must get valid IncomingTrafficLaneData from IncomingVehicleLane in UMassTrafficCrowdYieldProcessor::Execute.  IncomingVehicleLane.Index: %d IncomingVehicleLane.DataHandle.Index: %d, IncomingVehicleLane.DataHandle.Generation: %d."), IncomingVehicleLane.Index, IncomingVehicleLane.DataHandle.Index, IncomingVehicleLane.DataHandle.Generation))
+					continue;
+				}
+
+				YieldTargetEntity.Reset();
+				
+				const bool bShouldYieldOnCrosswalkToIncomingVehicleLane = ShouldYieldToIncomingVehicleLane(*IncomingTrafficLaneData, *IncomingTrafficLaneData, YieldTargetEntity);
+				UpdateYieldTrackingStateForVehicleLane(IncomingTrafficLaneData->LaneHandle, YieldTargetEntity, bShouldYieldOnCrosswalkToIncomingVehicleLane);
+
+				bShouldYieldOnCrosswalk |= bShouldYieldOnCrosswalkToIncomingVehicleLane;
+
+				for (const FZoneGraphTrafficLaneData* PredecessorTrafficLaneData : IncomingTrafficLaneData->PrevLanes)
+				{
+					if (PredecessorTrafficLaneData == nullptr)
 					{
 						continue;
 					}
-					
-					const bool bShouldYieldOnCrosswalkToIncomingVehicleLane = ShouldYieldToIncomingVehicleLane(*IncomingTrafficLaneData, *IncomingTrafficLaneData);
-					UpdateYieldTrackingStateForVehicleLane(IncomingTrafficLaneData->LaneHandle, bShouldYieldOnCrosswalkToIncomingVehicleLane);
 
-					bShouldYieldOnCrosswalk |= bShouldYieldOnCrosswalkToIncomingVehicleLane;
+					YieldTargetEntity.Reset();
 
-					for (const FZoneGraphTrafficLaneData* PredecessorTrafficLaneData : IncomingTrafficLaneData->PrevLanes)
-					{
-						if (PredecessorTrafficLaneData == nullptr)
-						{
-							continue;
-						}
+					const bool bShouldYieldOnCrosswalkToPredecessorVehicleLane = ShouldYieldToIncomingVehicleLane(*PredecessorTrafficLaneData, *IncomingTrafficLaneData, YieldTargetEntity);
+					UpdateYieldTrackingStateForVehicleLane(PredecessorTrafficLaneData->LaneHandle, YieldTargetEntity, bShouldYieldOnCrosswalkToPredecessorVehicleLane);
 
-						if (PredecessorTrafficLaneData->NumVehiclesOnLane <= 0)
-						{
-							continue;
-						}
-
-						if (!PredecessorTrafficLaneData->LeadVehicleNextLane.IsSet())
-						{
-							continue;
-						}
-
-						// We're only concerned if the lead vehicle on the Predecessor Lane
-						// will be heading into our Incoming Traffic Lane.
-						if (PredecessorTrafficLaneData->LeadVehicleNextLane.GetValue() != IncomingTrafficLaneData)
-						{
-							continue;
-						}
-
-						const bool bShouldYieldOnCrosswalkToPredecessorVehicleLane = ShouldYieldToIncomingVehicleLane(*PredecessorTrafficLaneData, *IncomingTrafficLaneData);
-						UpdateYieldTrackingStateForVehicleLane(PredecessorTrafficLaneData->LaneHandle, bShouldYieldOnCrosswalkToPredecessorVehicleLane);
-
-						bShouldYieldOnCrosswalk |= bShouldYieldOnCrosswalkToPredecessorVehicleLane;
-					}
+					bShouldYieldOnCrosswalk |= bShouldYieldOnCrosswalkToPredecessorVehicleLane;
 				}
 			}
 
@@ -290,6 +296,10 @@ void UMassTrafficCrowdYieldProcessor::Execute(FMassEntityManager& EntityManager,
 				// Set our MoveTargetFragment's DesiredSpeed to zero.
 				// This is the mechanism we use to yield.
 				MoveTargetFragment.DesiredSpeed = FMassInt16Real(0.0f);
+
+				// Track when we started yielding.
+				const float CurrentTimeSeconds = World->GetTimeSeconds();
+				CrosswalkLaneInfo->TrackEntityOnCrosswalkYieldStartTime(EntityHandle, CurrentTimeSeconds);
 			}
 			// If we should *stop* yielding on the crosswalk, ...
 			else if (bWasAlreadyYieldingOnCrosswalk && !bShouldYieldOnCrosswalk)
@@ -300,6 +310,40 @@ void UMassTrafficCrowdYieldProcessor::Execute(FMassEntityManager& EntityManager,
 
 				// Finally, we need to completely untrack all yield state data associated with this Entity.
 				CrosswalkLaneInfo->UnTrackEntityYieldingOnCrosswalk(EntityHandle);
+			}
+			// If we weren't already yielding, and we shouldn't start now, ...
+			else if (!bWasAlreadyYieldingOnCrosswalk && !bShouldYieldOnCrosswalk)
+			{
+				// And, we've got a "near zero" DesiredSpeed, ...
+				if (FMath::IsNearlyZero(MoveTargetFragment.DesiredSpeed.Get(), 1.0f))
+				{
+					// Set a reasonable DesiredSpeed as a failsafe so that if pedestrians
+					// get stuck on the crosswalk for any reason, they can resume motion
+					// and clear the crosswalk to prevent deadlock issues.
+					MoveTargetFragment.DesiredSpeed = FMassInt16Real(MassTrafficSettings->PedestrianFailsafeCrosswalkYieldResumeSpeed);
+					UE_LOG(LogMassTraffic, Log, TEXT("[Pedestrian Yield DesiredSpeed Failsafe] Correcting DesiredSpeed to %f for Entity: %d."), MoveTargetFragment.DesiredSpeed.Get(), EntityHandle.Index);
+				}
+			}
+			// If we were already yielding, and should continue yielding, ...
+			else // if (bWasAlreadyYieldingOnCrosswalk && bShouldYieldOnCrosswalk)
+			{
+				const float CurrentTimeSeconds = World->GetTimeSeconds();
+				const float EntityYieldStartTime = CrosswalkLaneInfo->GetEntityYieldStartTime(EntityHandle);
+
+				// And, we've been yielding for "too long", potentially involved in an unresolved yield deadlock, ...
+				if (CurrentTimeSeconds > EntityYieldStartTime + MassTrafficSettings->PedestrianMaxYieldOnCrosswalkTime)
+				{
+					// Get a "free pass" to ignore yielding to *any* Entities until we cross the crosswalk,
+					// if we don't already have one, in order to prevent unforeseen yield deadlock issues, as a failsafe.
+					if (!MassTrafficSubsystem.HasWildcardYieldOverride(LaneLocationFragment.LaneHandle, EntityHandle))
+					{
+						UE_LOG(LogMassTraffic, Log,
+							TEXT("[Pedestrian Yield Override Failsafe] Granting yield override for all potential yield targets to Entity: %d on LaneHandle.Index: %d LaneHandle.DataHandle.Index: %d LaneHandle.DataHandle.Generation: %d."),
+							EntityHandle.Index, LaneLocationFragment.LaneHandle.Index, LaneLocationFragment.LaneHandle.DataHandle.Index, LaneLocationFragment.LaneHandle.DataHandle.Generation);
+						
+						MassTrafficSubsystem.AddWildcardYieldOverride(LaneLocationFragment.LaneHandle, EntityHandle);
+					}
+				}
 			}
 		}
 	});

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficIntersectionSpawnDataGenerator.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficIntersectionSpawnDataGenerator.cpp
@@ -508,7 +508,14 @@ void UMassTrafficIntersectionSpawnDataGenerator::SetupLaneData(
 							{
 								continue;
 							}
-
+							
+							// Don't add our current lane's "splitting lanes" as "conflict lanes".
+							// If the previous lane branches, for instance to a left, right, and straight lane,
+							// and our current lane is the left lane, SplittingLanes will contain the straight and right lanes.
+							// However, these are not "conflict lanes" because they don't cross or merge with our current lane,
+							// but rather they branch from a common previous lane.
+							// And, there are other mechanisms meant to maintain the procession of vehicles,
+							// while handling the "splitting lanes" case.
 							if (CurrentSideVehicleIntersectionLane->SplittingLanes.Contains(OtherSideVehicleIntersectionLane))
 							{
 								continue;

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
@@ -1123,10 +1123,10 @@ bool ShouldYieldToCrosswalks_Internal(
 			}
 
 			// Skip crosswalks we've passed already.
-            if (VehicleCrosswalkLaneExitDistance <= 0.0f)
-            {
-            	continue;
-            }
+			if (VehicleCrosswalkLaneExitDistance <= 0.0f)
+			{
+				continue;
+			}
 
 			if (LaneLocationFragment.DistanceAlongLane < LaneLengthAtDownstreamCrosswalkLane - MassTrafficSettings->CrosswalkReactiveYieldDistanceVehicleLengthScale * RadiusFragment.Radius * 2.0)
 			{

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficLaneChange.cpp
@@ -763,39 +763,27 @@ bool CheckNextVehicle(const FMassEntityHandle Entity, const FMassEntityHandle Ne
 	return false;
 }
 
-bool DownstreamCrosswalkLaneHasYieldingEntities(const UMassTrafficSubsystem& MassTrafficSubsystem, const FZoneGraphTrafficLaneData* CurrentLaneData, const FZoneGraphLaneHandle& TestDownstreamCrosswalkLane)
-{
-	const FMassTrafficCrosswalkLaneInfo* CrosswalkLaneInfo = MassTrafficSubsystem.GetCrosswalkLaneInfo(TestDownstreamCrosswalkLane);
-
-	if (!ensureMsgf(CrosswalkLaneInfo != nullptr, TEXT("Must get valid CrosswalkLaneInfo in DownstreamCrosswalkLaneHasYieldingEntities.  TestDownstreamCrosswalkLane.Index: %d."), TestDownstreamCrosswalkLane.Index))
-	{
-		return false;
-	}
-
-	// Are there any Entities on the crosswalk lane that are yielding to our current lane?
-	return CrosswalkLaneInfo->IsAnyEntityOnCrosswalkYieldingToLane(CurrentLaneData->LaneHandle);
-}
-
 bool IsDownstreamCrosswalkLaneClear(
 	const UMassTrafficSubsystem& MassTrafficSubsystem,
 	const UMassCrowdSubsystem& MassCrowdSubsystem,
-	const FZoneGraphTrafficLaneData* CurrentLaneData,
-	const FZoneGraphTrafficLaneData* IntersectionLaneData,
+	const FZoneGraphTrafficLaneData& CurrentLaneData,
+	const FZoneGraphTrafficLaneData& IntersectionLaneData,
 	const FMassTrafficVehicleControlFragment& VehicleControlFragment,
 	const FMassZoneGraphLaneLocationFragment& LaneLocationFragment,
 	const FMassTrafficRandomFractionFragment& RandomFractionFragment,
 	const FAgentRadiusFragment& RadiusFragment,
 	const FZoneGraphStorage& ZoneGraphStorage,
 	const UMassTrafficSettings* MassTrafficSettings,
-	const FZoneGraphLaneHandle& TestDownstreamCrosswalkLane)
+	const FZoneGraphLaneHandle& TestDownstreamCrosswalkLane,
+	FMassEntityHandle& OutYieldTargetEntity)
 {
-	if (!ensureMsgf(CurrentLaneData->Length > 0.0f && LaneLocationFragment.LaneLength > 0.0f, TEXT("CurrentLane should have a length greater than zero.")))
+	if (!ensureMsgf(CurrentLaneData.Length > 0.0f && LaneLocationFragment.LaneLength > 0.0f, TEXT("CurrentLane should have a length greater than zero.")))
 	{
 		// If we have errant lane data, just say it's clear to attempt to keep traffic flowing.
 		return true;
 	}
 
-	if (!ensureMsgf(IntersectionLaneData->Length > 0.0f, TEXT("IntersectionLaneData should have a length greater than zero.")))
+	if (!ensureMsgf(IntersectionLaneData.Length > 0.0f, TEXT("IntersectionLaneData should have a length greater than zero.")))
 	{
 		// If we have errant lane data, just say it's clear to attempt to keep traffic flowing.
 		return true;
@@ -809,11 +797,6 @@ bool IsDownstreamCrosswalkLaneClear(
 		return true;
 	}
 
-	if (CrowdTrackingLaneData->NumEntitiesOnLane <= 0)
-	{
-		return true;
-	}
-
 	// When Pedestrians change onto their new lanes during the frame,
 	// we might not have all the properties for the Pedestrian yet.
 	// In that case, these will get set next frame.
@@ -823,10 +806,7 @@ bool IsDownstreamCrosswalkLaneClear(
 		&& CrowdTrackingLaneData->LeadEntityAccelerationAlongLane.IsSet()
 		&& CrowdTrackingLaneData->LeadEntityRadius.IsSet()))
 	{
-		// Since there are Entities on the test lane, but we can't determine the necessary properties
-		// about the lead Entity, we just wait until all Entities fully clear the test lane
-		// before allowing vehicles to resume from yielding.
-		return false;
+		return true;
 	}
 
 	// When Pedestrians change onto their new lanes during the frame,
@@ -838,10 +818,17 @@ bool IsDownstreamCrosswalkLaneClear(
 		&& CrowdTrackingLaneData->TailEntityAccelerationAlongLane.IsSet()
 		&& CrowdTrackingLaneData->TailEntityRadius.IsSet()))
 	{
-		// Since there are Entities on the test lane, but we can't determine the necessary properties
-		// about the tail Entity, we just wait until all Entities fully clear the test lane
-		// before allowing vehicles to resume from yielding.
-		return false;
+		return true;
+	}
+
+	// Skip processing our yield logic if we have a yield override for this Lane-Entity Pair.
+	// This mechanism is used to prevent yield cycle deadlocks.
+	if (MassTrafficSubsystem.HasYieldOverride(
+		LaneLocationFragment.LaneHandle, VehicleControlFragment.VehicleEntityHandle,
+		TestDownstreamCrosswalkLane, CrowdTrackingLaneData->TailEntityHandle.GetValue()))
+	{
+		// Just say the lane is clear.
+		return true;
 	}
 
 	const float EffectiveVehicleSpeed = VehicleControlFragment.IsYieldingAtIntersection() ? 0.0f : VehicleControlFragment.Speed;
@@ -856,8 +843,8 @@ bool IsDownstreamCrosswalkLaneClear(
 			MassTrafficSubsystem,
 			*MassTrafficSettings,
 			ZoneGraphStorage,
-			*CurrentLaneData,
-			*IntersectionLaneData,
+			CurrentLaneData,
+			IntersectionLaneData,
 			TestDownstreamCrosswalkLane,
 			LaneLocationFragment.DistanceAlongLane,
 			EffectiveVehicleSpeed,
@@ -867,10 +854,12 @@ bool IsDownstreamCrosswalkLaneClear(
 			&VehicleEnterDistance,
 			&VehicleExitDistance))
 	{
-		// Since there are Entities on the test lane,
-		// we just wait until all Entities fully clear the test lane before allowing vehicles to resume
-		// from yielding.
-		return false;
+		// Even though there are Entities on the lane,
+		// we still say the lane is clear since we can't determine
+		// to which Entity we might yield.
+		// The yield deadlock resolution processor requires us to know
+		// both the lane and Entity to which we're yielding.
+		return true;
 	}
 
 	if (VehicleControlFragment.IsYieldingAtIntersection())
@@ -883,45 +872,56 @@ bool IsDownstreamCrosswalkLaneClear(
 			VehicleExitTime);
 	}
 
-	// Don't consider yielding at stop sign controlled intersections
-	// until after the vehicle has completed its stop sign rest behavior.
-	if (CurrentLaneData != IntersectionLaneData)
+	// If we're not on our intersection lane yet, ...
+	if (CurrentLaneData.LaneHandle != IntersectionLaneData.LaneHandle)
 	{
 		const bool bVehicleIsNearStopLineAtIntersection = IsVehicleNearStopLine(
 			LaneLocationFragment.DistanceAlongLane,
-			CurrentLaneData->Length,
+			CurrentLaneData.Length,
 			RadiusFragment.Radius,
 			RandomFractionFragment.RandomFraction.GetFloat(),
 			MassTrafficSettings->StoppingDistanceRange);
 
-		// If our intersection lane has a stop sign requirement, ...
-		if (IntersectionLaneData->HasTrafficSignThatRequiresStopAtLaneStart())
+		// And, our intersection lane has a stop sign requirement, ...
+		if (IntersectionLaneData.HasTrafficSignThatRequiresStopAtLaneStart())
 		{
+			const bool bVehicleHasCompletedItsStopSignRestBehavior = VehicleControlFragment.StopSignIntersectionLane != nullptr
+					? VehicleControlFragment.StopSignIntersectionLane->LaneHandle == IntersectionLaneData.LaneHandle
+					: false;
+			
 			// If we're not near the stop line, or we are, but we haven't completed our stop sign rest behavior, ...
-			if (!bVehicleIsNearStopLineAtIntersection || VehicleControlFragment.StopSignIntersectionLane != IntersectionLaneData)
+			if (!bVehicleIsNearStopLineAtIntersection || !bVehicleHasCompletedItsStopSignRestBehavior)
 			{
 				// We should consider the crosswalk lane to be clear from our perspective.
 				return true;
 			}
 		}
-		else
+		// Or, if we have a yield sign, but no pedestrians around, and therefore no reason to yield at the sign, ...
+		else if (IntersectionLaneData.HasYieldSignAtLaneStart())
 		{
-			// If we have a yield sign, but no pedestrians around, and therefore no reason to yield at the sign, ...
-			if (IntersectionLaneData->HasYieldSignAtLaneStart())
+			// Then, we only need to wait until we're near the stop line,
+			// before we should consider yielding to the crosswalk lanes.
+			if (!bVehicleIsNearStopLineAtIntersection)
 			{
-				// Then, we only need to wait until we're near the stop line,
-				// before we should consider yielding to the crosswalk lanes.
-				if (!bVehicleIsNearStopLineAtIntersection)
-				{
-					// Until then, we should consider the crosswalk lanes to be clear from our perspective.
-					return true;
-				}
+				// Until then, we should consider the crosswalk lanes to be clear from our perspective.
+				return true;
+			}
+		}
+		// Or, if we have a traffic light, ...
+		else if (IntersectionLaneData.HasTrafficLightAtLaneStart())
+		{
+			// Then, we need to wait until we're near the stop line,
+			// and for our lane to be open, before we should consider yielding to the crosswalk lanes.
+			if (!bVehicleIsNearStopLineAtIntersection || !IntersectionLaneData.bIsOpen)
+			{
+				// Until then, we should consider the crosswalk lanes to be clear from our perspective.
+				return true;
 			}
 		}
 	}
 
-	// If our lane doesn't have a stop sign or yield sign, ...
-	if (!IntersectionLaneData->HasStopSignOrYieldSignAtLaneStart())
+	// If our lane doesn't have a stop sign, yield sign, or traffic light, ...
+	if (!IntersectionLaneData.HasStopSignOrYieldSignAtLaneStart() && !IntersectionLaneData.HasTrafficLightAtLaneStart())
 	{
 		// We just say the crosswalk lane is clear from our perspective
 		// if we won't enter the lane until after some specified horizon time.
@@ -947,7 +947,7 @@ bool IsDownstreamCrosswalkLaneClear(
 				*MassTrafficSettings,
 				ZoneGraphStorage,
 				TestDownstreamCrosswalkLane,
-				IntersectionLaneData->LaneHandle,
+				IntersectionLaneData.LaneHandle,
 				CrowdTrackingLaneData->LeadEntityDistanceAlongLane.GetValue(),
 				CrowdTrackingLaneData->LeadEntitySpeedAlongLane.GetValue(),
 				CrowdTrackingLaneData->LeadEntityRadius.GetValue(),
@@ -979,7 +979,7 @@ bool IsDownstreamCrosswalkLaneClear(
 				*MassTrafficSettings,
 				ZoneGraphStorage,
 				TestDownstreamCrosswalkLane,
-				IntersectionLaneData->LaneHandle,
+				IntersectionLaneData.LaneHandle,
 				CrowdTrackingLaneData->TailEntityDistanceAlongLane.GetValue(),
 				CrowdTrackingLaneData->TailEntitySpeedAlongLane.GetValue(),
 				CrowdTrackingLaneData->TailEntityRadius.GetValue(),
@@ -1010,39 +1010,40 @@ bool IsDownstreamCrosswalkLaneClear(
 	// since we're missing the necessary information to safely navigate past them before that.
 	if (!TryGetPedestrianEnterAndExitInfo(PedestrianEnterTime, PedestrianExitTime, PedestrianEnterDistance, PedestrianExitDistance))
 	{
-		return false;
-	}
-
-	// If we can't get the crosswalk lane width,
-	// we need to wait until they completely clear the crosswalk lane before proceeding
-	// since we're missing the necessary information to safely navigate past them before that.
-	float TestDownstreamCrosswalkLaneWidth;
-	if (!UE::ZoneGraph::Query::GetLaneWidth(ZoneGraphStorage, TestDownstreamCrosswalkLane, TestDownstreamCrosswalkLaneWidth))
-	{
-		return false;
+		// Even though there are Entities on the lane,
+		// we still say the lane is clear since we can't determine
+		// to which Entity we might yield.
+		// The yield deadlock resolution processor requires us to know
+		// both the lane and Entity to which we're yielding.
+		return true;
 	}
 
 	const bool bPedestrianIsInVehicleLane = PedestrianEnterDistance <= 0.0f && PedestrianExitDistance > 0.0f;
+	const bool bVehicleIsInCrosswalkLane = VehicleEnterDistance <= 0.0f && VehicleExitDistance > 0.0f;
 
 	const bool bInTimeConflictWithPedestrian = (VehicleExitTime >= 0.0f && PedestrianExitTime >= 0.0f)
 		&& (VehicleEnterTime < TNumericLimits<float>::Max() && PedestrianEnterTime < TNumericLimits<float>::Max())
 		&& VehicleEnterTime < PedestrianExitTime + MassTrafficSettings->VehicleCrosswalkYieldTimeBuffer && PedestrianEnterTime < VehicleExitTime + MassTrafficSettings->VehicleCrosswalkYieldTimeBuffer;
 
-	// In basic terms, we want to say that we're in "distance conflict" with a pedestrian,
+	// We say that we're in "distance conflict" with a pedestrian,
 	// if the pedestrian is in our lane, and we're "relatively close",
-	// but not if we've already entered the crosswalk lane.
-	// However, we need the vehicle to still recognize the "distance conflict" even if it
-	// has somewhat entered the crosswalk lane.  This will prevent vehicles,
-	// which have "crept" into the crosswalk, while waiting for an opportunity to merge,
-	// from running-over pedestrians, which may have crossed in front of the vehicle, during this time.
-	// So, we allow a vehicle to go "half-way" into a crosswalk lane before completely ignoring any pedestrians
-	// that may be in the vehicle lane.  If pedestrians are already there, the vehicle will yield.
+	// and our rear bumper hasn't exited the crosswalk lane yet.
+	//
+	// This allows the vehicle to "creep" into the crosswalk lane, while waiting for an opportunity to merge,
+	// while still considering the vehicle to be in "distance conflict" with the pedestrian.
+	//
+	// Basing it on the rear bumper's exit avoids running into tolerance issues,
+	// relative to how far the front bumper might be allowed to enter the crosswalk lane,
+	// before we're no longer in "distance conflict".
+	//
+	// If pedestrians are already in the vehicle lane, the vehicle will yield.
 	// And, if pedestrians walk towards the vehicle's lane, they will yield to the vehicle before entering,
-	// if the vehicle is "far enough" into the crosswalk lane.
-	const bool bInDistanceConflictWithPedestrian = bPedestrianIsInVehicleLane && VehicleEnterDistance < MassTrafficSettings->VehiclePedestrianBufferDistanceOnCrosswalk && VehicleEnterDistance > -TestDownstreamCrosswalkLaneWidth * 0.5f;
+	// if the vehicle has entered the crosswalk lane.
+	const bool bInDistanceConflictWithPedestrian = bPedestrianIsInVehicleLane && VehicleEnterDistance < MassTrafficSettings->VehiclePedestrianBufferDistanceOnCrosswalk && VehicleExitDistance > 0.0f;
 
-	if (bInTimeConflictWithPedestrian || bInDistanceConflictWithPedestrian)
+	if ((bInTimeConflictWithPedestrian && !bVehicleIsInCrosswalkLane) || bInDistanceConflictWithPedestrian)
 	{
+		OutYieldTargetEntity = CrowdTrackingLaneData->TailEntityHandle.GetValue();
 		return false;
 	}
 
@@ -1052,7 +1053,7 @@ bool IsDownstreamCrosswalkLaneClear(
 bool ShouldYieldToCrosswalks_Internal(
 	const UMassTrafficSubsystem& MassTrafficSubsystem,
 	const UMassCrowdSubsystem& MassCrowdSubsystem,
-	const FZoneGraphTrafficLaneData* CurrentLaneData,
+	const FZoneGraphTrafficLaneData& CurrentLaneData,
 	const FZoneGraphTrafficLaneData* IntersectionLaneData,
 	const FMassTrafficVehicleControlFragment& VehicleControlFragment,
 	const FMassZoneGraphLaneLocationFragment& LaneLocationFragment,
@@ -1060,64 +1061,90 @@ bool ShouldYieldToCrosswalks_Internal(
 	const FAgentRadiusFragment& RadiusFragment,
 	const FZoneGraphStorage& ZoneGraphStorage,
 	const UMassTrafficSettings* MassTrafficSettings,
-	FZoneGraphLaneHandle& OutYieldTargetLane)
+	FZoneGraphLaneHandle& OutYieldTargetLane,
+	FMassEntityHandle& OutYieldTargetEntity)
 {
 	auto ShouldYieldAtDownstreamCrosswalk = [&MassTrafficSubsystem,
 											 &MassCrowdSubsystem,
-											 CurrentLaneData,
-											 IntersectionLaneData,
+											 &CurrentLaneData,
 											 &VehicleControlFragment,
 											 &LaneLocationFragment,
 											 &RandomFractionFragment,
 											 &RadiusFragment,
 											 &ZoneGraphStorage,
 											 MassTrafficSettings,
-											 &OutYieldTargetLane] (const FZoneGraphLaneHandle& DownstreamCrosswalkLane)
+											 &OutYieldTargetLane,
+											 &OutYieldTargetEntity] (const FZoneGraphTrafficLaneData& CrossingVehicleLane, const FZoneGraphLaneHandle& DownstreamCrosswalkLane)
 	{
-		// Skip over any crosswalk lanes, which already have yielding Entities.
-		if (DownstreamCrosswalkLaneHasYieldingEntities(MassTrafficSubsystem, CurrentLaneData, DownstreamCrosswalkLane))
-		{
-			return false;
-		}
+		FMassEntityHandle YieldTargetEntity;
 
 		// We should yield, if any of our downstream crosswalk lanes are not clear.
-		if (!IsDownstreamCrosswalkLaneClear(MassTrafficSubsystem, MassCrowdSubsystem, CurrentLaneData, IntersectionLaneData,
-			VehicleControlFragment, LaneLocationFragment, RandomFractionFragment, RadiusFragment, ZoneGraphStorage, MassTrafficSettings, DownstreamCrosswalkLane))
+		if (!IsDownstreamCrosswalkLaneClear(MassTrafficSubsystem, MassCrowdSubsystem, CurrentLaneData, CrossingVehicleLane,
+			VehicleControlFragment, LaneLocationFragment, RandomFractionFragment, RadiusFragment, ZoneGraphStorage, MassTrafficSettings, DownstreamCrosswalkLane, YieldTargetEntity))
 		{
 			OutYieldTargetLane = DownstreamCrosswalkLane;
+			OutYieldTargetEntity = YieldTargetEntity;
 			return true;
 		}
 
 		return false;
 	};
 
-	// Check all the downstream crosswalk lanes for our current lane.
-	for (const auto& DownstreamCrosswalkLaneInfo : CurrentLaneData->DownstreamCrosswalkLanes)
+	// Should we run our logic for crosswalks on roads?
+	if (!CurrentLaneData.ConstData.bIsIntersectionLane && IntersectionLaneData == nullptr)
 	{
-		const float LaneLengthAtDownstreamCrosswalkLane = DownstreamCrosswalkLaneInfo.Value;
-
-		// Skip crosswalks we've passed already.
-		if (LaneLocationFragment.DistanceAlongLane > LaneLengthAtDownstreamCrosswalkLane)
+		// Check all the downstream crosswalk lanes for our current lane.
+		for (const auto& DownstreamCrosswalkLaneInfo : CurrentLaneData.DownstreamCrosswalkLanes)
 		{
-			continue;
-		}
+			const float LaneLengthAtDownstreamCrosswalkLane = DownstreamCrosswalkLaneInfo.Value;
 
-		if (LaneLocationFragment.DistanceAlongLane < LaneLengthAtDownstreamCrosswalkLane - MassTrafficSettings->CrosswalkReactiveYieldDistanceVehicleLengthScale * RadiusFragment.Radius * 2.0)
-		{
-			continue;
-		}
+			float VehicleCrosswalkLaneEnterTime;
+			float VehicleCrosswalkLaneExitTime;
+			
+			float VehicleCrosswalkLaneEnterDistance;
+			float VehicleCrosswalkLaneExitDistance;
 
-		if (ShouldYieldAtDownstreamCrosswalk(DownstreamCrosswalkLaneInfo.Key))
-		{
-			return true;
+			if (!TryGetVehicleEnterAndExitTimesForCrossingLane(
+				MassTrafficSubsystem,
+				*MassTrafficSettings,
+				ZoneGraphStorage,
+				CurrentLaneData,
+				CurrentLaneData,
+				DownstreamCrosswalkLaneInfo.Key,
+				LaneLocationFragment.DistanceAlongLane,
+				VehicleControlFragment.Speed,
+				RadiusFragment.Radius,
+				VehicleCrosswalkLaneEnterTime,
+				VehicleCrosswalkLaneExitTime,
+				&VehicleCrosswalkLaneEnterDistance,
+				&VehicleCrosswalkLaneExitDistance))
+			{
+				continue;
+			}
+
+			// Skip crosswalks we've passed already.
+            if (VehicleCrosswalkLaneExitDistance <= 0.0f)
+            {
+            	continue;
+            }
+
+			if (LaneLocationFragment.DistanceAlongLane < LaneLengthAtDownstreamCrosswalkLane - MassTrafficSettings->CrosswalkReactiveYieldDistanceVehicleLengthScale * RadiusFragment.Radius * 2.0)
+			{
+				continue;
+			}
+
+			if (ShouldYieldAtDownstreamCrosswalk(CurrentLaneData, DownstreamCrosswalkLaneInfo.Key))
+			{
+				return true;
+			}
 		}
 	}
-
-	if (IntersectionLaneData != CurrentLaneData)
+	// Or, should we run our logic for crosswalks at intersections?
+	else if (IntersectionLaneData != nullptr)
 	{
 		for (const auto& DownstreamCrosswalkLaneInfo : IntersectionLaneData->DownstreamCrosswalkLanes)
 		{
-			if (ShouldYieldAtDownstreamCrosswalk(DownstreamCrosswalkLaneInfo.Key))
+			if (ShouldYieldAtDownstreamCrosswalk(*IntersectionLaneData, DownstreamCrosswalkLaneInfo.Key))
 			{
 				return true;
 			}
@@ -1130,8 +1157,9 @@ bool ShouldYieldToCrosswalks_Internal(
 bool ShouldYieldAtIntersection_Internal(
 	const FZoneGraphTrafficLaneData& CurrentLaneData,
 	const FZoneGraphTrafficLaneData& PrevLaneData,
-	const TFunction<bool(const FZoneGraphTrafficLaneData&)>& IsTestLaneClearFunc,
+	const TFunction<bool(const FZoneGraphTrafficLaneData&, FMassEntityHandle&)>& IsTestLaneClearFunc,
 	FZoneGraphLaneHandle& OutYieldTargetLane,
+	FMassEntityHandle& OutYieldTargetEntity,
 	const bool bConsiderYieldForGoingStraight = true,
 	const bool bConsiderYieldForLeftTurns = true,
 	const bool bConsiderYieldForRightTurns = true)
@@ -1166,7 +1194,7 @@ bool ShouldYieldAtIntersection_Internal(
 					}
 					
 					// But, for the remaining lanes, we should yield, if they are not clear.
-					if (!IsTestLaneClearFunc(*NextLeftLane))
+					if (!IsTestLaneClearFunc(*NextLeftLane, OutYieldTargetEntity))
 					{
 						OutYieldTargetLane = NextLeftLane->LaneHandle;
 						return true;
@@ -1199,7 +1227,7 @@ bool ShouldYieldAtIntersection_Internal(
 					}
 					
 					// But, for the remaining lanes, we should yield, if they are not clear.
-					if (!IsTestLaneClearFunc(*NextRightLane))
+					if (!IsTestLaneClearFunc(*NextRightLane, OutYieldTargetEntity))
 					{
 						OutYieldTargetLane = NextRightLane->LaneHandle;
 						return true;
@@ -1232,7 +1260,7 @@ bool ShouldYieldAtIntersection_Internal(
 					}
 					
 					// But, for the remaining lanes, we should yield, if they are not clear.
-					if (!IsTestLaneClearFunc(*NextLeftLane))
+					if (!IsTestLaneClearFunc(*NextLeftLane, OutYieldTargetEntity))
 					{
 						OutYieldTargetLane = NextLeftLane->LaneHandle;
 						return true;
@@ -1262,7 +1290,7 @@ bool ShouldYieldAtIntersection_Internal(
 					}
 					
 					// But, for the remaining lanes, we should yield, if they are not clear.
-					if (!IsTestLaneClearFunc(*NextRightLane))
+					if (!IsTestLaneClearFunc(*NextRightLane, OutYieldTargetEntity))
 					{
 						OutYieldTargetLane = NextRightLane->LaneHandle;
 						return true;
@@ -1286,6 +1314,7 @@ bool ShouldPerformReactiveYieldAtIntersection(
 	const FZoneGraphStorage& ZoneGraphStorage,
 	bool& OutShouldGiveOpportunityForTurningVehiclesToReactivelyYieldAtIntersection,
 	FZoneGraphLaneHandle& OutYieldTargetLane,
+	FMassEntityHandle& OutYieldTargetEntity,
 	int32& OutMergeYieldCaseIndex)
 {
 	const UMassTrafficSettings* MassTrafficSettings = GetDefault<UMassTrafficSettings>();
@@ -1366,7 +1395,7 @@ bool ShouldPerformReactiveYieldAtIntersection(
 		return false;
 	}
 
-	const auto& IsTestLaneClear = [&EntityManager, &CurrentLaneData, &LaneLocationFragment, &RadiusFragment, MassTrafficSettings](const FZoneGraphTrafficLaneData& TestLane)
+	const auto& IsTestLaneClear = [&MassTrafficSubsystem, &EntityManager, &CurrentLaneData, &VehicleControlFragment, &LaneLocationFragment, &RadiusFragment, MassTrafficSettings](const FZoneGraphTrafficLaneData& TestLane, FMassEntityHandle& OutYieldTargetEntity)
 	{
 		if (!ensureMsgf(CurrentLaneData->Length > 0.0f && LaneLocationFragment.LaneLength > 0.0f, TEXT("CurrentLane should have a length greater than zero.")))
 		{
@@ -1374,8 +1403,18 @@ bool ShouldPerformReactiveYieldAtIntersection(
 			return true;
 		}
 		
-		if (TestLane.NumVehiclesOnLane > 0)
+		if (TestLane.NumVehiclesOnLane > 0 && TestLane.TailVehicle.IsValid())
 		{
+			// Skip processing our yield logic if we have a yield override for this Lane-Entity Pair.
+			// This mechanism is used to prevent yield cycle deadlocks.
+			if (MassTrafficSubsystem.HasYieldOverride(
+				LaneLocationFragment.LaneHandle, VehicleControlFragment.VehicleEntityHandle,
+				TestLane.LaneHandle, TestLane.TailVehicle))
+			{
+				// Just say the lane is clear.
+				return true;
+			}
+			
 			const auto& TryGetNormalizedDistanceAlongTestLane = [&EntityManager, &TestLane](float& OutNormalizedDistanceAlongTestLane)
 			{
 				float DistanceAlongTestLane = 0.0f;
@@ -1420,6 +1459,7 @@ bool ShouldPerformReactiveYieldAtIntersection(
 
 			if (NormalizedDistanceAlongCurrentLane < NormalizedYieldCutoffLaneDistance && NormalizedDistanceAlongTestLane < NormalizedYieldResumeLaneDistance)
 			{
+				OutYieldTargetEntity = TestLane.TailVehicle;
 				return false;
 			}
 		}
@@ -1427,13 +1467,18 @@ bool ShouldPerformReactiveYieldAtIntersection(
 		return true;
 	};
 
-	// If our yield behavior is being overriden, don't yield.  A deadlock is being prevented.
-	if (MassTrafficSubsystem.IsEntityInLaneYieldOverrideMap(CurrentLaneData->LaneHandle, VehicleControlFragment.VehicleEntityHandle))
-	{
-		return false;
-	}
-
 	FZoneGraphLaneHandle YieldTargetLane;
+	FMassEntityHandle YieldTargetEntity;
+
+	const bool bShouldYieldToCrosswalks = ShouldYieldToCrosswalks_Internal(MassTrafficSubsystem, MassCrowdSubsystem, *CurrentLaneData, IntersectionLaneData,
+		VehicleControlFragment, LaneLocationFragment, RandomFractionFragment, RadiusFragment, ZoneGraphStorage, MassTrafficSettings, YieldTargetLane, YieldTargetEntity);
+
+	if (bShouldYieldToCrosswalks)
+	{
+		OutYieldTargetLane = YieldTargetLane;
+		OutYieldTargetEntity = YieldTargetEntity;
+		return true;
+	}
 
 	// Only yield in response to merge conditions, if we are eligible to attempt a merge in the first place.
 	if (IsVehicleEligibleToMergeOntoLane(
@@ -1458,32 +1503,19 @@ bool ShouldPerformReactiveYieldAtIntersection(
 			MassTrafficSettings->StoppingDistanceRange,
 			ZoneGraphStorage,
 			YieldTargetLane,
+			YieldTargetEntity,
 			OutMergeYieldCaseIndex
 			);
 
 		if (bShouldYieldToMergeConflict)
 		{
 			OutYieldTargetLane = YieldTargetLane;
+			OutYieldTargetEntity = YieldTargetEntity;
 			return true;
 		}
 	}
-
-	const bool bHasRemainingDownstreamCrosswalkLanes = !CurrentLaneData->DownstreamCrosswalkLanes.FilterByPredicate([DistanceAlongLane=LaneLocationFragment.DistanceAlongLane](const auto& DownstreamCrosswalkLaneInfo)
-	{
-		return DownstreamCrosswalkLaneInfo.Value > DistanceAlongLane;
-	}).IsEmpty();
-
-	const bool bShouldYieldToCrosswalks = ShouldYieldToCrosswalks_Internal(MassTrafficSubsystem, MassCrowdSubsystem, CurrentLaneData,
-		bHasRemainingDownstreamCrosswalkLanes ? CurrentLaneData : IntersectionLaneData,
-		VehicleControlFragment, LaneLocationFragment, RandomFractionFragment, RadiusFragment, ZoneGraphStorage, MassTrafficSettings, YieldTargetLane);
-
-	if (bShouldYieldToCrosswalks)
-	{
-		OutYieldTargetLane = YieldTargetLane;
-		return true;
-	}
 	
-	const bool bShouldReactivelyYieldAtIntersection = ShouldYieldAtIntersection_Internal(*CurrentLaneData, *PrevLaneData, IsTestLaneClear, YieldTargetLane);
+	const bool bShouldReactivelyYieldAtIntersection = ShouldYieldAtIntersection_Internal(*CurrentLaneData, *PrevLaneData, IsTestLaneClear, YieldTargetLane, YieldTargetEntity);
 
 	// If we haven't started reactively yielding, ...
 	if (!VehicleControlFragment.IsReactivelyYieldingAtIntersection())
@@ -1503,6 +1535,7 @@ bool ShouldPerformReactiveYieldAtIntersection(
 	if (bShouldReactivelyYieldAtIntersection)
 	{
 		OutYieldTargetLane = YieldTargetLane;
+		OutYieldTargetEntity = YieldTargetEntity;
 		return true;
 	}
 
@@ -1518,7 +1551,8 @@ bool ShouldPerformReactiveYieldAtRoadCrosswalk(
 	const FAgentRadiusFragment& RadiusFragment,
 	const FMassTrafficRandomFractionFragment& RandomFractionFragment,
 	const FZoneGraphStorage& ZoneGraphStorage,
-	FZoneGraphLaneHandle& OutYieldTargetLane)
+	FZoneGraphLaneHandle& OutYieldTargetLane,
+	FMassEntityHandle& OutYieldTargetEntity)
 {
 	const UMassTrafficSettings* MassTrafficSettings = GetDefault<UMassTrafficSettings>();
 	if (!ensureMsgf(MassTrafficSettings != nullptr, TEXT("Can't access MassTrafficSettings in ShouldPerformReactiveYieldAtIntersection.  Yield behavior disabled.")))
@@ -1533,11 +1567,13 @@ bool ShouldPerformReactiveYieldAtRoadCrosswalk(
 	}
 
 	FZoneGraphLaneHandle YieldTargetLane;
+	FMassEntityHandle YieldTargetEntity;
 
-	if (ShouldYieldToCrosswalks_Internal(MassTrafficSubsystem, MassCrowdSubsystem, CurrentLaneData, CurrentLaneData,
-		VehicleControlFragment, LaneLocationFragment, RandomFractionFragment, RadiusFragment, ZoneGraphStorage, MassTrafficSettings, YieldTargetLane))
+	if (ShouldYieldToCrosswalks_Internal(MassTrafficSubsystem, MassCrowdSubsystem, *CurrentLaneData, nullptr,
+		VehicleControlFragment, LaneLocationFragment, RandomFractionFragment, RadiusFragment, ZoneGraphStorage, MassTrafficSettings, YieldTargetLane, YieldTargetEntity))
 	{
 		OutYieldTargetLane = YieldTargetLane;
+		OutYieldTargetEntity = YieldTargetEntity;
 		return true;
 	}
 

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficMovement.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficMovement.cpp
@@ -556,7 +556,7 @@ bool ShouldVehicleMergeOntoLane(
 			// We don't have any info about vehicles on this lane.
 			// So, we don't need to yield.
 			//
-			// Note:  Due to where NumVehiclesOnLane gets updated in the frame,
+			// Note:  Due to where a lane's NumVehiclesOnLane field gets updated in the frame,
 			// relative to where CoreVehicleInfos gets updated in the frame,
 			// NumVehiclesOnLane might be greater than 0 for this lane,
 			// while CoreVehicleInfos is empty.

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficUtils.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficUtils.cpp
@@ -355,6 +355,35 @@ int32 GetLanePriority(
 	return INDEX_NONE;
 }
 
+void DrawLaneData(
+	const UZoneGraphSubsystem& ZoneGraphSubsystem,
+	const FZoneGraphLaneHandle& LaneHandle,
+	const FColor LaneColor,
+	const UWorld& World,
+	const float ZOffset,
+	const float LifeTime)
+{
+	if (!LaneHandle.IsValid())
+	{
+		return;
+	}
+
+	if (const FZoneGraphStorage* ZoneGraphStorage = ZoneGraphSubsystem.GetZoneGraphStorage(LaneHandle.DataHandle))
+	{
+		const FZoneLaneData& ZoneLaneData = ZoneGraphStorage->Lanes[LaneHandle.Index];
+
+		for (int32 LanePointIndex = ZoneLaneData.PointsBegin; LanePointIndex < ZoneLaneData.PointsEnd - 1; ++LanePointIndex)
+		{
+			const FVector& LaneSegmentStart = ZoneGraphStorage->LanePoints[LanePointIndex] + FVector(0.0f, 0.0f, ZOffset);
+			const FVector& LaneSegmentEnd = ZoneGraphStorage->LanePoints[LanePointIndex + 1] + FVector(0.0f, 0.0f, ZOffset);
+
+			const float ArrowSize = LanePointIndex == ZoneLaneData.PointsEnd - 2 ? 10000.0f : 1000.0f;
+
+			DrawDebugDirectionalArrow(&World, LaneSegmentStart, LaneSegmentEnd, ArrowSize, LaneColor, false, LifeTime, 0, 10.0f);
+		}
+	}
+};
+
 bool TryGetVehicleEnterAndExitTimesForIntersection(
 	const FZoneGraphTrafficLaneData& VehicleCurrentLaneData,
 	const FZoneGraphTrafficLaneData& IntersectionLaneData,

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleControlProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleControlProcessor.cpp
@@ -216,9 +216,10 @@ namespace
 	void ProcessYieldAtRoadCrosswalkLogic(UMassTrafficSubsystem& MassTrafficSubsystem, const UMassCrowdSubsystem& MassCrowdSubsystem, const FMassEntityManager& EntityManager, FMassTrafficVehicleControlFragment& VehicleControlFragment, const FMassZoneGraphLaneLocationFragment& LaneLocationFragment, const FAgentRadiusFragment& RadiusFragment, const FMassTrafficRandomFractionFragment& RandomFractionFragment, const FZoneGraphStorage& ZoneGraphStorage, TFunction<void()> PerformYieldActionFunc)
 	{
 		FZoneGraphLaneHandle YieldTargetLane;
-		const bool bShouldReactivelyYieldAtRoadCrosswalk = UE::MassTraffic::ShouldPerformReactiveYieldAtRoadCrosswalk(MassTrafficSubsystem, MassCrowdSubsystem, EntityManager, VehicleControlFragment, LaneLocationFragment, RadiusFragment, RandomFractionFragment, ZoneGraphStorage, YieldTargetLane);
+		FMassEntityHandle YieldTargetEntity;
+		const bool bShouldReactivelyYieldAtRoadCrosswalk = UE::MassTraffic::ShouldPerformReactiveYieldAtRoadCrosswalk(MassTrafficSubsystem, MassCrowdSubsystem, EntityManager, VehicleControlFragment, LaneLocationFragment, RadiusFragment, RandomFractionFragment, ZoneGraphStorage, YieldTargetLane, YieldTargetEntity);
 
-		UE::MassTraffic::UpdateYieldAtIntersectionState(MassTrafficSubsystem, VehicleControlFragment, LaneLocationFragment.LaneHandle, YieldTargetLane, bShouldReactivelyYieldAtRoadCrosswalk, false);
+		UE::MassTraffic::UpdateYieldAtIntersectionState(MassTrafficSubsystem, VehicleControlFragment, LaneLocationFragment.LaneHandle, YieldTargetLane, YieldTargetEntity, bShouldReactivelyYieldAtRoadCrosswalk, false);
 
 		// If we're reactively yielding, then we should always perform our yield action.
 		if (bShouldReactivelyYieldAtRoadCrosswalk)
@@ -236,10 +237,11 @@ namespace
 	{
 		bool bShouldGiveOpportunityForTurningVehiclesToReactivelyYieldAtIntersection = false;
 		FZoneGraphLaneHandle YieldTargetLane;
+		FMassEntityHandle YieldTargetEntity;
 		int32 MergeYieldCaseIndex = INDEX_NONE;
-		const bool bShouldReactivelyYieldAtIntersection = UE::MassTraffic::ShouldPerformReactiveYieldAtIntersection(MassTrafficSubsystem, MassCrowdSubsystem, EntityManager, VehicleControlFragment, LaneLocationFragment, RadiusFragment, RandomFractionFragment, ZoneGraphStorage, bShouldGiveOpportunityForTurningVehiclesToReactivelyYieldAtIntersection, YieldTargetLane, MergeYieldCaseIndex);
+		const bool bShouldReactivelyYieldAtIntersection = UE::MassTraffic::ShouldPerformReactiveYieldAtIntersection(MassTrafficSubsystem, MassCrowdSubsystem, EntityManager, VehicleControlFragment, LaneLocationFragment, RadiusFragment, RandomFractionFragment, ZoneGraphStorage, bShouldGiveOpportunityForTurningVehiclesToReactivelyYieldAtIntersection, YieldTargetLane, YieldTargetEntity, MergeYieldCaseIndex);
 
-		UE::MassTraffic::UpdateYieldAtIntersectionState(MassTrafficSubsystem, VehicleControlFragment, LaneLocationFragment.LaneHandle, YieldTargetLane, bShouldReactivelyYieldAtIntersection, bShouldGiveOpportunityForTurningVehiclesToReactivelyYieldAtIntersection);
+		UE::MassTraffic::UpdateYieldAtIntersectionState(MassTrafficSubsystem, VehicleControlFragment, LaneLocationFragment.LaneHandle, YieldTargetLane, YieldTargetEntity, bShouldReactivelyYieldAtIntersection, bShouldGiveOpportunityForTurningVehiclesToReactivelyYieldAtIntersection);
 
 		// If we're reactively yielding, then we should always perform our yield action.
 		if (bShouldReactivelyYieldAtIntersection)
@@ -607,11 +609,14 @@ void UMassTrafficVehicleControlProcessor::SimpleVehicleControl(
 		#endif
 	);
 
+	const float VariedAcceleration = MassTrafficSettings->Acceleration * (1.0f + MassTrafficSettings->AccelerationVariancePct * (RandomFractionFragment.RandomFraction * 2.0f - 1.0f));
+	VehicleControlFragment.AccelerationEstimate = VariedAcceleration;
+
 	const auto& PerformYieldAction = [&TargetSpeed]()
 	{
 		TargetSpeed = 0.0f;
 	};
-
+	
 	if (CurrentLaneData->HasYieldSignAlongRoad(LaneLocationFragment.DistanceAlongLane) && !CurrentLaneData->ConstData.bIsIntersectionLane)
 	{
 		ProcessYieldAtRoadCrosswalkLogic(MassTrafficSubsystem, MassCrowdSubsystem, EntityManager, VehicleControlFragment, LaneLocationFragment, AgentRadiusFragment, RandomFractionFragment, ZoneGraphStorage, PerformYieldAction);
@@ -620,9 +625,6 @@ void UMassTrafficVehicleControlProcessor::SimpleVehicleControl(
 	{
 		ProcessYieldAtIntersectionLogic(MassTrafficSubsystem, MassCrowdSubsystem, EntityManager, VehicleControlFragment, LaneLocationFragment, AgentRadiusFragment, RandomFractionFragment, ZoneGraphStorage, PerformYieldAction);
 	}
-
-	const float VariedAcceleration = MassTrafficSettings->Acceleration * (1.0f + MassTrafficSettings->AccelerationVariancePct * (RandomFractionFragment.RandomFraction * 2.0f - 1.0f));
-	VehicleControlFragment.AccelerationEstimate = VariedAcceleration;
 
 	// (See all READYLANE.)
 	SetIsVehicleReadyToUseNextIntersectionLane(VehicleControlFragment, LaneLocationFragment, AgentRadiusFragment, RandomFractionFragment, *MassTrafficSettings, bShouldProceedAtStopSign, bVehicleHasNoRoom);
@@ -751,7 +753,7 @@ void UMassTrafficVehicleControlProcessor::SimpleVehicleControl(
 			LaneLocationFragment.DistanceAlongLane = LaneLocationFragment.LaneLength;
 		}
 	}
-	
+
 	// Debug speed
 	UE::MassTraffic::DrawDebugSpeed(
 		GetWorld(),
@@ -972,6 +974,9 @@ void UMassTrafficVehicleControlProcessor::PIDVehicleControl(
 		#endif
 	);
 
+	const float VariedAcceleration = MassTrafficSettings->Acceleration * (1.0f + MassTrafficSettings->AccelerationVariancePct * (RandomFractionFragment.RandomFraction * 2.0f - 1.0f));
+	VehicleControlFragment.AccelerationEstimate = VariedAcceleration;
+
 	const auto& PerformYieldAction = [&TargetSpeed]()
 	{
 		TargetSpeed = 0.0f;
@@ -985,9 +990,6 @@ void UMassTrafficVehicleControlProcessor::PIDVehicleControl(
 	{
 		ProcessYieldAtIntersectionLogic(MassTrafficSubsystem, MassCrowdSubsystem, EntityManager, VehicleControlFragment, LaneLocationFragment, AgentRadiusFragment, RandomFractionFragment, ZoneGraphStorage, PerformYieldAction);
 	}
-
-	const float VariedAcceleration = MassTrafficSettings->Acceleration * (1.0f + MassTrafficSettings->AccelerationVariancePct * (RandomFractionFragment.RandomFraction * 2.0f - 1.0f));
-	VehicleControlFragment.AccelerationEstimate = VariedAcceleration;
 
 	// (See all READYLANE.)
 	SetIsVehicleReadyToUseNextIntersectionLane(VehicleControlFragment, LaneLocationFragment, AgentRadiusFragment, RandomFractionFragment, *MassTrafficSettings, bShouldProceedAtStopSign, bVehicleHasNoRoom);

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficYieldDeadlockProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficYieldDeadlockProcessor.cpp
@@ -8,17 +8,18 @@
 #include "MassExecutionContext.h"
 #include "MassZoneGraphNavigationFragments.h"
 #include "MassTrafficLaneChange.h"
+#include "Async/Async.h"
 #include "MassGameplayExternalTraits.h"
 
 namespace
 {
 	struct DFSStackFrame
 	{
-		FZoneGraphLaneHandle Node;
-		TArray<FZoneGraphLaneHandle> Neighbors;
+		FYieldCycleNode Node;
+		TArray<FYieldCycleNode> Neighbors;
 		int32 NextIndex;
 
-		DFSStackFrame(const FZoneGraphLaneHandle& InNode, const TArray<FZoneGraphLaneHandle>& InNeighbors)
+		DFSStackFrame(const FYieldCycleNode& InNode, const TArray<FYieldCycleNode>& InNeighbors)
 			: Node(InNode)
 			, Neighbors(InNeighbors)
 			, NextIndex(0)
@@ -26,27 +27,28 @@ namespace
 		}
 	};
 	
-	TArray<FZoneGraphLaneHandle> FindFirstCycleDFS(
-	const TMap<FZoneGraphLaneHandle, TSet<FZoneGraphLaneHandle>>& LaneYieldMap,
-	const FZoneGraphLaneHandle& StartLane)
+	TArray<FYieldCycleNode> FindFirstCycleDFS(
+		const TMap<FLaneEntityPair, TSet<FLaneEntityPair>>& YieldMap,
+		const FYieldCycleNode& StartNode,
+		const TFunction<TOptional<FLaneEntityPair>(const FLaneEntityPair&)>& GetImplicitNeighbor)
 	{
 		TArray<DFSStackFrame> Stack;
-		TArray<FZoneGraphLaneHandle> CurrentPath;
-		TSet<FZoneGraphLaneHandle> CurrentPathSet;
+		TArray<FYieldCycleNode> CurrentPath;
+		TSet<FYieldCycleNode> CurrentPathSet;
 
-		TArray<FZoneGraphLaneHandle> StartNodeNeighbors;
-		if (const TSet<FZoneGraphLaneHandle>* Neighbors = LaneYieldMap.Find(StartLane))
+		TArray<FYieldCycleNode> StartNodeNeighbors;
+		if (const TSet<FLaneEntityPair>* Neighbors = YieldMap.Find(StartNode.LaneEntityPair))
 		{
-			for (const FZoneGraphLaneHandle& Neighbor : *Neighbors)
+			for (const FLaneEntityPair& Neighbor : *Neighbors)
 			{
 				StartNodeNeighbors.Add(Neighbor);
 			}
 		}
 
-		// The search starts from the StartLane.
-		Stack.Add(DFSStackFrame(StartLane, StartNodeNeighbors));
-		CurrentPath.Add(StartLane);
-		CurrentPathSet.Add(StartLane);
+		// The search starts from the StartNode.
+		Stack.Add(DFSStackFrame(StartNode, StartNodeNeighbors));
+		CurrentPath.Add(StartNode);
+		CurrentPathSet.Add(StartNode);
 
 		while (Stack.Num() > 0)
 		{
@@ -54,24 +56,34 @@ namespace
 
 			if (TopFrame.NextIndex < TopFrame.Neighbors.Num())
 			{
-				FZoneGraphLaneHandle& Neighbor = TopFrame.Neighbors[TopFrame.NextIndex];
+				FYieldCycleNode& Neighbor = TopFrame.Neighbors[TopFrame.NextIndex];
 				TopFrame.NextIndex++;
 
 				// If we found our goal, return the cycle.
-				if (Neighbor == StartLane)
+				if (Neighbor == StartNode)
 				{
-					CurrentPath.Add(StartLane);
+					// Add neighbor to complete the path as it might
+					// represent an implicit edge from the previous node.
+					CurrentPath.Add(Neighbor);
 					return CurrentPath;
 				}
 				else if (!CurrentPathSet.Contains(Neighbor))
 				{
-					TArray<FZoneGraphLaneHandle> NeighborNeighborsArray;
-					if (const TSet<FZoneGraphLaneHandle>* NeighborNeighbors = LaneYieldMap.Find(Neighbor))
+					TArray<FYieldCycleNode> NeighborNeighborsArray;
+					if (const TSet<FLaneEntityPair>* NeighborNeighbors = YieldMap.Find(Neighbor.LaneEntityPair))
 					{
-						for (const FZoneGraphLaneHandle& NeighborNeighbor : *NeighborNeighbors)
+						for (const FLaneEntityPair& NeighborNeighbor : *NeighborNeighbors)
 						{
 							NeighborNeighborsArray.Add(NeighborNeighbor);
 						}
+					}
+					
+					if (const TOptional<FLaneEntityPair> ImplicitNeighbor = GetImplicitNeighbor(Neighbor.LaneEntityPair); ImplicitNeighbor.IsSet())
+					{
+						FYieldCycleNode ImplicitNeighborNode = ImplicitNeighbor.GetValue();
+						ImplicitNeighborNode.bHasImplicitYieldFromPrevNode = true;
+						
+						NeighborNeighborsArray.Add(ImplicitNeighborNode);
 					}
 
 					// Push neighbor onto stack. 
@@ -90,7 +102,7 @@ namespace
 		}
 
 		// No cycle found.
-		return TArray<FZoneGraphLaneHandle>();
+		return TArray<FYieldCycleNode>();
 	}
 }
 
@@ -185,181 +197,47 @@ void UMassTrafficYieldDeadlockResolutionProcessor::Execute(FMassEntityManager& E
 	});
 
 	// First, clean-up any stale yield overrides before potentially adding any new ones.
-	{
-		TMap<FZoneGraphLaneHandle, TSet<FMassEntityHandle>>& LaneYieldOverrideMap = MassTrafficSubsystem.GetMutableLaneYieldOverrideMap();
-		
-		for (auto LaneYieldOverrideMapItr = LaneYieldOverrideMap.CreateIterator(); LaneYieldOverrideMapItr; ++LaneYieldOverrideMapItr)
-		{
-			const FZoneGraphLaneHandle& YieldOverrideLane = LaneYieldOverrideMapItr.Key();
-			TSet<FMassEntityHandle>& YieldOverrideEntities = LaneYieldOverrideMapItr.Value();
+	CleanupStaleYieldOverrides(MassTrafficSubsystem, EntityManager);
 
-			for (auto YieldOverrideEntityItr = YieldOverrideEntities.CreateIterator(); YieldOverrideEntityItr; ++YieldOverrideEntityItr)
-			{
-				const FMassEntityHandle& YieldOverrideEntity = *YieldOverrideEntityItr;
-				FMassEntityView YieldOverrideCandidateEntityView(EntityManager, YieldOverrideEntity);
-				const FMassZoneGraphLaneLocationFragment& LaneLocationFragment = YieldOverrideCandidateEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
-
-				// If this Entity is on a new lane since it was granted a yield override, ...
-				if (LaneLocationFragment.LaneHandle != YieldOverrideLane)
-				{
-					YieldOverrideEntityItr.RemoveCurrent();
-				}
-			}
-
-			if (YieldOverrideEntities.IsEmpty())
-			{
-				LaneYieldOverrideMapItr.RemoveCurrent();
-			}
-		}
-	}
-
-	const auto& DrawDebugIndicatorsForEntities = [&ZoneGraphSubsystem, &EntityManager, &PedestrianEntities, this](const TArray<FZoneGraphLaneHandle>& SourceLanes, const TMap<FZoneGraphLaneHandle, TSet<FMassEntityHandle>>& EntitiesMap, const FVector& IndicatorOffset, const FColor& PedestrianColor, const FColor& VehicleColor, const float LifeTime)
-	{
-		for (const FZoneGraphLaneHandle& SourceLane : SourceLanes)
-		{
-			if (const FZoneGraphStorage* ZoneGraphStorage = ZoneGraphSubsystem.GetZoneGraphStorage(SourceLane.DataHandle))
-			{
-				if (const TSet<FMassEntityHandle>* Entities = EntitiesMap.Find(SourceLane))
-				{
-					for (const FMassEntityHandle& Entity : *Entities)
-					{
-						FMassEntityView EntityView(EntityManager, Entity);
-
-						const FMassZoneGraphLaneLocationFragment& LaneLocationFragment = EntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
-
-						FZoneGraphLaneLocation EntityZoneGraphLaneLocation;
-						if (UE::ZoneGraph::Query::CalculateLocationAlongLane(*ZoneGraphStorage, SourceLane, LaneLocationFragment.DistanceAlongLane, EntityZoneGraphLaneLocation))
-						{
-							const FColor& EntityColor = PedestrianEntities.Contains(Entity) ? PedestrianColor : VehicleColor;
-							DrawDebugSphere(GetWorld(), EntityZoneGraphLaneLocation.Position + IndicatorOffset, 50.0f, 16, EntityColor, false, LifeTime, 0, 10.0f);
-						}
-					}
-				}
-			}
-		}
-	};
-
-	// Draw spheres for each Entity with a yield override, if debug option is enabled.
+	// Draw yield override indicators, if debug option is enabled.
 	if (GMassTrafficDebugYieldDeadlockResolution > 0)
 	{
-		const TMap<FZoneGraphLaneHandle, TSet<FMassEntityHandle>>& LaneYieldOverrideMap = MassTrafficSubsystem.GetLaneYieldOverrideMap();
-
-		TArray<FZoneGraphLaneHandle> YieldOverrideLanes;
-		LaneYieldOverrideMap.GetKeys(YieldOverrideLanes);
-		
-		DrawDebugIndicatorsForEntities(YieldOverrideLanes, LaneYieldOverrideMap, FVector(0.0f, 0.0f, 300.0f), FColor::Cyan, FColor::Blue, 0.1f);
+		if (const UWorld* World = GetWorld())
+		{
+			const TMap<FLaneEntityPair, TSet<FLaneEntityPair>>& YieldOverrideMap = MassTrafficSubsystem.GetYieldOverrideMap();
+			
+			DrawDebugYieldOverrideIndicators(MassTrafficSubsystem, ZoneGraphSubsystem, EntityManager, PedestrianEntities, FVector(0.0f, 0.0f, 300.0f), FColor::Cyan, FColor::Blue, *World, 0.1f);
+		}
 	}
 
-	const auto& FindYieldCycleLanes = [&MassTrafficSubsystem]()
+	// Draw yield map arrows, if debug option is enabled.
+	// This is the complete state of all yielding Entities this frame,
+	// and it's the direct input to the yield cycle detector.
+	if (GMassTrafficDebugYieldDeadlockResolution > 0)
 	{
-		const TMap<FZoneGraphLaneHandle, TSet<FZoneGraphLaneHandle>>& LaneYieldMap = MassTrafficSubsystem.GetLaneYieldMap();
-
-		TArray<FZoneGraphLaneHandle> YieldingLanes;
-		LaneYieldMap.GetKeys(YieldingLanes);
-
-		for (const FZoneGraphLaneHandle& SearchStartLane : YieldingLanes)
+		if (const UWorld* World = GetWorld())
 		{
-			const TArray<FZoneGraphLaneHandle> YieldCycleLanes = FindFirstCycleDFS(LaneYieldMap, SearchStartLane);
-
-			if (!YieldCycleLanes.IsEmpty())
-			{
-				return YieldCycleLanes;
-			}
+			DrawDebugYieldMap(MassTrafficSubsystem, ZoneGraphSubsystem, EntityManager, PedestrianEntities, FVector(0.0f, 0.0f, 300.0f), FColor::Silver, FColor::White, *World, 0.1f);
 		}
+	}
 
-		return TArray<FZoneGraphLaneHandle>();
-	};
-
-	const TArray<FZoneGraphLaneHandle> YieldCycleLanes = FindYieldCycleLanes();
+	const TArray<FYieldCycleNode> YieldCycleNodes = FindYieldCycleNodes(MassTrafficSubsystem, EntityManager, VehicleEntities);
 
 	// If we didn't find a yield cycle, ...
-	if (YieldCycleLanes.IsEmpty())
+	if (YieldCycleNodes.IsEmpty())
 	{
 		// There is nothing to do here.
 		return;
 	}
 
-	const TMap<FZoneGraphLaneHandle, TSet<FMassEntityHandle>>& YieldingEntitiesMap = MassTrafficSubsystem.GetYieldingEntitiesMap();
-
-	// Draw spheres for each Entity in a yield cycle, if debug option is enabled.
+	// Draw yield cycle arrows, if debug option is enabled.
 	if (GMassTrafficDebugYieldDeadlockResolution > 0)
 	{
-		DrawDebugIndicatorsForEntities(YieldCycleLanes, YieldingEntitiesMap, FVector(0.0f, 0.0f, 300.0f), FColor::Magenta, FColor::Purple, 0.5f);
+		if (const UWorld* World = GetWorld())
+		{
+			DrawDebugYieldCycleIndicators(ZoneGraphSubsystem, EntityManager, PedestrianEntities, YieldCycleNodes, FVector(0.0f, 0.0f, 300.0f), FColor::Orange, FColor::Purple, FColor::Magenta, *World, 0.5f);
+		}
 	}
-
-	const auto& GetYieldOverrideCandidateLanes = [&YieldCycleLanes, &YieldingEntitiesMap, &VehicleEntities, &PedestrianEntities]()
-	{
-		TSet<FZoneGraphLaneHandle> YieldOverrideCandidateLanes;
-
-		// First, see if any pedestrians are in the yield cycle.
-		// If so, all such pedestrians will become our YieldOverrideCandidates.
-		for (const FZoneGraphLaneHandle& YieldCycleLane : YieldCycleLanes)
-		{
-			if (const TSet<FMassEntityHandle>* YieldingEntities = YieldingEntitiesMap.Find(YieldCycleLane))
-			{
-				if (!YieldingEntities->Intersect(PedestrianEntities).IsEmpty())
-				{
-					YieldOverrideCandidateLanes.Add(YieldCycleLane);
-				}
-			}
-		}
-
-		// If we found any pedestrians in the yield cycle,
-		// return their associated lanes as our YieldOverrideCandidateLanes.
-		if (!YieldOverrideCandidateLanes.IsEmpty())
-		{
-			return YieldOverrideCandidateLanes;
-		}
-
-		// Now, look for vehicles.
-		for (const FZoneGraphLaneHandle& YieldCycleLane : YieldCycleLanes)
-		{
-			if (const TSet<FMassEntityHandle>* YieldingEntities = YieldingEntitiesMap.Find(YieldCycleLane))
-			{
-				if (!YieldingEntities->Intersect(VehicleEntities).IsEmpty())
-				{
-					YieldOverrideCandidateLanes.Add(YieldCycleLane);
-				}
-			}
-		}
-
-		if (!ensureMsgf(!YieldOverrideCandidateLanes.IsEmpty(), TEXT("YieldCycleLanes had entries.  But, we found no vehicles or pedestrians in the yield cycle in UMassTrafficYieldDeadlockResolutionProcessor::Execute.")))
-		{
-			return TSet<FZoneGraphLaneHandle>();
-		}
-
-		return YieldOverrideCandidateLanes;
-	};
-
-	const auto& GetSelectedYieldOverrideCandidateLane = [&EntityManager, &YieldingEntitiesMap](const TSet<FZoneGraphLaneHandle>& YieldOverrideCandidateLanes)
-	{
-		FZoneGraphLaneHandle SelectedYieldOverrideCandidateLane;
-		float MaxNormalizedDistanceAlongLane = TNumericLimits<float>::Lowest();
-
-		// Select the lane with the Entity furthest along the lane among all the candidate lanes.
-		for (const FZoneGraphLaneHandle& YieldOverrideCandidateLane : YieldOverrideCandidateLanes)
-		{
-			if (const TSet<FMassEntityHandle>* YieldOverrideCandidateEntities = YieldingEntitiesMap.Find(YieldOverrideCandidateLane))
-			{
-				for (const FMassEntityHandle& YieldOverrideCandidateEntity : *YieldOverrideCandidateEntities)
-				{
-					FMassEntityView YieldOverrideCandidateEntityView(EntityManager, YieldOverrideCandidateEntity);
-
-					const FMassZoneGraphLaneLocationFragment& LaneLocationFragment = YieldOverrideCandidateEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
-
-					const float NormalizedDistanceAlongLane = LaneLocationFragment.LaneLength > 0.0f ? LaneLocationFragment.DistanceAlongLane / LaneLocationFragment.LaneLength : 0.0f;
-
-					if (NormalizedDistanceAlongLane > MaxNormalizedDistanceAlongLane)
-					{
-						MaxNormalizedDistanceAlongLane = NormalizedDistanceAlongLane;
-						SelectedYieldOverrideCandidateLane = YieldOverrideCandidateLane;
-					}
-				}
-			}
-		}
-
-		return SelectedYieldOverrideCandidateLane;
-	};
 
 	// Only add Entities to the yield override map, if yield deadlock resolution is enabled.
 	if (GMassTrafficResolveYieldDeadlocks <= 0)
@@ -367,27 +245,629 @@ void UMassTrafficYieldDeadlockResolutionProcessor::Execute(FMassEntityManager& E
 		return;
 	}
 
-	// Get all the yield candidate lanes, then select one candidate lane to override, in order to break this yield cycle.
-	// Note:  Once we add yield overrides for Entities on a lane in a yield cycle, the same yield cycle
-	// should not form again next frame as the Entities will skip their yield logic altogether
-	// until they clear the lane in which the yield override was initiated.
-	const TSet<FZoneGraphLaneHandle>& YieldOverrideCandidateLanes = GetYieldOverrideCandidateLanes();
-	const FZoneGraphLaneHandle& SelectedYieldOverrideCandidateLane = GetSelectedYieldOverrideCandidateLane(YieldOverrideCandidateLanes);
-
-	// If our selected yield override candidate lane is valid, ...
-	if (SelectedYieldOverrideCandidateLane.IsValid())
+	// Get all the yield override candidates, then select one candidate to override, in order to break this yield cycle.
+	// Note:  Once we add a yield override for an Entity in a yield cycle, the same yield cycle
+	// should not form again next frame as the Entity will ignore yielding to the specified yield target Entity
+	// until the selected yield override candidate clears the lane in which the yield override was initiated.
+	const TArray<int32>& YieldOverrideCandidateIndexes = GetYieldOverrideCandidateIndexes(YieldCycleNodes, VehicleEntities, PedestrianEntities);
+	const int32& SelectedYieldOverrideCandidateIndex = GetSelectedYieldOverrideCandidateIndex(YieldCycleNodes, EntityManager, YieldOverrideCandidateIndexes);
+	
+	if (!ensureMsgf(SelectedYieldOverrideCandidateIndex != INDEX_NONE, TEXT("Must get valid SelectedYieldOverrideCandidateIndex in UMassTrafficYieldDeadlockResolutionProcessor::Execute.")))
 	{
-		if (const TSet<FMassEntityHandle>* SelectedYieldOverrideEntities = YieldingEntitiesMap.Find(SelectedYieldOverrideCandidateLane))
-		{
-			UE_LOG(LogMassTraffic, Log, TEXT("Breaking yield cycle deadlock by overriding the yield logic for %d Entities on SelectedYieldOverrideCandidateLane.Index: %d SelectedYieldOverrideCandidateLane.DataHandle.Index: %d SelectedYieldOverrideCandidateLane.DataHandle.Generation: %d"),
-				SelectedYieldOverrideEntities->Num(), SelectedYieldOverrideCandidateLane.Index, SelectedYieldOverrideCandidateLane.DataHandle.Index, SelectedYieldOverrideCandidateLane.DataHandle.Generation);
+		return;
+	}
+
+	const FYieldCycleNode& SelectedYieldOverrideCandidate = YieldCycleNodes[SelectedYieldOverrideCandidateIndex];
+	const FYieldCycleNode& TargetIgnoreYieldCandidate = YieldCycleNodes[SelectedYieldOverrideCandidateIndex + 1];	// Plus 1 is safe here.
+
+	if (!ensureMsgf(!TargetIgnoreYieldCandidate.bHasImplicitYieldFromPrevNode, TEXT("TargetIgnoreYieldCandidate must not have implicit yield from SelectedYieldOverrideCandidate in UMassTrafficYieldDeadlockResolutionProcessor::Execute.")))
+	{
+		return;
+	}
+
+	int32 NumLanesInYieldCycle;
+	int32 NumVehicleEntitiesInYieldCycle;
+	int32 NumPedestrianEntitiesInYieldCycle;
+	
+	const int32 NumEntitiesInYieldCycle = GetNumEntitiesInYieldCycle(
+		YieldCycleNodes,
+		VehicleEntities,
+		PedestrianEntities,
+		&NumLanesInYieldCycle,
+		&NumVehicleEntitiesInYieldCycle,
+		&NumPedestrianEntitiesInYieldCycle);
+
+	UE_LOG(LogMassTraffic, Log, TEXT("Breaking yield cycle deadlock with %d total Entities (%d vehicles, %d pedestrians) on %d lanes by overriding the yield logic for SelectedYieldOverrideCandidate -> TargetIgnoreYieldCandidate: (Lane: %d Entity: %d) -> (Lane: %d Entity: %d)."),
+		NumEntitiesInYieldCycle, NumVehicleEntitiesInYieldCycle, NumPedestrianEntitiesInYieldCycle, NumLanesInYieldCycle,
+		SelectedYieldOverrideCandidate.LaneEntityPair.LaneHandle.Index, SelectedYieldOverrideCandidate.LaneEntityPair.EntityHandle.Index,
+		TargetIgnoreYieldCandidate.LaneEntityPair.LaneHandle.Index, TargetIgnoreYieldCandidate.LaneEntityPair.EntityHandle.Index);
+
+	// We break the yield cycle deadlock by adding one *explicit* edge in the yield cycle as a yield override.
+	// That is, the SelectedYieldOverrideCandidate is allowed to ignore yielding to TargetIgnoreYieldCandidate
+	// until SelectedYieldOverrideCandidate's Entity manages to move onto a new lane.
+	MassTrafficSubsystem.AddYieldOverride(
+		SelectedYieldOverrideCandidate.LaneEntityPair.LaneHandle,
+		SelectedYieldOverrideCandidate.LaneEntityPair.EntityHandle,
+		TargetIgnoreYieldCandidate.LaneEntityPair.LaneHandle,
+		TargetIgnoreYieldCandidate.LaneEntityPair.EntityHandle);
+}
+
+void UMassTrafficYieldDeadlockResolutionProcessor::CleanupStaleYieldOverrides(UMassTrafficSubsystem& MassTrafficSubsystem, const FMassEntityManager& EntityManager) const
+{
+	TMap<FLaneEntityPair, TSet<FLaneEntityPair>>& YieldOverrideMap = MassTrafficSubsystem.GetMutableYieldOverrideMap();
 			
-			for (const FMassEntityHandle& SelectedYieldOverrideEntity : *SelectedYieldOverrideEntities)
+	for (auto YieldOverrideMapItr = YieldOverrideMap.CreateIterator(); YieldOverrideMapItr; ++YieldOverrideMapItr)
+	{
+		const FLaneEntityPair& YieldOverrideLaneEntityPair = YieldOverrideMapItr.Key();
+				
+		const FZoneGraphLaneHandle& YieldOverrideLane = YieldOverrideLaneEntityPair.LaneHandle;
+		const FMassEntityHandle& YieldOverrideEntity = YieldOverrideLaneEntityPair.EntityHandle;
+
+		FMassEntityView YieldOverrideEntityView(EntityManager, YieldOverrideEntity);
+		const FMassZoneGraphLaneLocationFragment& YieldOverrideLaneLocationFragment = YieldOverrideEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
+
+		// If the YieldOverrideEntity is on a new lane since it was granted any number of yield overrides, ...
+		if (YieldOverrideLaneLocationFragment.LaneHandle != YieldOverrideLane)
+		{
+			// Remove its yield overrides.
+			YieldOverrideMapItr.RemoveCurrent();
+		}
+	}
+	
+	TSet<FLaneEntityPair>& WildcardYieldOverrideSet = MassTrafficSubsystem.GetMutableWildcardYieldOverrideSet();
+
+	for (auto WildcardYieldOverrideSetItr = WildcardYieldOverrideSet.CreateIterator(); WildcardYieldOverrideSetItr; ++WildcardYieldOverrideSetItr)
+	{
+		const FZoneGraphLaneHandle& WildcardYieldOverrideLane = WildcardYieldOverrideSetItr->LaneHandle;
+		const FMassEntityHandle& WildcardYieldOverrideEntity = WildcardYieldOverrideSetItr->EntityHandle;
+
+		FMassEntityView WildcardYieldOverrideEntityView(EntityManager, WildcardYieldOverrideEntity);
+		const FMassZoneGraphLaneLocationFragment& WildcardYieldOverrideLaneLocationFragment = WildcardYieldOverrideEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
+
+		// If the WildcardYieldOverrideEntity is on a new lane since it was granted a wildcard yield override, ...
+		if (WildcardYieldOverrideLaneLocationFragment.LaneHandle != WildcardYieldOverrideLane)
+		{
+			// Remove its wildcard yield override.
+			WildcardYieldOverrideSetItr.RemoveCurrent();
+		}
+	}
+}
+
+TArray<FYieldCycleNode> UMassTrafficYieldDeadlockResolutionProcessor::FindYieldCycleNodes(
+	const UMassTrafficSubsystem& MassTrafficSubsystem,
+	const FMassEntityManager& EntityManager,
+	const TSet<FMassEntityHandle>& VehicleEntities) const
+{
+	const TMap<FZoneGraphLaneHandle, TSet<FMassEntityHandle>>& YieldingEntitiesMap = MassTrafficSubsystem.GetYieldingEntitiesMap();
+
+	const auto& GetImplicitYieldTarget = [&EntityManager, &YieldingEntitiesMap, &VehicleEntities](const FLaneEntityPair& QueryLaneEntityPair) -> TOptional<FLaneEntityPair>
+	{
+		if (VehicleEntities.Contains(QueryLaneEntityPair.EntityHandle))
+		{
+			const FMassEntityView QueryVehicleEntityView(EntityManager, QueryLaneEntityPair.EntityHandle);
+
+			const FMassTrafficVehicleControlFragment& VehicleControlFragment = QueryVehicleEntityView.GetFragmentData<FMassTrafficVehicleControlFragment>();
+			const FMassTrafficNextVehicleFragment& NextVehicleFragment = QueryVehicleEntityView.GetFragmentData<FMassTrafficNextVehicleFragment>();
+
+			// If not explicitly yielding, but we're currently stopped, ...
+			if (!VehicleControlFragment.IsYieldingAtIntersection() && VehicleControlFragment.IsVehicleCurrentlyStopped())
 			{
-				// Add all the Entities on the selected candidate lane.
-				// These Entities will be allowed to ignore their yield logic to break the deadlock.
-				MassTrafficSubsystem.AddEntityToLaneYieldOverrideMap(SelectedYieldOverrideCandidateLane, SelectedYieldOverrideEntity);
+				// And, we have a vehicle somewhere in front of us, ...
+				if (NextVehicleFragment.HasNextVehicle())
+				{
+					if (const TSet<FMassEntityHandle>* YieldingEntities = YieldingEntitiesMap.Find(QueryLaneEntityPair.LaneHandle))
+					{
+						// And, that vehicle in front of us is yielding on our lane, ...
+						if (const FMassEntityHandle NextVehicle = NextVehicleFragment.GetNextVehicle(); YieldingEntities->Contains(NextVehicle))
+						{
+							// Then, we are implicitly yielding to that vehicle
+							// for the purposes of finding yield cycle deadlocks.
+							const FLaneEntityPair ImplicitYieldTarget(QueryLaneEntityPair.LaneHandle, NextVehicle);
+							return ImplicitYieldTarget;
+						}
+					}
+				}
+			}
+		}
+
+		return TOptional<FLaneEntityPair>();
+	};
+
+	const TMap<FLaneEntityPair, TSet<FLaneEntityPair>>& YieldMap = MassTrafficSubsystem.GetYieldMap();
+
+	TArray<FLaneEntityPair> YieldingLaneEntityPairs;
+	YieldMap.GetKeys(YieldingLaneEntityPairs);
+
+	for (const FLaneEntityPair& SearchStartLaneEntityPair : YieldingLaneEntityPairs)
+	{
+		const TArray<FYieldCycleNode> YieldCycleNodes = FindFirstCycleDFS(YieldMap, SearchStartLaneEntityPair, GetImplicitYieldTarget);
+
+		if (!YieldCycleNodes.IsEmpty())
+		{
+			return YieldCycleNodes;
+		}
+	}
+
+	return TArray<FYieldCycleNode>();
+}
+
+int32 UMassTrafficYieldDeadlockResolutionProcessor::GetNumEntitiesInYieldCycle(
+	const TArray<FYieldCycleNode>& YieldCycleNodes,
+	const TSet<FMassEntityHandle>& VehicleEntities,
+	const TSet<FMassEntityHandle>& PedestrianEntities,
+	int32* OutNumLanesInYieldCycle,
+	int32* OutNumVehicleEntitiesInYieldCycle,
+	int32* OutNumPedestrianEntitiesInYieldCycle) const
+{
+	// We need to subtract 1 in order not to count the "cyclic" node at the end.
+	int32 NumEntitiesInYieldCycle = YieldCycleNodes.Num() - 1;
+	
+	int32 NumVehicleEntitiesInYieldCycle = 0;
+	int32 NumPedestrianEntitiesInYieldCycle = 0;
+
+	TSet<FZoneGraphLaneHandle> YieldCycleLanes;
+	
+	for (int32 YieldCycleIndex = 0; YieldCycleIndex < YieldCycleNodes.Num() - 1; ++YieldCycleIndex)
+	{
+		const FYieldCycleNode& YieldCycleNode = YieldCycleNodes[YieldCycleIndex];
+		
+		const FZoneGraphLaneHandle& YieldingLane = YieldCycleNode.LaneEntityPair.LaneHandle;
+		const FMassEntityHandle& YieldingEntity = YieldCycleNode.LaneEntityPair.EntityHandle;
+
+		YieldCycleLanes.Add(YieldingLane);
+			
+		if (VehicleEntities.Contains(YieldingEntity))
+		{
+			++NumVehicleEntitiesInYieldCycle;
+		}
+
+		if (PedestrianEntities.Contains(YieldingEntity))
+		{
+			++NumPedestrianEntitiesInYieldCycle;
+		}
+	}
+
+	if (OutNumLanesInYieldCycle != nullptr)
+	{
+		*OutNumLanesInYieldCycle = YieldCycleLanes.Num();
+	}
+
+	if (OutNumVehicleEntitiesInYieldCycle != nullptr)
+	{
+		*OutNumVehicleEntitiesInYieldCycle = NumVehicleEntitiesInYieldCycle;
+	}
+
+	if (OutNumPedestrianEntitiesInYieldCycle != nullptr)
+	{
+		*OutNumPedestrianEntitiesInYieldCycle = NumPedestrianEntitiesInYieldCycle;
+	}
+
+	return NumEntitiesInYieldCycle;
+}
+
+TArray<int32> UMassTrafficYieldDeadlockResolutionProcessor::GetYieldOverrideCandidateIndexes(
+	const TArray<FYieldCycleNode>& YieldCycleNodes,
+	const TSet<FMassEntityHandle>& VehicleEntities,
+	const TSet<FMassEntityHandle>& PedestrianEntities) const
+{
+	TArray<int32> YieldOverrideCandidateIndexes;
+
+	// First, see if any pedestrians are in the yield cycle.
+	// If so, all such pedestrians will become our YieldOverrideCandidates.
+	for (int32 YieldCycleIndex = 0; YieldCycleIndex < YieldCycleNodes.Num() - 1; ++YieldCycleIndex)
+	{
+		const FYieldCycleNode& YieldCycleNode = YieldCycleNodes[YieldCycleIndex];
+		
+		const FMassEntityHandle& YieldingEntity = YieldCycleNode.LaneEntityPair.EntityHandle;
+		
+		if (PedestrianEntities.Contains(YieldingEntity))
+		{
+			YieldOverrideCandidateIndexes.Add(YieldCycleIndex);
+		}
+	}
+
+	// If we found any pedestrians in the yield cycle,
+	// return them as our YieldOverrideCandidateLanes.
+	if (!YieldOverrideCandidateIndexes.IsEmpty())
+	{
+		return YieldOverrideCandidateIndexes;
+	}
+
+	// Now, look for vehicles.
+	for (int32 YieldCycleIndex = 0; YieldCycleIndex < YieldCycleNodes.Num() - 1; ++YieldCycleIndex)
+	{
+		const FYieldCycleNode& YieldCycleNode = YieldCycleNodes[YieldCycleIndex];
+		const FYieldCycleNode& NextYieldCycleNode = YieldCycleNodes[YieldCycleIndex + 1];
+
+		// Vehicles can implicitly yield by stopping behind a vehicle in front of them on their own lane.
+		// And, breaking these edges in the yield cycle won't resolve the yield cycle deadlock.
+		// So, we skip selecting yield override candidates that are implicitly yielding
+		// to the next node in the yield cycle.
+		if (NextYieldCycleNode.bHasImplicitYieldFromPrevNode)
+		{
+			continue;
+		}
+		
+		const FMassEntityHandle& YieldingEntity = YieldCycleNode.LaneEntityPair.EntityHandle;
+
+		if (VehicleEntities.Contains(YieldingEntity))
+		{
+			YieldOverrideCandidateIndexes.Add(YieldCycleIndex);
+		}
+	}
+
+	if (!ensureMsgf(YieldCycleNodes.IsEmpty() || !YieldOverrideCandidateIndexes.IsEmpty(), TEXT("YieldCycleNodes has entries.  But, we found no vehicles or pedestrians in the yield cycle in UMassTrafficYieldDeadlockResolutionProcessor::Execute.")))
+	{
+		return TArray<int32>();
+	}
+
+	return YieldOverrideCandidateIndexes;
+}
+
+int32 UMassTrafficYieldDeadlockResolutionProcessor::GetSelectedYieldOverrideCandidateIndex(
+	const TArray<FYieldCycleNode>& YieldCycleNodes,
+	const FMassEntityManager& EntityManager,
+	const TArray<int32>& YieldOverrideCandidateIndexes) const
+{
+	// First, figure-out which candidate Entities are yielding on which lane.
+	TMap<FZoneGraphLaneHandle, TSet<FMassEntityHandle>> YieldingCandidatesMap;
+	for (const int32& YieldOverrideCandidateIndex : YieldOverrideCandidateIndexes)
+	{
+		const FYieldCycleNode& YieldOverrideCandidate = YieldCycleNodes[YieldOverrideCandidateIndex];
+		
+		const FZoneGraphLaneHandle& YieldingLane = YieldOverrideCandidate.LaneEntityPair.LaneHandle;
+		const FMassEntityHandle& YieldingEntity = YieldOverrideCandidate.LaneEntityPair.EntityHandle;
+		
+		TSet<FMassEntityHandle>& YieldingEntities = YieldingCandidatesMap.FindOrAdd(YieldingLane);
+		YieldingEntities.Add(YieldingEntity);
+	}
+
+	// Then, figure-out which lanes are tied for having the least number of candidate Entities.
+	TSet<FZoneGraphLaneHandle> LanesWithMinYieldingEntitiesInYieldOverrideCandidates;
+	int32 MinYieldingEntitiesInYieldOverrideCandidates = TNumericLimits<int32>::Max();
+
+	for (TTuple<FZoneGraphLaneHandle, TSet<FMassEntityHandle>> YieldingCandidatePair : YieldingCandidatesMap)
+	{
+		const FZoneGraphLaneHandle& YieldingLane = YieldingCandidatePair.Key;
+		const TSet<FMassEntityHandle>& YieldingEntities = YieldingCandidatePair.Value;
+
+		const int32 NumYieldingEntities = YieldingEntities.Num();
+
+		// Reset LaneWithMinYieldingEntitiesInYieldOverrideCandidates
+		// on new MinYieldingEntitiesInYieldOverrideCandidates.
+		if (NumYieldingEntities < MinYieldingEntitiesInYieldOverrideCandidates)
+		{
+			LanesWithMinYieldingEntitiesInYieldOverrideCandidates.Reset();
+		}
+
+		if (NumYieldingEntities <= MinYieldingEntitiesInYieldOverrideCandidates)
+		{
+			MinYieldingEntitiesInYieldOverrideCandidates = NumYieldingEntities;
+			LanesWithMinYieldingEntitiesInYieldOverrideCandidates.Add(YieldingLane);
+		}
+	}
+
+	ensureMsgf(!LanesWithMinYieldingEntitiesInYieldOverrideCandidates.IsEmpty(), TEXT("LanesWithMinYieldingEntitiesInYieldOverrideCandidates must contain at least 1 lane in UMassTrafficYieldDeadlockResolutionProcessor::Execute."));
+	
+	int32 SelectedYieldOverrideCandidateIndex = INDEX_NONE;
+	float MaxNormalizedDistanceAlongLane = TNumericLimits<float>::Lowest();
+
+	// Select the candidate with the Entity furthest along the lane among all the candidate lanes.
+	for (const int32& YieldOverrideCandidateIndex : YieldOverrideCandidateIndexes)
+	{
+		const FYieldCycleNode& YieldOverrideCandidate = YieldCycleNodes[YieldOverrideCandidateIndex];
+		
+		const FZoneGraphLaneHandle& YieldingLane = YieldOverrideCandidate.LaneEntityPair.LaneHandle;
+
+		// Only consider yield override candidates on lanes
+		// tied for having the minimum number of candidate Entities.
+		if (!LanesWithMinYieldingEntitiesInYieldOverrideCandidates.Contains(YieldingLane))
+		{
+			continue;
+		}
+		
+		const FMassEntityHandle& YieldOverrideCandidateEntity = YieldOverrideCandidate.LaneEntityPair.EntityHandle;
+		
+		FMassEntityView YieldOverrideCandidateEntityView(EntityManager, YieldOverrideCandidateEntity);
+
+		const FMassZoneGraphLaneLocationFragment& LaneLocationFragment = YieldOverrideCandidateEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
+
+		const float NormalizedDistanceAlongLane = LaneLocationFragment.LaneLength > 0.0f ? LaneLocationFragment.DistanceAlongLane / LaneLocationFragment.LaneLength : 0.0f;
+
+		if (NormalizedDistanceAlongLane > MaxNormalizedDistanceAlongLane)
+		{
+			MaxNormalizedDistanceAlongLane = NormalizedDistanceAlongLane;
+			SelectedYieldOverrideCandidateIndex = YieldOverrideCandidateIndex;
+		}
+	}
+
+	return SelectedYieldOverrideCandidateIndex;
+}
+
+void UMassTrafficYieldDeadlockResolutionProcessor::DrawDebugYieldMap(
+	const UMassTrafficSubsystem& MassTrafficSubsystem,
+	const UZoneGraphSubsystem& ZoneGraphSubsystem,
+	const FMassEntityManager& EntityManager,
+	const TSet<FMassEntityHandle>& PedestrianEntities,
+	const FVector& IndicatorOffset,
+	const FColor& PedestrianYieldColor,
+	const FColor& VehicleYieldColor,
+	const UWorld& World,
+	const float LifeTime) const
+{
+	TArray<TFunction<void()>> DebugDrawCalls;
+
+	const TMap<FLaneEntityPair, TSet<FLaneEntityPair>>& YieldMap = MassTrafficSubsystem.GetYieldMap();
+
+	for (const TTuple<FLaneEntityPair, TSet<FLaneEntityPair>>& YieldMapPair : YieldMap)
+	{
+		const FLaneEntityPair& YieldingLaneEntityPair = YieldMapPair.Key;
+		const TSet<FLaneEntityPair>& YieldTargets = YieldMapPair.Value;
+		
+		const FZoneGraphLaneHandle& YieldingLane = YieldingLaneEntityPair.LaneHandle;
+		const FMassEntityHandle& YieldingEntity = YieldingLaneEntityPair.EntityHandle;
+
+		const FZoneGraphStorage* YieldingZoneGraphStorage = ZoneGraphSubsystem.GetZoneGraphStorage(YieldingLane.DataHandle);
+
+		if (YieldingZoneGraphStorage == nullptr)
+		{
+			continue;
+		}
+
+		for (const FLaneEntityPair& YieldTarget : YieldTargets)
+		{
+			const FZoneGraphLaneHandle& YieldTargetLane = YieldTarget.LaneHandle;
+			const FMassEntityHandle& YieldTargetEntity = YieldTarget.EntityHandle;
+			
+			const FZoneGraphStorage* YieldTargetZoneGraphStorage = ZoneGraphSubsystem.GetZoneGraphStorage(YieldTargetLane.DataHandle);
+
+			if (YieldTargetZoneGraphStorage == nullptr)
+			{
+				continue;
+			}
+
+			const FMassEntityView YieldingEntityView(EntityManager, YieldingEntity);
+			const FMassEntityView YieldTargetEntityView(EntityManager, YieldTargetEntity);
+	
+			const FMassZoneGraphLaneLocationFragment& YieldingLaneLocationFragment = YieldingEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
+			const FMassZoneGraphLaneLocationFragment& YieldTargetLaneLocationFragment = YieldTargetEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
+	
+			FZoneGraphLaneLocation YieldingEntityZoneGraphLaneLocation;
+			FZoneGraphLaneLocation YieldTargetEntityZoneGraphLaneLocation;
+			
+			if (UE::ZoneGraph::Query::CalculateLocationAlongLane(*YieldingZoneGraphStorage, YieldingLane, YieldingLaneLocationFragment.DistanceAlongLane, YieldingEntityZoneGraphLaneLocation)
+				&& UE::ZoneGraph::Query::CalculateLocationAlongLane(*YieldTargetZoneGraphStorage, YieldTargetLane, YieldTargetLaneLocationFragment.DistanceAlongLane, YieldTargetEntityZoneGraphLaneLocation))
+			{
+				const FColor& YieldColor = PedestrianEntities.Contains(YieldingEntity) ? PedestrianYieldColor : VehicleYieldColor;
+
+				DebugDrawCalls.Add([
+					World=&World,
+					YieldingEntityPosition=YieldingEntityZoneGraphLaneLocation.Position,
+					YieldTargetEntityPosition=YieldTargetEntityZoneGraphLaneLocation.Position,
+					IndicatorOffset,
+					YieldColor,
+					LifeTime]()
+				{
+					DrawDebugDirectionalArrow(World, YieldingEntityPosition + IndicatorOffset, YieldTargetEntityPosition + IndicatorOffset, 1000.0f, YieldColor, false, LifeTime, 0, 10.0f);
+				});
 			}
 		}
 	}
+	
+	AsyncTask(ENamedThreads::GameThread, [DebugDrawCalls]()
+	{
+		for (const auto& DebugDrawCall : DebugDrawCalls)
+		{
+			DebugDrawCall();
+		}
+	});
+}
+
+void UMassTrafficYieldDeadlockResolutionProcessor::DrawDebugYieldCycleIndicators(
+	const UZoneGraphSubsystem& ZoneGraphSubsystem,
+	const FMassEntityManager& EntityManager,
+	const TSet<FMassEntityHandle>& PedestrianEntities,
+	const TArray<FYieldCycleNode>& YieldCycleNodes,
+	const FVector& IndicatorOffset,
+	const FColor& PedestrianYieldColor,
+	const FColor& VehicleYieldColor,
+	const FColor& VehicleImplicitYieldColor,
+	const UWorld& World,
+	const float LifeTime) const
+{
+	TArray<TFunction<void()>> DebugDrawCalls;
+	
+	for (int32 YieldCycleIndex = 0; YieldCycleIndex < YieldCycleNodes.Num() - 1; ++YieldCycleIndex)
+	{
+		const FYieldCycleNode& YieldCycleNode = YieldCycleNodes[YieldCycleIndex];
+		const FYieldCycleNode& NextYieldCycleNode = YieldCycleNodes[YieldCycleIndex + 1];
+
+		const FZoneGraphLaneHandle& YieldingLane = YieldCycleNode.LaneEntityPair.LaneHandle;
+		const FMassEntityHandle& YieldingEntity = YieldCycleNode.LaneEntityPair.EntityHandle;
+
+		const FZoneGraphLaneHandle& NextYieldingLane = NextYieldCycleNode.LaneEntityPair.LaneHandle;
+		const FMassEntityHandle& NextYieldingEntity = NextYieldCycleNode.LaneEntityPair.EntityHandle;
+		
+		const FZoneGraphStorage* YieldingZoneGraphStorage = ZoneGraphSubsystem.GetZoneGraphStorage(YieldingLane.DataHandle);
+		const FZoneGraphStorage* NextYieldingZoneGraphStorage = ZoneGraphSubsystem.GetZoneGraphStorage(NextYieldingLane.DataHandle);
+		
+		if (YieldingZoneGraphStorage != nullptr && NextYieldingZoneGraphStorage != nullptr)
+		{
+			const FMassEntityView YieldingEntityView(EntityManager, YieldingEntity);
+			const FMassEntityView NextYieldingEntityView(EntityManager, NextYieldingEntity);
+	
+			const FMassZoneGraphLaneLocationFragment& YieldingLaneLocationFragment = YieldingEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
+			const FMassZoneGraphLaneLocationFragment& NextYieldingLaneLocationFragment = NextYieldingEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
+	
+			FZoneGraphLaneLocation YieldingEntityZoneGraphLaneLocation;
+			FZoneGraphLaneLocation NextYieldingEntityZoneGraphLaneLocation;
+			
+			if (UE::ZoneGraph::Query::CalculateLocationAlongLane(*YieldingZoneGraphStorage, YieldingLane, YieldingLaneLocationFragment.DistanceAlongLane, YieldingEntityZoneGraphLaneLocation)
+				&& UE::ZoneGraph::Query::CalculateLocationAlongLane(*NextYieldingZoneGraphStorage, NextYieldingLane, NextYieldingLaneLocationFragment.DistanceAlongLane, NextYieldingEntityZoneGraphLaneLocation))
+			{
+				const FColor& YieldColor = PedestrianEntities.Contains(YieldingEntity)
+					? PedestrianYieldColor
+					: NextYieldCycleNode.bHasImplicitYieldFromPrevNode ? VehicleImplicitYieldColor : VehicleYieldColor;
+
+				DebugDrawCalls.Add([
+					World=&World,
+					YieldingEntityPosition=YieldingEntityZoneGraphLaneLocation.Position,
+					NextYieldingEntityPosition=NextYieldingEntityZoneGraphLaneLocation.Position,
+					IndicatorOffset,
+					YieldColor,
+					LifeTime]()
+				{
+					DrawDebugDirectionalArrow(World, YieldingEntityPosition + IndicatorOffset, NextYieldingEntityPosition + IndicatorOffset, 1000.0f, YieldColor, false, LifeTime, 0, 10.0f);
+				});
+			}
+		}
+	}
+
+	for (const FYieldCycleNode& YieldCycleNode : YieldCycleNodes)
+	{
+		DebugDrawCalls.Add([
+			&ZoneGraphSubsystem,
+			YieldCycleLane=YieldCycleNode.LaneEntityPair.LaneHandle,
+			World=&World,
+			LifeTime]()
+		{
+			UE::MassTraffic::DrawLaneData(ZoneGraphSubsystem, YieldCycleLane, FColor::Purple, *World, 10.0f, LifeTime);
+		});
+	}
+
+	AsyncTask(ENamedThreads::GameThread, [DebugDrawCalls]()
+	{
+		for (const auto& DebugDrawCall : DebugDrawCalls)
+		{
+			DebugDrawCall();
+		}
+	});
+}
+
+void UMassTrafficYieldDeadlockResolutionProcessor::DrawDebugYieldOverrideIndicators(
+	const UMassTrafficSubsystem& MassTrafficSubsystem,
+	const UZoneGraphSubsystem& ZoneGraphSubsystem,
+	const FMassEntityManager& EntityManager,
+	const TSet<FMassEntityHandle>& PedestrianEntities,
+	const FVector& IndicatorOffset,
+	const FColor& PedestrianYieldOverrideColor,
+	const FColor& VehicleYieldOverrideColor,
+	const UWorld& World,
+	const float LifeTime) const
+{
+	TArray<TFunction<void()>> DebugDrawCalls;
+	
+	const TMap<FLaneEntityPair, TSet<FLaneEntityPair>>& YieldOverrideMap = MassTrafficSubsystem.GetYieldOverrideMap();
+
+	for (const TTuple<FLaneEntityPair, TSet<FLaneEntityPair>>& YieldOverridePair : YieldOverrideMap)
+	{
+		const FLaneEntityPair& YieldOverrideLaneEntityPair = YieldOverridePair.Key;
+		const TSet<FLaneEntityPair>& YieldIgnoreTargets = YieldOverridePair.Value;
+		
+		const FZoneGraphLaneHandle& YieldOverrideLane = YieldOverrideLaneEntityPair.LaneHandle;
+		const FMassEntityHandle& YieldOverrideEntity = YieldOverrideLaneEntityPair.EntityHandle;
+
+		const FZoneGraphStorage* YieldOverrideZoneGraphStorage = ZoneGraphSubsystem.GetZoneGraphStorage(YieldOverrideLane.DataHandle);
+
+		if (YieldOverrideZoneGraphStorage == nullptr)
+		{
+			continue;
+		}
+
+		for (const FLaneEntityPair& YieldIgnoreTarget : YieldIgnoreTargets)
+		{
+			const FZoneGraphLaneHandle& YieldIgnoreTargetLane = YieldIgnoreTarget.LaneHandle;
+			const FMassEntityHandle& YieldIgnoreTargetEntity = YieldIgnoreTarget.EntityHandle;
+			
+			const FZoneGraphStorage* YieldIgnoreTargetZoneGraphStorage = ZoneGraphSubsystem.GetZoneGraphStorage(YieldIgnoreTargetLane.DataHandle);
+
+			if (YieldIgnoreTargetZoneGraphStorage == nullptr)
+			{
+				continue;
+			}
+
+			const FMassEntityView YieldOverrideEntityView(EntityManager, YieldOverrideEntity);
+			const FMassEntityView YieldIgnoreTargetEntityView(EntityManager, YieldIgnoreTargetEntity);
+	
+			const FMassZoneGraphLaneLocationFragment& YieldOverrideLaneLocationFragment = YieldOverrideEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
+			const FMassZoneGraphLaneLocationFragment& YieldIgnoreTargetLaneLocationFragment = YieldIgnoreTargetEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
+	
+			FZoneGraphLaneLocation YieldOverrideEntityZoneGraphLaneLocation;
+			FZoneGraphLaneLocation YieldIgnoreTargetEntityZoneGraphLaneLocation;
+			
+			if (UE::ZoneGraph::Query::CalculateLocationAlongLane(*YieldOverrideZoneGraphStorage, YieldOverrideLane, YieldOverrideLaneLocationFragment.DistanceAlongLane, YieldOverrideEntityZoneGraphLaneLocation)
+				&& UE::ZoneGraph::Query::CalculateLocationAlongLane(*YieldIgnoreTargetZoneGraphStorage, YieldIgnoreTargetLane, YieldIgnoreTargetLaneLocationFragment.DistanceAlongLane, YieldIgnoreTargetEntityZoneGraphLaneLocation))
+			{
+				const FColor& YieldOverrideColor = PedestrianEntities.Contains(YieldOverrideEntity) ? PedestrianYieldOverrideColor : VehicleYieldOverrideColor;
+
+				DebugDrawCalls.Add([
+					World=&World,
+					YieldOverrideEntityPosition=YieldOverrideEntityZoneGraphLaneLocation.Position,
+					YieldIgnoreTargetEntityPosition=YieldIgnoreTargetEntityZoneGraphLaneLocation.Position,
+					IndicatorOffset,
+					YieldOverrideColor,
+					LifeTime]()
+				{
+					DrawDebugDirectionalArrow(World, YieldOverrideEntityPosition + IndicatorOffset, YieldIgnoreTargetEntityPosition + IndicatorOffset, 1000.0f, YieldOverrideColor, false, LifeTime, 0, 10.0f);
+				});
+			}
+		}
+	}
+
+	const TSet<FLaneEntityPair>& WildcardYieldOverrideSet = MassTrafficSubsystem.GetWildcardYieldOverrideSet();
+
+	for (const FLaneEntityPair& WildcardYieldOverridePair : WildcardYieldOverrideSet)
+	{
+		const FZoneGraphLaneHandle& WildcardYieldOverrideLane = WildcardYieldOverridePair.LaneHandle;
+		const FMassEntityHandle& WildcardYieldOverrideEntity = WildcardYieldOverridePair.EntityHandle;
+
+		const FZoneGraphStorage* WildcardYieldOverrideZoneGraphStorage = ZoneGraphSubsystem.GetZoneGraphStorage(WildcardYieldOverrideLane.DataHandle);
+
+		if (WildcardYieldOverrideZoneGraphStorage == nullptr)
+		{
+			continue;
+		}
+		
+		const FMassEntityView WildcardYieldOverrideEntityView(EntityManager, WildcardYieldOverrideEntity);
+		const FMassZoneGraphLaneLocationFragment& WildcardYieldOverrideLaneLocationFragment = WildcardYieldOverrideEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
+		
+		FZoneGraphLaneLocation WildcardYieldOverrideEntityZoneGraphLaneLocation;
+		
+		if (UE::ZoneGraph::Query::CalculateLocationAlongLane(*WildcardYieldOverrideZoneGraphStorage, WildcardYieldOverrideLane, WildcardYieldOverrideLaneLocationFragment.DistanceAlongLane, WildcardYieldOverrideEntityZoneGraphLaneLocation))
+		{
+			const FColor& YieldOverrideColor = PedestrianEntities.Contains(WildcardYieldOverrideEntity) ? PedestrianYieldOverrideColor : VehicleYieldOverrideColor;
+
+			DebugDrawCalls.Add([
+				World=&World,
+				WildcardYieldOverrideEntityPosition=WildcardYieldOverrideEntityZoneGraphLaneLocation.Position,
+				IndicatorOffset,
+				YieldOverrideColor,
+				LifeTime]()
+			{
+				DrawDebugSphere(World, WildcardYieldOverrideEntityPosition + IndicatorOffset, 20.0f, 16, YieldOverrideColor, false, LifeTime, 0, 10.0f);
+			});
+		}
+	}
+	
+	for (const TTuple<FLaneEntityPair, TSet<FLaneEntityPair>>& YieldOverridePair : YieldOverrideMap)
+	{
+		const FLaneEntityPair& YieldOverrideLaneEntityPair = YieldOverridePair.Key;
+		
+		DebugDrawCalls.Add([
+			&ZoneGraphSubsystem,
+			YieldOverrideLane=YieldOverrideLaneEntityPair.LaneHandle,
+			World=&World,
+			LifeTime]()
+		{
+			UE::MassTraffic::DrawLaneData(ZoneGraphSubsystem, YieldOverrideLane, FColor::Blue, *World, 10.0f, LifeTime);
+		});
+	}
+
+	AsyncTask(ENamedThreads::GameThread, [DebugDrawCalls]()
+	{
+		for (const auto& DebugDrawCall : DebugDrawCalls)
+		{
+			DebugDrawCall();
+		}
+	});
 }

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficLaneChange.h
@@ -216,6 +216,7 @@ bool ShouldPerformReactiveYieldAtIntersection(
 	const FZoneGraphStorage& ZoneGraphStorage,
 	bool& OutShouldGiveOpportunityForTurningVehiclesToReactivelyYieldAtIntersection,
 	FZoneGraphLaneHandle& OutYieldTargetLane,
+	FMassEntityHandle& OutYieldTargetEntity,
 	int32& OutMergeYieldCaseIndex);
 
 bool ShouldPerformReactiveYieldAtRoadCrosswalk(
@@ -227,6 +228,7 @@ bool ShouldPerformReactiveYieldAtRoadCrosswalk(
 	const FAgentRadiusFragment& RadiusFragment,
 	const FMassTrafficRandomFractionFragment& RandomFractionFragment,
 	const FZoneGraphStorage& ZoneGraphStorage,
-	FZoneGraphLaneHandle& OutYieldTargetLane);
+	FZoneGraphLaneHandle& OutYieldTargetLane,
+	FMassEntityHandle& OutYieldTargetEntity);
 
 };

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficMovement.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficMovement.h
@@ -152,6 +152,7 @@ bool ShouldVehicleMergeOntoLane(
 	const FVector2D& StoppingDistanceRange,
 	const FZoneGraphStorage& ZoneGraphStorage,
 	FZoneGraphLaneHandle& OutYieldTargetLane,
+	FMassEntityHandle& OutYieldTargetEntity,
 	int32& OutMergeYieldCaseIndex);
 
 MASSTRAFFIC_API bool ShouldStopAtNextStopLine(
@@ -200,6 +201,7 @@ MASSTRAFFIC_API void UpdateYieldAtIntersectionState(
 	FMassTrafficVehicleControlFragment& VehicleControlFragment,
 	const FZoneGraphLaneHandle& CurrentLaneHandle,
 	const FZoneGraphLaneHandle& YieldTargetLaneHandle,
+	const FMassEntityHandle& YieldTargetEntity,
 	const bool bShouldReactivelyYieldAtIntersection,
 	const bool bShouldGiveOpportunityForTurningVehiclesToReactivelyYieldAtIntersection);
 

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficSettings.h
@@ -476,6 +476,19 @@ public:
 	UPROPERTY(EditAnywhere, Config, Category="Yield Behavior")
 	float VehiclePedestrianBufferDistanceOnCrosswalk = 200.0f;
 
+	// As a failsafe to prevent non-"yield cycle" deadlocks,
+	// pedestrians will only yield for this maximum time on crosswalks,
+	// after which they will be granted a yield override on their current lane,
+	// against all potential yield targets, until they finish crossing the crosswalk.
+	UPROPERTY(EditAnywhere, Config, Category="Yield Behavior")
+	float PedestrianMaxYieldOnCrosswalkTime = 30.0f;
+
+	// As a failsafe to prevent issues where pedestrians
+	// sometimes end up with a "zero" speed after yielding on crosswalks,
+	// we will resume their motion with this speed, instead.
+	UPROPERTY(EditAnywhere, Config, Category="Yield Behavior")
+	float PedestrianFailsafeCrosswalkYieldResumeSpeed = 200.0f;
+
 	// The time buffer the vehicles will use when detecting conflicts with other vehicles
 	// during their merge behavior.
 	UPROPERTY(EditAnywhere, Config, Category="Merge Behavior")
@@ -487,6 +500,14 @@ public:
 	// it will perform the crosswalk yield behavior logic.
 	UPROPERTY(EditAnywhere, Config, Category="Yield Behavior")
 	float VehicleCrosswalkYieldLookAheadTime = 2.0f;
+
+	// Vehicles will ignore running their merge yield logic for test vehicles,
+	// which will enter the intersection after this time delta.
+	// This is mainly used to cull merge yield considerations against test vehicles
+	// approaching from an intersection side with Sign Type "None" or a traffic light with open lanes,
+	// until they will be entering the intersection within this time delta.
+	UPROPERTY(EditAnywhere, Config, Category="Merge Behavior")
+	float VehicleMergeYieldTestVehicleEnterIntersectionHorizonTime = 4.0f;
 
 	// The time buffer the vehicles will use when detecting conflicts with other vehicles
 	// during their merge behavior.

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficTypes.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficTypes.h
@@ -576,18 +576,6 @@ struct MASSTRAFFIC_API FZoneGraphTrafficLaneData
 	uint8 NumVehiclesOnLane = 0;
 	uint8 NumVehiclesApproachingLane = 0; 
 	uint8 NumReservedVehiclesOnLane = 0; // See all CANTSTOPLANEEXIT.
-
-	TOptional<FMassEntityHandle> LeadVehicleEntityHandle;
-	TOptional<float> LeadVehicleDistanceAlongLane;
-	TOptional<float> LeadVehicleAccelerationEstimate;
-	TOptional<float> LeadVehicleSpeed;
-	TOptional<bool> bLeadVehicleIsYielding;
-	TOptional<float> LeadVehicleRadius;
-	TOptional<FZoneGraphTrafficLaneData*> LeadVehicleNextLane;
-	TOptional<FZoneGraphTrafficLaneData*> LeadVehicleStopSignIntersectionLane;
-	TOptional<float> LeadVehicleRandomFraction;
-	TOptional<float> LeadVehicleIsNearStopLineAtIntersection;
-	TOptional<float> LeadVehicleRemainingStopSignRestTime;
 	
 	FMassEntityHandle IntersectionEntityHandle;
 	

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficUtils.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficUtils.h
@@ -16,6 +16,7 @@ struct FMassTrafficVehicleSpawnFilter;
 
 class UMassTrafficSettings;
 class UMassTrafficSubsystem;
+class UZoneGraphSubsystem;
 
 /**
 * Helpful functions for determining lane directions from Zone Graph data.
@@ -141,6 +142,14 @@ FORCEINLINE float GetSpeedLimitAlongLane(const float Length, const float SpeedLi
 	const float SpeedScale = 1.0f - FMath::Clamp(TimeLeftOnLane / TimeToBlendFromLaneEnd, 0.0f, 1.0f);
 	return FMath::Lerp(SpeedLimit, MinNextLaneSpeedLimit, SpeedScale) IF_MASSTRAFFIC_ENABLE_DEBUG( * GMassTrafficSpeedLimitScale );
 }
+
+void DrawLaneData(
+	const UZoneGraphSubsystem& ZoneGraphSubsystem,
+	const FZoneGraphLaneHandle& LaneHandle,
+	const FColor LaneColor,
+	const UWorld& World,
+	const float ZOffset = 10.0f,
+	const float LifeTime = 0.1f);
 
 bool TryGetVehicleEnterAndExitTimesForIntersection(
 	const FZoneGraphTrafficLaneData& VehicleCurrentLaneData,

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficYieldDeadlockProcessor.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficYieldDeadlockProcessor.h
@@ -5,6 +5,33 @@
 #include "MassTrafficProcessorBase.h"
 #include "MassTrafficYieldDeadlockProcessor.generated.h"
 
+struct FYieldCycleNode
+{
+	FYieldCycleNode() = default;
+	
+	FYieldCycleNode(const FLaneEntityPair& InLaneEntityPair)
+		: LaneEntityPair(InLaneEntityPair)
+	{
+	}
+
+	FLaneEntityPair LaneEntityPair;
+	bool bHasImplicitYieldFromPrevNode = false;
+
+	bool operator==(const FYieldCycleNode& Other) const
+	{
+		return LaneEntityPair == Other.LaneEntityPair
+			&& bHasImplicitYieldFromPrevNode == Other.bHasImplicitYieldFromPrevNode;
+	}
+
+	friend uint32 GetTypeHash(const FYieldCycleNode& YieldCycleNode)
+	{
+		uint32 Hash = GetTypeHash(YieldCycleNode.LaneEntityPair);
+		
+		Hash = HashCombine(Hash, GetTypeHash(YieldCycleNode.bHasImplicitYieldFromPrevNode));
+			
+		return Hash;
+	}
+};
 
 UCLASS()
 class MASSTRAFFIC_API UMassTrafficYieldDeadlockFrameInitProcessor : public UMassTrafficProcessorBase
@@ -33,6 +60,65 @@ public:
 protected:
 	virtual void ConfigureQueries() override;
 	virtual void Execute(FMassEntityManager& EntitySubSystem, FMassExecutionContext& Context) override;
+
+	void CleanupStaleYieldOverrides(UMassTrafficSubsystem& MassTrafficSubsystem, const FMassEntityManager& EntityManager) const;
+
+	TArray<FYieldCycleNode> FindYieldCycleNodes(
+		const UMassTrafficSubsystem& MassTrafficSubsystem,
+		const FMassEntityManager& EntityManager,
+		const TSet<FMassEntityHandle>& VehicleEntities) const;
+
+	int32 GetNumEntitiesInYieldCycle(
+		const TArray<FYieldCycleNode>& YieldCycleNodes,
+		const TSet<FMassEntityHandle>& VehicleEntities,
+		const TSet<FMassEntityHandle>& PedestrianEntities,
+		int32* OutNumLanesInYieldCycle = nullptr,
+		int32* OutNumVehicleEntitiesInYieldCycle = nullptr,
+		int32* OutNumPedestrianEntitiesInYieldCycle = nullptr) const;
+
+	TArray<int32> GetYieldOverrideCandidateIndexes(
+		const TArray<FYieldCycleNode>& YieldCycleNodes,
+		const TSet<FMassEntityHandle>& VehicleEntities,
+		const TSet<FMassEntityHandle>& PedestrianEntities) const;
+
+	int32 GetSelectedYieldOverrideCandidateIndex(
+		const TArray<FYieldCycleNode>& YieldCycleNodes,
+		const FMassEntityManager& EntityManager,
+		const TArray<int32>& YieldOverrideCandidateIndexes) const;
+
+	void DrawDebugYieldMap(
+		const UMassTrafficSubsystem& MassTrafficSubsystem,
+		const UZoneGraphSubsystem& ZoneGraphSubsystem,
+		const FMassEntityManager& EntityManager,
+		const TSet<FMassEntityHandle>& PedestrianEntities,
+		const FVector& IndicatorOffset,
+		const FColor& PedestrianYieldColor,
+		const FColor& VehicleYieldColor,
+		const UWorld& World,
+		const float LifeTime) const;
+
+	void DrawDebugYieldCycleIndicators(
+		const UZoneGraphSubsystem& ZoneGraphSubsystem,
+		const FMassEntityManager& EntityManager,
+		const TSet<FMassEntityHandle>& PedestrianEntities,
+		const TArray<FYieldCycleNode>& YieldCycleNodes,
+		const FVector& IndicatorOffset,
+		const FColor& PedestrianYieldColor,
+		const FColor& VehicleYieldColor,
+		const FColor& VehicleImplicitYieldColor,
+		const UWorld& World,
+		const float LifeTime) const;
+
+	void DrawDebugYieldOverrideIndicators(
+		const UMassTrafficSubsystem& MassTrafficSubsystem,
+		const UZoneGraphSubsystem& ZoneGraphSubsystem,
+		const FMassEntityManager& EntityManager,
+		const TSet<FMassEntityHandle>& PedestrianEntities,
+		const FVector& IndicatorOffset,
+		const FColor& PedestrianYieldOverrideColor,
+		const FColor& VehicleYieldOverrideColor,
+		const UWorld& World,
+		const float LifeTime) const;
 
 	FMassEntityQuery EntityQuery_Vehicles;
 	FMassEntityQuery EntityQuery_Pedestrians;


### PR DESCRIPTION
Before this, vehicles would only be aware of the lead vehicle on any lane.

Additional support for this feature:

- Refactored yield cycle deadlock processor to operate on Lane-Entity
  Pairs.

- Fixed issue where vehicles would sometimes run over pedestrians in the
  crosswalk when the vehicles would enter the intersection.

- Added improved debug visualizations for yield cycle detection,
  resolution, and the full state of all yielding Entities for the
  current frame.
  Set `MassTraffic.DebugYieldDeadlockResolution` to 1 to see them in action.

- Improved yield "stuttering" issues when vehicles are attempting to
  navigate through 2-way and 1-way intersections.

- Enabled merge yield behaviors for criss-crossing lanes, originating
  from the same intersection side.

- Enabled merge yield behavior for traffic light intersections.

- Added fail-safes for pedestrians to resume their motion on crosswalks,
such that unforeseen yield deadlock patterns can be avoided.