### PR TITLE
Fix Issue with Rebuilt MassCrowd rpaths on Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,5 @@ FROM ghcr.io/epicgames/unreal-engine:dev-slim-${UNREAL_VERSION}
 
 ENV UNREAL_ENGINE_PATH='/home/ue4/UnrealEngine'
 
-# Unreal can't find these plugins' libraries at runtime or cook time. TODO: Why? Fix this?
-ENV LD_LIBRARY_PATH="/home/ue4/UnrealEngine/Engine/Plugins/AI/MassAI/Binaries/Linux:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/MassGameplay/Binaries/Linux:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/ZoneGraph/Binaries/Linux:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/ZoneGraphAnnotations/Binaries/Linux"
-
 # Install dependencies
 RUN sudo apt-get update && sudo apt-get install -y jq rsync

--- a/EngineMods/5.4/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.3
+++ b/EngineMods/5.4/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.3
@@ -1,6 +1,6 @@
 diff --color -urN --strip-trailing-cr Source/MassCrowd/MassCrowd.Build.cs /Users/pete/Desktop/MassCrowd/Source/MassCrowd/MassCrowd.Build.cs
---- Source/MassCrowd/MassCrowd.Build.cs 2025-04-10 22:00:27
-+++ /Users/pete/Desktop/MassCrowd/Source/MassCrowd/MassCrowd.Build.cs   2025-04-10 22:02:18
+--- Source/MassCrowd/MassCrowd.Build.cs	2024-04-15 18:02:10
++++ /Users/pete/Desktop/MassCrowd/Source/MassCrowd/MassCrowd.Build.cs	2025-04-12 21:14:27
 @@ -1,5 +1,7 @@
  // Copyright Epic Games, Inc. All Rights Reserved.
 
@@ -8,32 +8,32 @@ diff --color -urN --strip-trailing-cr Source/MassCrowd/MassCrowd.Build.cs /Users
 +
  namespace UnrealBuildTool.Rules
  {
-        public class MassCrowd: ModuleRules
-@@ -34,10 +36,25 @@
-                                        "ZoneGraph",
-                                        "ZoneGraphAnnotations",
-                                        "ZoneGraphDebug"
-+                               }
-+                       );
+ 	public class MassCrowd: ModuleRules
+@@ -36,8 +38,25 @@
+ 					"ZoneGraphDebug"
+ 				}
+ 			);
 +
-+                       // Added by Tempo. We needed to make some mods to this plugin. To do so, we copied it out of the engine,
-+                       // applied our mods to the source, rebuilt it, and copied the result back. The only wrinkle is the rpaths
-+                       // in the dynamic libraries are then relative to the location we built it, not it's final destination in the
-+                       // engine (and no, it's not allowed to re-build a plugin in-place in the engine). So we use these here to
-+                       // add the correct rpaths relative to the final destination for this plugin.
-+                       PublicRuntimeLibraryPaths.AddRange(
-+                               new string[] {
-+                                       Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "MassGameplay", "Binaries", Target.Platform.ToString()),
-+                                       Path.Combine("..", "..", "..", "..", "..", "Plugins", "AI", "MassAI", "Binaries", Target.Platform.ToString()),
-+                                       Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "StateTree", "Binaries", Target.Platform.ToString()),
-+                                       Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "ZoneGraph", "Binaries", Target.Platform.ToString()),
-+                                       Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "ZoneGraphAnnotations", "Binaries", Target.Platform.ToString()),
-                                }
-                        );
++			// TEMPO_MOD Begin - [For Fixing rpaths of Rebuilt Engine Plugins] - Manually add rpaths for plugin dependencies
++			// Added by Tempo. We needed to make some mods to this plugin. To do so, we copied it out of the engine,
++			// applied our mods to the source, rebuilt it, and copied the result back. The only wrinkle is the rpaths
++			// in the dynamic libraries are then relative to the location we built it, not it's final destination in the
++			// engine (and no, it's not allowed to re-build a plugin in-place in the engine). So we use these here to
++			// add the correct rpaths relative to the final destination for this plugin.
++			PublicRuntimeLibraryPaths.AddRange(
++					new string[] {
++							Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "MassGameplay", "Binaries", Target.Platform.ToString()),
++							Path.Combine("..", "..", "..", "..", "..", "Plugins", "AI", "MassAI", "Binaries", Target.Platform.ToString()),
++							Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "StateTree", "Binaries", Target.Platform.ToString()),
++							Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "ZoneGraph", "Binaries", Target.Platform.ToString()),
++							Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "ZoneGraphAnnotations", "Binaries", Target.Platform.ToString()),
++				}
++			);
++			// TEMPO_MOD End
 
-                        SetupIrisSupport(Target);
-                }
-        }
+ 			SetupIrisSupport(Target);
+ 		}
+ 	}
 -}
 \ No newline at end of file
 +}

