### PR TITLE
Fix Rotation Conversion Bug

### DIFF
--- a/TempoCore/Source/TempoCoreShared/Public/TempoConversion.h
+++ b/TempoCore/Source/TempoCoreShared/Public/TempoConversion.h
@@ -53,36 +53,53 @@ struct QuantityConverter<UC_NONE, R2L>
 
     static FQuat Convert(const FQuat& In)
     {
+        // The vector formed by a quaternion's X, Y, and Z components is aligned with the axis of rotation.
+        // The angle of rotation is proportional to the cosine of the W component.
+        // Converting between handedness involves two steps:
+        // - Converting the handedness of the axis of rotation (negate Y)
+        // - Rotating in the opposite direction (negate X, Y, and Z. W doesn't change because cosine is symmetric)
         return FQuat(-In.X, In.Y, -In.Z, In.W);
     }
 
     static FRotator Convert(const FRotator& In)
     {
-        return FRotator(Convert(In.Quaternion()));
+        // Unreal uses a unique rotation convention:
+        // Intrinsic rotations (Yaw, then Pitch, then Roll) about a left-handed (forward, right, up) coordinate system.
+        // BUT:
+        // - Yaw is left-handed
+        // - Pitch is *right-handed*
+        // - Roll is *right-handed*
+        // So to convert to/from a true right handed (forward, left, up) coordinate system, with the same ordering:
+        // - Negate Yaw (due to handedness)
+        // - Negate Pitch (due to flipped axis)
+        // - Leave Roll (no change needed)
+        return FRotator(-In.Pitch, -In.Yaw, In.Roll);
     }
 };
 
 template<>
 struct QuantityConverter<UC_NONE, L2R>
 {
+    // Handedness conversions are all symmetric
+
     static FVector2D Convert(const FVector2D& In)
     {
-        return FVector2D(In.X, -In.Y);
+        return QuantityConverter<UC_NONE, R2L>::Convert(In);
     }
 
     static FVector Convert(const FVector& In)
     {
-        return FVector(In.X, -In.Y, In.Z);
+        return QuantityConverter<UC_NONE, R2L>::Convert(In);
     }
 
     static FQuat Convert(const FQuat& In)
     {
-        return FQuat(-In.X, In.Y, -In.Z, In.W);
+        return QuantityConverter<UC_NONE, R2L>::Convert(In);
     }
 
     static FRotator Convert(const FRotator& In)
     {
-        return FRotator(Convert(In.Quaternion()));
+        return QuantityConverter<UC_NONE, R2L>::Convert(In);
     }
 };
 


### PR DESCRIPTION
Unreal's `FRotator` uses a unique rotation convention, where yaw is left handed but pitch and roll are *right handed* (all with respect to a left-handed coordinate system). 

See the [comment](https://github.com/EpicGames/UnrealEngine/commit/0b635787f74ad136a5c40663fe1c74e211608ef8#diff-2c5da1cee70a70d751b11b8dbdcb53dfd4193216884c121ead3353c9ebe29c38R31) (added in 5.1 after "experimentation") 

This means our math, which assumes all three have the same handedness, is incorrect. This corrects the mistake and adds clarifying comments to explain handedness conversions for both `FQuat` and `FRotator`.