### PR TITLE
Call PreEditChange and PostEditChange When Setting Struct Property in TempoWorld

### DIFF
--- a/TempoWorld/Source/TempoWorld/Private/TempoActorControlServiceSubsystem.cpp
+++ b/TempoWorld/Source/TempoWorld/Private/TempoActorControlServiceSubsystem.cpp
@@ -1329,7 +1329,22 @@ grpc::Status SetStructPropertyImpl(const UWorld* World, const RequestType& Reque
 	const FString StructCPPName = StructProperty->Struct->GetStructCPPName();
 	if (StructCPPName.Equals(ExpectedStructCPPName))
 	{
+#if WITH_EDITOR
+		if (World->WorldType == EWorldType::Editor)
+		{
+			Object->PreEditChange(Property);
+		}
+#endif
 		StructProperty->SetValue_InContainer(Object, &Value);
+#if WITH_EDITOR
+		if (World->WorldType == EWorldType::Editor)
+		{
+			FPropertyChangedEvent Event(Property);
+			Object->PostEditChangeProperty(Event);
+		}
+#endif
+
+		MarkRenderStateDirty(Object);
 	}
 	else
 	{


### PR DESCRIPTION
We call PreEditChange, PostEditChange, and MarkRenderStateDirty before and after setting single and array properties. Need to do the same for struct properties.