--- a/EngineMods/5.4/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.3
+++ b/EngineMods/5.4/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.3
@@ -1,0 +1,39 @@
+diff --color -urN --strip-trailing-cr Source/MassCrowd/MassCrowd.Build.cs /Users/pete/Desktop/MassCrowd/Source/MassCrowd/MassCrowd.Build.cs
+--- Source/MassCrowd/MassCrowd.Build.cs 2025-04-10 22:00:27
++++ /Users/pete/Desktop/MassCrowd/Source/MassCrowd/MassCrowd.Build.cs   2025-04-10 22:02:18
+@@ -1,5 +1,7 @@
+ // Copyright Epic Games, Inc. All Rights Reserved.
+
++using System.IO;
++
+ namespace UnrealBuildTool.Rules
+ {
+        public class MassCrowd: ModuleRules
+@@ -34,10 +36,25 @@
+                                        "ZoneGraph",
+                                        "ZoneGraphAnnotations",
+                                        "ZoneGraphDebug"
++                               }
++                       );
++
++                       // Added by Tempo. We needed to make some mods to this plugin. To do so, we copied it out of the engine,
++                       // applied our mods to the source, rebuilt it, and copied the result back. The only wrinkle is the rpaths
++                       // in the dynamic libraries are then relative to the location we built it, not it's final destination in the
++                       // engine (and no, it's not allowed to re-build a plugin in-place in the engine). So we use these here to
++                       // add the correct rpaths relative to the final destination for this plugin.
++                       PublicRuntimeLibraryPaths.AddRange(
++                               new string[] {
++                                       Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "MassGameplay", "Binaries", Target.Platform.ToString()),
++                                       Path.Combine("..", "..", "..", "..", "..", "Plugins", "AI", "MassAI", "Binaries", Target.Platform.ToString()),
++                                       Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "StateTree", "Binaries", Target.Platform.ToString()),
++                                       Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "ZoneGraph", "Binaries", Target.Platform.ToString()),
++                                       Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "ZoneGraphAnnotations", "Binaries", Target.Platform.ToString()),
+                                }
+                        );
+
+                        SetupIrisSupport(Target);
+                }
+        }
+-}
+\ No newline at end of file
++}

--- a/EngineMods/5.4/Engine/Source/Programs/UnrealBuildTool/Platform/Linux/LinuxToolChain.cs.patch.1
+++ b/EngineMods/5.4/Engine/Source/Programs/UnrealBuildTool/Platform/Linux/LinuxToolChain.cs.patch.1
@@ -1,12 +1,14 @@
 --- Platform/Linux/LinuxToolChain.cs	2025-04-11 10:07:25
 +++ LinuxToolChain.cs	2025-04-11 11:40:07
-@@ -1251,7 +1251,8 @@
+@@ -1251,7 +1251,10 @@
  			{
  				string RelativePath = RuntimeLibaryPath;
  
 -				if (!RelativePath.StartsWith("$"))
-+				// StartsWith(".") added by Tempo to allow RuntimeLibraryPath to actually be treated as relative
++				// TEMPO_MOD Begin - [For Fixing rpaths of Rebuilt Engine Plugins] - Avoid making RelativePath relative
++				// to the build output when it starts with "." (in addition to "$", which was already here).
 +				if (!RelativePath.StartsWith("$") && !RelativePath.StartsWith("."))
++				// TEMPO_MOD End
  				{
  					if (LinkEnvironment.bIsBuildingDLL)
  					{

--- a/EngineMods/5.4/Engine/Source/Programs/UnrealBuildTool/Platform/Linux/LinuxToolChain.cs.patch.1
+++ b/EngineMods/5.4/Engine/Source/Programs/UnrealBuildTool/Platform/Linux/LinuxToolChain.cs.patch.1
@@ -1,0 +1,12 @@
+--- Platform/Linux/LinuxToolChain.cs	2025-04-11 10:07:25
++++ LinuxToolChain.cs	2025-04-11 11:40:07
+@@ -1251,7 +1251,8 @@
+ 			{
+ 				string RelativePath = RuntimeLibaryPath;
+ 
+-				if (!RelativePath.StartsWith("$"))
++				// StartsWith(".") added by Tempo to allow RuntimeLibraryPath to actually be treated as relative
++				if (!RelativePath.StartsWith("$") && !RelativePath.StartsWith("."))
+ 				{
+ 					if (LinkEnvironment.bIsBuildingDLL)
+ 					{

--- a/EngineMods/EngineMods.json
+++ b/EngineMods/EngineMods.json
@@ -10,7 +10,8 @@
         "ToolChain/TempoVCToolChain.cs"
       ],
       "Patch": [
-        "Configuration/UEBuildTarget.cs.patch.1"
+        "Configuration/UEBuildTarget.cs.patch.1",
+        "Platform/Linux/LinuxToolChain.cs.patch.1"
       ]
     },
     {
@@ -28,7 +29,8 @@
       "Root": "Engine/Plugins/AI/MassCrowd",
       "Patch": [
         "MassCrowd.patch.1",
-        "MassCrowd.patch.2"
+        "MassCrowd.patch.2",
+        "MassCrowd.patch.3"
       ]
     }
   ]


### PR DESCRIPTION
We noticed an issue on Linux where, sometimes but not always, MassCrowd plugin fails to load because it cannot find the dynamic libraries of its dependent engine plugins. This issue is caused by the way we rebuild MassCrowd with Tempo mods. To rebuild it, we copy it outside the engine, apply our mods, and then copy the rebuilt plugin back in. This strategy is both desirable (it prevents dirtying the working MassCrowd plugin if our rebuild fails or is interrupted) and required (UBT refuses to re-build a plugin in the engine folder). However, UBT adds rpaths, which the MassCrowd dynamic libraries will use to search for their dependent dynamic libraries during the rebuild. These rpaths are relative to the location where the plugin is built, so when we copy it back they're wrong.

If we were distributing a plugin as a binary we could fix up the rpaths by hand (as Cesium [does](https://github.com/CesiumGS/cesium-unreal/issues/988), when facing the same issue), but there's no built-in way to do that in Linux so we can't do it automatically without forcing the user to install some new dependencies.

So, instead we manually add the correct rpaths in the Build.cs file, via `PublicRuntimeLibraryPaths`. No problem.

But wait, one more thing: `LinuxToolChain.cs` reinterprets RuntimeLibraryPaths as relative to the build target, which re-introduces exactly the same problem we had in the first place. Unless the path starts with `$`, and I'm honestly not sure what that's for. So, we add one more case for which to not reinterpret the path: when it starts with `.`.