### PR TITLE
Add Missing Return When Getting Object Property And ArrayDim != 1

### DIFF
--- a/TempoWorld/Source/TempoWorld/Private/TempoActorControlServiceSubsystem.cpp
+++ b/TempoWorld/Source/TempoWorld/Private/TempoActorControlServiceSubsystem.cpp
@@ -681,7 +681,7 @@ void GetObjectProperties(const UObject* Object, GetPropertiesResponse& Response)
 			// UProperties can be C-style arrays (who knew?), and this will be indicated by a non-1 ArrayDim member.
 			// For example, FPostProcessSettings has FLinearColor LensFlareTints[8]
 			// We don't support these types
-			Type = TEXT("Unsupported");
+			Type = TEXT("unsupported");
 			return;
 		}
 

--- a/TempoWorld/Source/TempoWorld/Private/TempoActorControlServiceSubsystem.cpp
+++ b/TempoWorld/Source/TempoWorld/Private/TempoActorControlServiceSubsystem.cpp
@@ -682,7 +682,9 @@ void GetObjectProperties(const UObject* Object, GetPropertiesResponse& Response)
 			// For example, FPostProcessSettings has FLinearColor LensFlareTints[8]
 			// We don't support these types
 			Type = TEXT("Unsupported");
+			return;
 		}
+
 		if (const FStrProperty* StrProperty = CastField<FStrProperty>(Property))
 		{
 			Type = TEXT("string");


### PR DESCRIPTION
I neglected to add a `return` when catching this unexpected property type (a C-style array).