### PR TITLE
Add Support for UE 5.5

### DIFF
--- a/.github/workflows/build_and_package.yml
+++ b/.github/workflows/build_and_package.yml
@@ -99,7 +99,7 @@ jobs:
     name: Build and Package Project
     runs-on: ${{ inputs.platform }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}-${{ inputs.unreal_version }}
       cancel-in-progress: true
     steps:
     - name: Validate Inputs
@@ -112,9 +112,9 @@ jobs:
             ;;
         esac
         case "${{ inputs.unreal_version }}" in
-          "5.4.4") ;;
+          "5.4.4"|"5.5.4") ;;
           *)
-            echo "Error: Invalid Unreal Version. Only 5.4.4 supported for now."
+            echo "Error: Invalid Unreal Version. Only 5.4.4 and 5.5.4 are supported."
             exit 1
             ;;
         esac
@@ -193,6 +193,7 @@ jobs:
           .engine-mods-cache/TempoMods/**
           .engine-mods-cache/Engine/Plugins/Runtime/ZoneGraph/**
           .engine-mods-cache/Engine/Plugins/AI/MassCrowd/**
+          .engine-mods-cache/Engine/Plugins/Runtime/MassEntity/**
           .engine-mods-cache/Engine/Source/Programs/UnrealBuildTool/**
           .engine-mods-cache/Engine/Binaries/DotNET/UnrealBuildTool/**
           .engine-mods-cache/Engine/Binaries/DotNET/AutomationTool/**
@@ -258,6 +259,7 @@ jobs:
         docker create --name temp_engine tempo_unreal_image
         docker cp temp_engine:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/ZoneGraph ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime
         docker cp temp_engine:/home/ue4/UnrealEngine/Engine/Plugins/AI/MassCrowd ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/AI
+        docker cp temp_engine:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/MassEntity ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime
         docker cp temp_engine:/home/ue4/UnrealEngine/Engine/Source/Programs/UnrealBuildTool ${{ github.workspace }}/.engine-mods-cache/Engine/Source/Programs
         docker cp temp_engine:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/UnrealBuildTool ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET
         docker cp temp_engine:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/AutomationTool ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET
@@ -282,6 +284,7 @@ jobs:
           -v ${{ github.workspace }}/.engine-mods-cache/TempoMods:/home/ue4/UnrealEngine/TempoMods \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/ZoneGraph:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/ZoneGraph \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/AI/MassCrowd:/home/ue4/UnrealEngine/Engine/Plugins/AI/MassCrowd \
+          -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/MassEntity:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/MassEntity \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Source/Programs/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Source/Programs/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/AutomationTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/AutomationTool \
@@ -295,6 +298,7 @@ jobs:
           -v ${{ github.workspace }}/.engine-mods-cache/TempoMods:/home/ue4/UnrealEngine/TempoMods \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/ZoneGraph:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/ZoneGraph \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/AI/MassCrowd:/home/ue4/UnrealEngine/Engine/Plugins/AI/MassCrowd \
+          -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/MassEntity:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/MassEntity \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Source/Programs/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Source/Programs/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/AutomationTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/AutomationTool \
@@ -309,6 +313,7 @@ jobs:
           -v ${{ github.workspace }}/.engine-mods-cache/TempoMods:/home/ue4/UnrealEngine/TempoMods \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/ZoneGraph:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/ZoneGraph \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/AI/MassCrowd:/home/ue4/UnrealEngine/Engine/Plugins/AI/MassCrowd \
+          -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/MassEntity:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/MassEntity \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Source/Programs/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Source/Programs/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/AutomationTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/AutomationTool \
@@ -322,6 +327,7 @@ jobs:
           -v ${{ github.workspace }}/.engine-mods-cache/TempoMods:/home/ue4/UnrealEngine/TempoMods \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/ZoneGraph:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/ZoneGraph \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/AI/MassCrowd:/home/ue4/UnrealEngine/Engine/Plugins/AI/MassCrowd \
+          -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/MassEntity:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/MassEntity \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Source/Programs/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Source/Programs/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/AutomationTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/AutomationTool \
@@ -346,6 +352,7 @@ jobs:
           -v ${{ github.workspace }}/.engine-mods-cache/TempoMods:/home/ue4/UnrealEngine/TempoMods \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/ZoneGraph:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/ZoneGraph \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/AI/MassCrowd:/home/ue4/UnrealEngine/Engine/Plugins/AI/MassCrowd \
+          -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/MassEntity:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/MassEntity \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Source/Programs/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Source/Programs/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/AutomationTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/AutomationTool \
@@ -362,6 +369,7 @@ jobs:
           -v ${{ github.workspace }}/.engine-mods-cache/TempoMods:/home/ue4/UnrealEngine/TempoMods \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/ZoneGraph:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/ZoneGraph \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/AI/MassCrowd:/home/ue4/UnrealEngine/Engine/Plugins/AI/MassCrowd \
+          -v ${{ github.workspace }}/.engine-mods-cache/Engine/Plugins/Runtime/MassEntity:/home/ue4/UnrealEngine/Engine/Plugins/Runtime/MassEntity \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Source/Programs/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Source/Programs/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/UnrealBuildTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/UnrealBuildTool \
           -v ${{ github.workspace }}/.engine-mods-cache/Engine/Binaries/DotNET/AutomationTool:/home/ue4/UnrealEngine/Engine/Binaries/DotNET/AutomationTool \
@@ -398,6 +406,7 @@ jobs:
           .engine-mods-cache/TempoMods/**
           .engine-mods-cache/Engine/Plugins/Runtime/ZoneGraph/**
           .engine-mods-cache/Engine/Plugins/AI/MassCrowd/**
+          .engine-mods-cache/Engine/Plugins/Runtime/MassEntity/**
           .engine-mods-cache/Engine/Source/Programs/UnrealBuildTool/**
           .engine-mods-cache/Engine/Binaries/DotNET/UnrealBuildTool/**
           .engine-mods-cache/Engine/Binaries/DotNET/AutomationTool/**

--- a/.github/workflows/tempo_build_and_package.yml
+++ b/.github/workflows/tempo_build_and_package.yml
@@ -23,7 +23,8 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-22.04 ]
-        unreal_version: [ 5.4.4 ]
+        unreal_version: [ 5.4.4, 5.5.4 ]
+      fail-fast: false
     with:
       platform: ${{ matrix.platform }}
       unreal_version: ${{ matrix.unreal_version }}

--- a/EngineMods/5.4/Engine/Plugins/Runtime/MassEntity/MassEntity.patch.1
+++ b/EngineMods/5.4/Engine/Plugins/Runtime/MassEntity/MassEntity.patch.1
@@ -1,0 +1,58 @@
+diff --color -urN --strip-trailing-cr Source/MassEntity/Public/MassEntityTypes.h /Users/pete/Desktop/MassEntity/Source/MassEntity/Public/MassEntityTypes.h
+--- Source/MassEntity/Public/MassEntityTypes.h	2024-06-04 07:20:35
++++ /Users/pete/Desktop/MassEntity/Source/MassEntity/Public/MassEntityTypes.h	2025-04-11 09:59:49
+@@ -51,6 +51,16 @@
+ 	FMassSharedFragment() {}
+ };
+
++// FMassConstSharedFragment was added in UE 5.5. Unfortunately, due to UHT constraints, preprocessor macros cannot be
++// used to change the parent of a USTRUCT, add  USTRUCT, or any other lighter-touch workaround, so we backport it here.
++USTRUCT()
++struct FMassConstSharedFragment : public FMassSharedFragment
++{
++        GENERATED_BODY()
++
++        FMassConstSharedFragment() {}
++};
++
+ // A handle to a lightweight entity.  An entity is used in conjunction with the FMassEntityManager
+ // for the current world and can contain lightweight fragments.
+ USTRUCT()
+diff --color -urN --strip-trailing-cr /Users/pete/Desktop/MassEntity/Source/MassEntity/MassEntity.Build.cs Source/MassEntity/MassEntity.Build.cs
+--- Source/MassEntity/MassEntity.Build.cs	2025-04-12 22:15:57
++++ /Users/pete/Desktop/MassEntity/Source/MassEntity/MassEntity.Build.cs	2025-04-12 21:54:59
+@@ -1,5 +1,7 @@
+ // Copyright Epic Games, Inc. All Rights Reserved.
+
++using System.IO;
++
+ namespace UnrealBuildTool.Rules
+ {
+ 	public class MassEntity : ModuleRules
+@@ -17,6 +19,19 @@
+ 					"DeveloperSettings",
+ 				}
+ 			);
++
++			// TEMPO_MOD Begin - [For Fixing rpaths of Rebuilt Engine Plugins] - Manually add rpaths for plugin dependencies
++			// Added by Tempo. We needed to make some mods to this plugin. To do so, we copied it out of the engine,
++			// applied our mods to the source, rebuilt it, and copied the result back. The only wrinkle is the rpaths
++			// in the dynamic libraries are then relative to the location we built it, not it's final destination in the
++			// engine (and no, it's not allowed to re-build a plugin in-place in the engine). So we use these here to
++			// add the correct rpaths relative to the final destination for this plugin.
++			PublicRuntimeLibraryPaths.AddRange(
++					new string[] {
++							Path.Combine("..", "..", "..", "..", "..", "Plugins", "Experimental", "StructUtils", "Binaries", Target.Platform.ToString()),
++				}
++			);
++			// TEMPO_MOD End
+
+ 			if (Target.bBuildEditor || Target.bCompileAgainstEditor)
+ 			{
+@@ -30,4 +45,4 @@
+ 			}
+ 		}
+ 	}
+-}
+\ No newline at end of file
++}

--- a/EngineMods/5.4/Engine/Source/Programs/UnrealBuildTool/Configuration/UEBuildTarget.cs.patch.2
+++ b/EngineMods/5.4/Engine/Source/Programs/UnrealBuildTool/Configuration/UEBuildTarget.cs.patch.2
@@ -1,0 +1,12 @@
+--- Configuration/UEBuildTarget.cs	2025-04-12 12:55:13
++++ /Users/pete/Desktop/Configuration/UEBuildTarget.cs	2025-04-12 12:56:40
+@@ -3191,6 +3191,10 @@
+ 			{
+ 				return true;
+ 			}
++			if (PluginModuleName == "MassEntity" || PluginModuleName == "MassEntityTestSuite" || PluginModuleName == "MassEntityEditor")
++			{
++				return true;
++			}
+ 			return false;
+ 		}

--- a/EngineMods/5.5/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.1
+++ b/EngineMods/5.5/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.1
@@ -1,0 +1,289 @@
+diff -urN --strip-trailing-cr Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp"
+--- Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp	2023-06-01 08:28:46.000000000 -0400
++++ "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp"	2024-12-16 22:10:20.235534200 -0500
+@@ -9,11 +9,14 @@
+ #include "MassEntityManager.h"
+ #include "MassMovementFragments.h"
+ #include "MassCrowdSettings.h"
++#include "MassEntityView.h"
+ #include "ZoneGraphAnnotationSubsystem.h"
+ #include "MassZoneGraphNavigationFragments.h"
+ #include "Annotations/ZoneGraphDisturbanceAnnotation.h"
+ #include "MassSimulationLOD.h"
+ #include "MassSignalSubsystem.h"
++#include "ZoneGraphSubsystem.h"
++#include "MassGameplayExternalTraits.h"
+ 
+ //----------------------------------------------------------------------//
+ // UMassCrowdLaneTrackingSignalProcessor
+@@ -62,6 +65,173 @@
+ }
+ 
+ //----------------------------------------------------------------------//
++// UMassCrowdUpdateTrackingLaneProcessor
++//----------------------------------------------------------------------//
++UMassCrowdUpdateTrackingLaneProcessor::UMassCrowdUpdateTrackingLaneProcessor()
++	: EntityQuery(*this)
++{
++	ExecutionOrder.ExecuteAfter.Add(UE::Mass::ProcessorGroupNames::Tasks);
++}
++
++void UMassCrowdUpdateTrackingLaneProcessor::ConfigureQueries()
++{
++	EntityQuery.AddTagRequirement<FMassCrowdTag>(EMassFragmentPresence::All);
++	
++	ProcessorRequirements.AddSubsystemRequirement<UMassCrowdSubsystem>(EMassFragmentAccess::ReadWrite);
++	ProcessorRequirements.AddSubsystemRequirement<UZoneGraphSubsystem>(EMassFragmentAccess::ReadOnly);
++}
++
++void UMassCrowdUpdateTrackingLaneProcessor::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
++{
++	// Gather all Crowd Entities.
++	TArray<FMassEntityHandle> AllCrowdEntities;
++	EntityQuery.ForEachEntityChunk(EntityManager, Context, [&](const FMassExecutionContext& QueryContext)
++	{
++		const int32 NumEntities = QueryContext.GetNumEntities();
++		for (int32 Index = 0; Index < NumEntities; ++Index)
++		{
++			AllCrowdEntities.Add(QueryContext.GetEntity(Index));
++		}
++	});
++	
++	if (AllCrowdEntities.IsEmpty())
++	{
++		return;
++	}
++	
++	// Sort by ZoneGraphStorage Index, then Lane Index, then *ascending* DistanceAlongLane.
++	AllCrowdEntities.Sort(
++		[&EntityManager](const FMassEntityHandle& EntityA, const FMassEntityHandle& EntityB)
++		{
++			const FMassZoneGraphLaneLocationFragment& A = EntityManager.GetFragmentDataChecked<FMassZoneGraphLaneLocationFragment>(EntityA);
++			const FMassZoneGraphLaneLocationFragment& B = EntityManager.GetFragmentDataChecked<FMassZoneGraphLaneLocationFragment>(EntityB);
++
++			if (A.LaneHandle == B.LaneHandle)
++			{
++				return A.DistanceAlongLane < B.DistanceAlongLane;
++			}
++			else if (A.LaneHandle.DataHandle == B.LaneHandle.DataHandle)
++			{
++				return A.LaneHandle.Index < B.LaneHandle.Index;
++			}
++			else
++			{
++				return A.LaneHandle.DataHandle.Index < B.LaneHandle.DataHandle.Index;
++			}
++		}
++	);
++
++	const TArray<FMassEntityHandle>& AscendingCrowdEntities = AllCrowdEntities;
++	TArray<FMassEntityHandle> DescendingCrowdEntities(AllCrowdEntities);
++	
++	// Sort by ZoneGraphStorage Index, then Lane Index, then *descending* DistanceAlongLane.
++	DescendingCrowdEntities.Sort(
++		[&EntityManager](const FMassEntityHandle& EntityA, const FMassEntityHandle& EntityB)
++		{
++			const FMassZoneGraphLaneLocationFragment& A = EntityManager.GetFragmentDataChecked<FMassZoneGraphLaneLocationFragment>(EntityA);
++			const FMassZoneGraphLaneLocationFragment& B = EntityManager.GetFragmentDataChecked<FMassZoneGraphLaneLocationFragment>(EntityB);
++
++			if (A.LaneHandle == B.LaneHandle)
++			{
++				return A.DistanceAlongLane > B.DistanceAlongLane;
++			}
++			else if (A.LaneHandle.DataHandle == B.LaneHandle.DataHandle)
++			{
++				return A.LaneHandle.Index < B.LaneHandle.Index;
++			}
++			else
++			{
++				return A.LaneHandle.DataHandle.Index < B.LaneHandle.DataHandle.Index;
++			}
++		}
++	);
++
++	UMassCrowdSubsystem& MassCrowdSubsystem = Context.GetMutableSubsystemChecked<UMassCrowdSubsystem>();
++	const UZoneGraphSubsystem& ZoneGraphSubsystem = Context.GetSubsystemChecked<UZoneGraphSubsystem>();
++
++	// First, we need to reset the "distance along lane" fields for the "lead" and "tail" Entities.
++	TConstArrayView<FRegisteredZoneGraphData> RegisteredZoneGraphDatas = ZoneGraphSubsystem.GetRegisteredZoneGraphData();
++	for (const FRegisteredZoneGraphData& RegisteredZoneGraphData : RegisteredZoneGraphDatas)
++	{
++		if (!ensureMsgf(RegisteredZoneGraphData.ZoneGraphData != nullptr, TEXT("Must get valid RegisteredZoneGraphData.ZoneGraphData in UMassCrowdUpdateTrackingLaneProcessor::Execute.")))
++		{
++			continue;
++		}
++		
++		const FZoneGraphStorage& ZoneGraphStorage = RegisteredZoneGraphData.ZoneGraphData->GetStorage();
++		FRegisteredCrowdLaneData* RegisteredCrowdLaneData = MassCrowdSubsystem.GetMutableCrowdData(ZoneGraphStorage.DataHandle);
++
++		if (!ensureMsgf(RegisteredCrowdLaneData != nullptr, TEXT("Must get valid RegisteredCrowdLaneData in UMassCrowdUpdateTrackingLaneProcessor::Execute.")))
++		{
++			continue;
++		}
++
++		for (TTuple<int32, FCrowdTrackingLaneData>& RegisteredCrowdLaneDataPair : RegisteredCrowdLaneData->LaneToTrackingDataLookup)
++		{
++			FCrowdTrackingLaneData& RegisteredCrowdTrackingLaneData = RegisteredCrowdLaneDataPair.Value;
++			RegisteredCrowdTrackingLaneData.LeadEntityNormalizedDistanceAlongLane.Reset();
++			RegisteredCrowdTrackingLaneData.TailEntityNormalizedDistanceAlongLane.Reset();
++		}
++	}
++
++	// Then, update the "distance along lane" fields for the "lead" and "tail" Entities.
++	for (int32 SortedCrowdEntityIndex = 0; SortedCrowdEntityIndex < AscendingCrowdEntities.Num(); ++SortedCrowdEntityIndex)
++	{
++		// First, update the field for the "lead" Entity.
++		const FMassEntityHandle LeadEntityHandle = DescendingCrowdEntities[SortedCrowdEntityIndex];
++			
++		const FMassEntityView LeadEntityView(EntityManager, LeadEntityHandle);
++		const FMassZoneGraphLaneLocationFragment& LeadEntityLaneLocation = LeadEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
++
++		if (LeadEntityLaneLocation.LaneLength > 0.0f)
++		{
++			FCrowdTrackingLaneData* LeadEntityCrowdTrackingLaneData = MassCrowdSubsystem.GetMutableCrowdTrackingLaneData(LeadEntityLaneLocation.LaneHandle);
++			
++			if (LeadEntityCrowdTrackingLaneData == nullptr)
++			{
++				continue;
++			}
++
++			// We only set the LeadEntityNormalizedDistanceAlongLane value for a given lane, if it hasn't already been set.
++			// And, since we're indexing into DescendingCrowdEntities, which has been sorted by descending DistanceAlongLane,
++			// the first Entity to be indexed for a given lane will in fact be the "Lead Entity" for that lane,
++			// and it will have the first (and only) opportunity to set the LeadEntityNormalizedDistanceAlongLane field.
++			if (!LeadEntityCrowdTrackingLaneData->LeadEntityNormalizedDistanceAlongLane.IsSet())
++			{
++				const float NormalizedDistanceAlongLane = LeadEntityLaneLocation.DistanceAlongLane / LeadEntityLaneLocation.LaneLength;
++				LeadEntityCrowdTrackingLaneData->LeadEntityNormalizedDistanceAlongLane = NormalizedDistanceAlongLane;
++			}
++		}
++
++		// Then, update the field for the "tail" Entity.
++		const FMassEntityHandle TailEntityHandle = AscendingCrowdEntities[SortedCrowdEntityIndex];
++			
++		const FMassEntityView TailEntityView(EntityManager, TailEntityHandle);
++		const FMassZoneGraphLaneLocationFragment& TailEntityLaneLocation = TailEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
++
++		if (TailEntityLaneLocation.LaneLength > 0.0f)
++		{
++			FCrowdTrackingLaneData* TailEntityCrowdTrackingLaneData = MassCrowdSubsystem.GetMutableCrowdTrackingLaneData(TailEntityLaneLocation.LaneHandle);
++			
++			if (TailEntityCrowdTrackingLaneData == nullptr)
++			{
++				continue;
++			}
++
++			// We only set the TailEntityNormalizedDistanceAlongLane value for a given lane, if it hasn't already been set.
++			// And, since we're indexing into AscendingCrowdEntities, which has been sorted by ascending DistanceAlongLane,
++			// the first Entity to be indexed for a given lane will in fact be the "Tail Entity" for that lane,
++			// and it will have the first (and only) opportunity to set the TailEntityNormalizedDistanceAlongLane field.
++			if (!TailEntityCrowdTrackingLaneData->TailEntityNormalizedDistanceAlongLane.IsSet())
++			{
++				const float NormalizedDistanceAlongLane = TailEntityLaneLocation.DistanceAlongLane / TailEntityLaneLocation.LaneLength;
++				TailEntityCrowdTrackingLaneData->TailEntityNormalizedDistanceAlongLane = NormalizedDistanceAlongLane;
++			}
++		}
++	}
++}
++
++//----------------------------------------------------------------------//
+ // UMassCrowdLaneTrackingDestructor
+ //----------------------------------------------------------------------//
+ UMassCrowdLaneTrackingDestructor::UMassCrowdLaneTrackingDestructor()
+diff -urN --strip-trailing-cr Source/MassCrowd/Private/MassCrowdSubsystem.cpp "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Private/MassCrowdSubsystem.cpp"
+--- Source/MassCrowd/Private/MassCrowdSubsystem.cpp	2024-03-29 04:15:28.000000000 -0400
++++ "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Private/MassCrowdSubsystem.cpp"	2024-12-16 22:10:20.253042400 -0500
+@@ -261,6 +261,11 @@
+ 	return CrowdLaneData.LaneToTrackingDataLookup.Find(LaneHandle.Index);
+ }
+ 
++FCrowdTrackingLaneData* UMassCrowdSubsystem::GetMutableCrowdTrackingLaneData(const FZoneGraphLaneHandle LaneHandle) const
++{
++	return const_cast<FCrowdTrackingLaneData*>(GetCrowdTrackingLaneData(LaneHandle));
++}
++
+ const FCrowdBranchingLaneData* UMassCrowdSubsystem::GetCrowdBranchingLaneData(const FZoneGraphLaneHandle LaneHandle) const
+ {
+ 	if (!ensureMsgf(LaneHandle.IsValid(), TEXT("Invalid lane handle: returning a null entry.")))
+@@ -363,6 +368,11 @@
+ 	return &LanesData;
+ }
+ 
++FRegisteredCrowdLaneData* UMassCrowdSubsystem::GetMutableCrowdData(const FZoneGraphDataHandle DataHandle) const
++{
++	return const_cast<FRegisteredCrowdLaneData*>(GetCrowdData(DataHandle));
++}
++
+ void UMassCrowdSubsystem::OnEntityLaneChanged(const FMassEntityHandle Entity, const FZoneGraphLaneHandle PreviousLaneHandle, const FZoneGraphLaneHandle CurrentLaneHandle)
+ {
+ 	const bool bPreviousLocationValid = PreviousLaneHandle.IsValid();
+diff -urN --strip-trailing-cr Source/MassCrowd/Public/MassCrowdNavigationProcessor.h "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdNavigationProcessor.h"
+--- Source/MassCrowd/Public/MassCrowdNavigationProcessor.h	2023-06-01 08:28:40.000000000 -0400
++++ "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdNavigationProcessor.h"	2024-12-16 22:10:20.263042700 -0500
+@@ -24,6 +24,21 @@
+ 	virtual void SignalEntities(FMassEntityManager& EntityManager, FMassExecutionContext& Context, FMassSignalNameLookup& EntitySignals) override;
+ };
+ 
++UCLASS()
++class MASSCROWD_API UMassCrowdUpdateTrackingLaneProcessor : public UMassProcessor
++{
++	GENERATED_BODY()
++public:
++	UMassCrowdUpdateTrackingLaneProcessor();
++
++protected:
++	
++	virtual void ConfigureQueries() override;
++	virtual void Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context) override;
++	
++	FMassEntityQuery EntityQuery;
++};
++
+ /** Processors that cleans up the lane tracking on entity destruction. */
+ UCLASS()
+ class MASSCROWD_API UMassCrowdLaneTrackingDestructor : public UMassObserverProcessor
+diff -urN --strip-trailing-cr Source/MassCrowd/Public/MassCrowdSubsystem.h "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdSubsystem.h"
+--- Source/MassCrowd/Public/MassCrowdSubsystem.h	2024-03-29 04:15:26.000000000 -0400
++++ "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdSubsystem.h"	2024-12-16 22:10:20.279076900 -0500
+@@ -84,6 +84,14 @@
+ 	const FRegisteredCrowdLaneData* GetCrowdData(const FZoneGraphDataHandle DataHandle) const;
+ 
+ 	/**
++	 * Returns the readonly runtime data associated to a given zone graph.
++	 * @param DataHandle A valid handle of the zone graph used to retrieve the runtime crowd data
++	 * @return Runtime data associated to the zone graph if available; nullptr otherwise
++	 * @note Method will ensure if DataHandle is invalid or if associated data doesn't exist. Should call HasCrowdDataForZoneGraph first.
++	 */
++	FRegisteredCrowdLaneData* GetMutableCrowdData(const FZoneGraphDataHandle DataHandle) const;
++
++	/**
+ 	 * Returns the readonly runtime data associated to a given zone graph lane.
+ 	 * @param LaneHandle A valid lane handle used to retrieve the runtime data; ensure if handle is invalid
+ 	 * @return Runtime data associated to the lane (if available)
+@@ -98,6 +106,13 @@
+ 	const FCrowdTrackingLaneData* GetCrowdTrackingLaneData(const FZoneGraphLaneHandle LaneHandle) const;
+ 
+ 	/**
++	 * Returns the entity tracking runtime data associated to a given zone graph lane.
++	 * @param LaneHandle A valid lane handle used to retrieve the associated tracking data; ensure if handle is invalid
++	 * @return Runtime data associated to the lane (nullptr if provided handle is invalid or no data is associated to that lane)
++	 */
++	FCrowdTrackingLaneData* GetMutableCrowdTrackingLaneData(const FZoneGraphLaneHandle LaneHandle) const;
++
++	/**
+ 	 * Returns the branching data associated to a given zone graph lane.
+  	 * @param LaneHandle A valid lane handle used to retrieve the associated data; ensure if handle is invalid
+ 	 * @return Branching data associated to the lane (nullptr if provided handle is invalid or no data is associated to that lane)
+diff -urN --strip-trailing-cr Source/MassCrowd/Public/MassCrowdTypes.h "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdTypes.h"
+--- Source/MassCrowd/Public/MassCrowdTypes.h	2023-06-01 08:28:40.000000000 -0400
++++ "/media/giovanni/OS/Program Files/Epic Games/UE_5.4/Engine/Plugins/AI/MassCrowd/Source/MassCrowd/Public/MassCrowdTypes.h"	2024-12-16 22:10:20.297043300 -0500
+@@ -57,6 +57,9 @@
+ 	int32 WaitAreaIndex = INDEX_NONE;
+ 
+ 	int32 NumEntitiesOnLane = 0;
++	
++	TOptional<float> LeadEntityNormalizedDistanceAlongLane;
++	TOptional<float> TailEntityNormalizedDistanceAlongLane;
+ };
+ 
+ /** Runtime data associated to lane that can be used to wait another one to open. */

--- a/EngineMods/5.5/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.2
+++ b/EngineMods/5.5/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.2
@@ -1,0 +1,170 @@
+diff -urN --strip-trailing-cr Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp /home/giovanni/Develop/VayuSim/Plugins/Tempo/External/MassCrowd/Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp
+--- Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp	2025-03-10 19:08:17.830935324 -0400
++++ /home/giovanni/Develop/VayuSim/Plugins/Tempo/External/MassCrowd/Source/MassCrowd/Private/MassCrowdNavigationProcessor.cpp	2025-03-10 17:18:45.929878760 -0400
+@@ -17,6 +17,7 @@
+ #include "MassSignalSubsystem.h"
+ #include "ZoneGraphSubsystem.h"
+ #include "MassGameplayExternalTraits.h"
++#include "ZoneGraphQuery.h"
+ 
+ //----------------------------------------------------------------------//
+ // UMassCrowdLaneTrackingSignalProcessor
+@@ -67,6 +68,10 @@
+ //----------------------------------------------------------------------//
+ // UMassCrowdUpdateTrackingLaneProcessor
+ //----------------------------------------------------------------------//
++
++// Important:  UMassCrowdUpdateTrackingLaneProcessor is meant to run before
++// UMassTrafficVehicleControlProcessor and UMassTrafficCrowdYieldProcessor.
++// So, this must be setup in DefaultMass.ini.
+ UMassCrowdUpdateTrackingLaneProcessor::UMassCrowdUpdateTrackingLaneProcessor()
+ 	: EntityQuery(*this)
+ {
+@@ -76,6 +81,9 @@
+ void UMassCrowdUpdateTrackingLaneProcessor::ConfigureQueries()
+ {
+ 	EntityQuery.AddTagRequirement<FMassCrowdTag>(EMassFragmentPresence::All);
++	EntityQuery.AddRequirement<FMassVelocityFragment>(EMassFragmentAccess::ReadOnly);
++	EntityQuery.AddRequirement<FMassForceFragment>(EMassFragmentAccess::ReadOnly);
++	EntityQuery.AddRequirement<FAgentRadiusFragment>(EMassFragmentAccess::ReadOnly);
+ 	
+ 	ProcessorRequirements.AddSubsystemRequirement<UMassCrowdSubsystem>(EMassFragmentAccess::ReadWrite);
+ 	ProcessorRequirements.AddSubsystemRequirement<UZoneGraphSubsystem>(EMassFragmentAccess::ReadOnly);
+@@ -169,8 +177,18 @@
+ 		for (TTuple<int32, FCrowdTrackingLaneData>& RegisteredCrowdLaneDataPair : RegisteredCrowdLaneData->LaneToTrackingDataLookup)
+ 		{
+ 			FCrowdTrackingLaneData& RegisteredCrowdTrackingLaneData = RegisteredCrowdLaneDataPair.Value;
+-			RegisteredCrowdTrackingLaneData.LeadEntityNormalizedDistanceAlongLane.Reset();
+-			RegisteredCrowdTrackingLaneData.TailEntityNormalizedDistanceAlongLane.Reset();
++
++			RegisteredCrowdTrackingLaneData.LeadEntityHandle.Reset();
++			RegisteredCrowdTrackingLaneData.LeadEntityDistanceAlongLane.Reset();
++			RegisteredCrowdTrackingLaneData.LeadEntitySpeedAlongLane.Reset();
++			RegisteredCrowdTrackingLaneData.LeadEntityAccelerationAlongLane.Reset();
++			RegisteredCrowdTrackingLaneData.LeadEntityRadius.Reset();
++
++			RegisteredCrowdTrackingLaneData.TailEntityHandle.Reset();
++			RegisteredCrowdTrackingLaneData.TailEntityDistanceAlongLane.Reset();
++			RegisteredCrowdTrackingLaneData.TailEntitySpeedAlongLane.Reset();
++			RegisteredCrowdTrackingLaneData.TailEntityAccelerationAlongLane.Reset();
++			RegisteredCrowdTrackingLaneData.TailEntityRadius.Reset();
+ 		}
+ 	}
+ 
+@@ -182,6 +200,9 @@
+ 			
+ 		const FMassEntityView LeadEntityView(EntityManager, LeadEntityHandle);
+ 		const FMassZoneGraphLaneLocationFragment& LeadEntityLaneLocation = LeadEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
++		const FMassVelocityFragment& LeadEntityVelocityFragment = LeadEntityView.GetFragmentData<FMassVelocityFragment>();
++		const FMassForceFragment& LeadEntityForceFragment = LeadEntityView.GetFragmentData<FMassForceFragment>();
++		const FAgentRadiusFragment& LeadEntityRadiusFragment = LeadEntityView.GetFragmentData<FAgentRadiusFragment>();
+ 
+ 		if (LeadEntityLaneLocation.LaneLength > 0.0f)
+ 		{
+@@ -192,14 +213,30 @@
+ 				continue;
+ 			}
+ 
+-			// We only set the LeadEntityNormalizedDistanceAlongLane value for a given lane, if it hasn't already been set.
++			const FZoneGraphStorage* ZoneGraphStorage = ZoneGraphSubsystem.GetZoneGraphStorage(LeadEntityLaneLocation.LaneHandle.DataHandle);
++
++			if (!ensureMsgf(ZoneGraphStorage != nullptr, TEXT("Must get valid ZoneGraphStorage in UMassCrowdUpdateTrackingLaneProcessor::Execute.")))
++			{
++				continue;
++			}
++
++			// We only set the LeadEntityDistanceAlongLane value for a given lane, if it hasn't already been set.
+ 			// And, since we're indexing into DescendingCrowdEntities, which has been sorted by descending DistanceAlongLane,
+ 			// the first Entity to be indexed for a given lane will in fact be the "Lead Entity" for that lane,
+-			// and it will have the first (and only) opportunity to set the LeadEntityNormalizedDistanceAlongLane field.
+-			if (!LeadEntityCrowdTrackingLaneData->LeadEntityNormalizedDistanceAlongLane.IsSet())
++			// and it will have the first (and only) opportunity to set the LeadEntityDistanceAlongLane field.
++			if (!LeadEntityCrowdTrackingLaneData->LeadEntityDistanceAlongLane.IsSet())
+ 			{
+-				const float NormalizedDistanceAlongLane = LeadEntityLaneLocation.DistanceAlongLane / LeadEntityLaneLocation.LaneLength;
+-				LeadEntityCrowdTrackingLaneData->LeadEntityNormalizedDistanceAlongLane = NormalizedDistanceAlongLane;
++				LeadEntityCrowdTrackingLaneData->LeadEntityHandle = LeadEntityHandle;
++				LeadEntityCrowdTrackingLaneData->LeadEntityDistanceAlongLane = LeadEntityLaneLocation.DistanceAlongLane;
++				LeadEntityCrowdTrackingLaneData->LeadEntityRadius = LeadEntityRadiusFragment.Radius;
++
++				FZoneGraphLaneLocation LeadEntityZoneGraphLaneLocation;
++				UE::ZoneGraph::Query::CalculateLocationAlongLane(*ZoneGraphStorage, LeadEntityLaneLocation.LaneHandle, LeadEntityLaneLocation.DistanceAlongLane, LeadEntityZoneGraphLaneLocation);
++				const float LeadEntitySpeedAlongLane = FVector::DotProduct(LeadEntityVelocityFragment.Value, LeadEntityZoneGraphLaneLocation.Tangent);
++				const float LeadEntityAccelerationAlongLane = FVector::DotProduct(LeadEntityForceFragment.Value, LeadEntityZoneGraphLaneLocation.Tangent);
++
++				LeadEntityCrowdTrackingLaneData->LeadEntitySpeedAlongLane = LeadEntitySpeedAlongLane;
++				LeadEntityCrowdTrackingLaneData->LeadEntityAccelerationAlongLane = LeadEntityAccelerationAlongLane;
+ 			}
+ 		}
+ 
+@@ -208,6 +245,9 @@
+ 			
+ 		const FMassEntityView TailEntityView(EntityManager, TailEntityHandle);
+ 		const FMassZoneGraphLaneLocationFragment& TailEntityLaneLocation = TailEntityView.GetFragmentData<FMassZoneGraphLaneLocationFragment>();
++		const FMassVelocityFragment& TailEntityVelocityFragment = TailEntityView.GetFragmentData<FMassVelocityFragment>();
++		const FMassForceFragment& TailEntityForceFragment = TailEntityView.GetFragmentData<FMassForceFragment>();
++		const FAgentRadiusFragment& TailEntityRadiusFragment = TailEntityView.GetFragmentData<FAgentRadiusFragment>();
+ 
+ 		if (TailEntityLaneLocation.LaneLength > 0.0f)
+ 		{
+@@ -218,14 +258,30 @@
+ 				continue;
+ 			}
+ 
+-			// We only set the TailEntityNormalizedDistanceAlongLane value for a given lane, if it hasn't already been set.
++			const FZoneGraphStorage* ZoneGraphStorage = ZoneGraphSubsystem.GetZoneGraphStorage(TailEntityLaneLocation.LaneHandle.DataHandle);
++
++			if (!ensureMsgf(ZoneGraphStorage != nullptr, TEXT("Must get valid ZoneGraphStorage in UMassCrowdUpdateTrackingLaneProcessor::Execute.")))
++			{
++				continue;
++			}
++
++			// We only set the TailEntityDistanceAlongLane value for a given lane, if it hasn't already been set.
+ 			// And, since we're indexing into AscendingCrowdEntities, which has been sorted by ascending DistanceAlongLane,
+ 			// the first Entity to be indexed for a given lane will in fact be the "Tail Entity" for that lane,
+-			// and it will have the first (and only) opportunity to set the TailEntityNormalizedDistanceAlongLane field.
+-			if (!TailEntityCrowdTrackingLaneData->TailEntityNormalizedDistanceAlongLane.IsSet())
++			// and it will have the first (and only) opportunity to set the TailEntityDistanceAlongLane field.
++			if (!TailEntityCrowdTrackingLaneData->TailEntityDistanceAlongLane.IsSet())
+ 			{
+-				const float NormalizedDistanceAlongLane = TailEntityLaneLocation.DistanceAlongLane / TailEntityLaneLocation.LaneLength;
+-				TailEntityCrowdTrackingLaneData->TailEntityNormalizedDistanceAlongLane = NormalizedDistanceAlongLane;
++				TailEntityCrowdTrackingLaneData->TailEntityHandle = TailEntityHandle;
++				TailEntityCrowdTrackingLaneData->TailEntityDistanceAlongLane = TailEntityLaneLocation.DistanceAlongLane;
++				TailEntityCrowdTrackingLaneData->TailEntityRadius = TailEntityRadiusFragment.Radius;
++				
++				FZoneGraphLaneLocation TailEntityZoneGraphLaneLocation;
++				UE::ZoneGraph::Query::CalculateLocationAlongLane(*ZoneGraphStorage, TailEntityLaneLocation.LaneHandle, TailEntityLaneLocation.DistanceAlongLane, TailEntityZoneGraphLaneLocation);
++				const float TailEntitySpeedAlongLane = FVector::DotProduct(TailEntityVelocityFragment.Value, TailEntityZoneGraphLaneLocation.Tangent);
++				const float TailEntityAccelerationAlongLane = FVector::DotProduct(TailEntityForceFragment.Value, TailEntityZoneGraphLaneLocation.Tangent);
++
++				TailEntityCrowdTrackingLaneData->TailEntitySpeedAlongLane = TailEntitySpeedAlongLane;
++				TailEntityCrowdTrackingLaneData->TailEntityAccelerationAlongLane = TailEntityAccelerationAlongLane;
+ 			}
+ 		}
+ 	}
+diff -urN --strip-trailing-cr Source/MassCrowd/Public/MassCrowdTypes.h /home/giovanni/Develop/VayuSim/Plugins/Tempo/External/MassCrowd/Source/MassCrowd/Public/MassCrowdTypes.h
+--- Source/MassCrowd/Public/MassCrowdTypes.h	2025-03-10 19:08:17.831935340 -0400
++++ /home/giovanni/Develop/VayuSim/Plugins/Tempo/External/MassCrowd/Source/MassCrowd/Public/MassCrowdTypes.h	2025-03-10 17:18:45.930878738 -0400
+@@ -57,9 +57,18 @@
+ 	int32 WaitAreaIndex = INDEX_NONE;
+ 
+ 	int32 NumEntitiesOnLane = 0;
+-	
+-	TOptional<float> LeadEntityNormalizedDistanceAlongLane;
+-	TOptional<float> TailEntityNormalizedDistanceAlongLane;
++
++	TOptional<FMassEntityHandle> LeadEntityHandle;
++	TOptional<float> LeadEntityDistanceAlongLane;
++	TOptional<float> LeadEntitySpeedAlongLane;
++	TOptional<float> LeadEntityAccelerationAlongLane;
++	TOptional<float> LeadEntityRadius;
++
++	TOptional<FMassEntityHandle> TailEntityHandle;
++	TOptional<float> TailEntityDistanceAlongLane;
++	TOptional<float> TailEntitySpeedAlongLane;
++	TOptional<float> TailEntityAccelerationAlongLane;
++	TOptional<float> TailEntityRadius;
+ };
+ 
+ /** Runtime data associated to lane that can be used to wait another one to open. */

--- a/EngineMods/5.5/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.3
+++ b/EngineMods/5.5/Engine/Plugins/AI/MassCrowd/MassCrowd.patch.3
@@ -1,0 +1,39 @@
+diff --color -urN --strip-trailing-cr Source/MassCrowd/MassCrowd.Build.cs /Users/pete/Desktop/MassCrowd/Source/MassCrowd/MassCrowd.Build.cs
+--- Source/MassCrowd/MassCrowd.Build.cs	2024-04-15 18:02:10
++++ /Users/pete/Desktop/MassCrowd/Source/MassCrowd/MassCrowd.Build.cs	2025-04-12 21:14:27
+@@ -1,5 +1,7 @@
+ // Copyright Epic Games, Inc. All Rights Reserved.
+
++using System.IO;
++
+ namespace UnrealBuildTool.Rules
+ {
+ 	public class MassCrowd: ModuleRules
+@@ -35,8 +37,25 @@
+ 					"ZoneGraphDebug"
+ 				}
+ 			);
++
++			// TEMPO_MOD Begin - [For Fixing rpaths of Rebuilt Engine Plugins] - Manually add rpaths for plugin dependencies
++			// Added by Tempo. We needed to make some mods to this plugin. To do so, we copied it out of the engine,
++			// applied our mods to the source, rebuilt it, and copied the result back. The only wrinkle is the rpaths
++			// in the dynamic libraries are then relative to the location we built it, not it's final destination in the
++			// engine (and no, it's not allowed to re-build a plugin in-place in the engine). So we use these here to
++			// add the correct rpaths relative to the final destination for this plugin.
++			PublicRuntimeLibraryPaths.AddRange(
++					new string[] {
++							Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "MassGameplay", "Binaries", Target.Platform.ToString()),
++							Path.Combine("..", "..", "..", "..", "..", "Plugins", "AI", "MassAI", "Binaries", Target.Platform.ToString()),
++							Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "StateTree", "Binaries", Target.Platform.ToString()),
++							Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "ZoneGraph", "Binaries", Target.Platform.ToString()),
++							Path.Combine("..", "..", "..", "..", "..", "Plugins", "Runtime", "ZoneGraphAnnotations", "Binaries", Target.Platform.ToString()),
++				}
++			);
++			// TEMPO_MOD End
+
+ 			SetupIrisSupport(Target);
+ 		}
+ 	}
+-}
+\ No newline at end of file
++}

--- a/EngineMods/5.5/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.1
+++ b/EngineMods/5.5/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.1
@@ -1,0 +1,486 @@
+diff --color -urN Source/ZoneGraph/Private/ZoneGraphBuilder.cpp /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphBuilder.cpp
+--- Source/ZoneGraph/Private/ZoneGraphBuilder.cpp	2024-09-26 22:04:48
++++ /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphBuilder.cpp	2024-09-17 17:52:05
+@@ -1,11 +1,10 @@
+ // Copyright Epic Games, Inc. All Rights Reserved.
+ 
+ #include "ZoneGraphBuilder.h"
++
+ #include "ZoneGraphTypes.h"
+ #include "ZoneGraphDelegates.h"
+ #include "ZoneGraphData.h"
+-#include "ZoneShapeComponent.h"
+-#include "ZoneShapeUtilities.h"
+ #include "ZoneGraphSettings.h"
+ 
+ namespace UE::ZoneGraph::Internal
+@@ -312,6 +311,9 @@
+ void FZoneGraphBuilder::BuildSingleShape(const UZoneShapeComponent& ShapeComp, const FMatrix& LocalToWorld, FZoneGraphStorage& OutZoneStorage)
+ {
+ 	TArray<FZoneShapeLaneInternalLink> InternalLinks;
++
++	// Const cast is intentional.  Need to update connected shapes before running through the build pathway.
++	const_cast<UZoneShapeComponent&>(ShapeComp).UpdateConnectedShapes();
+ 	AppendShapeToZoneStorage(ShapeComp, LocalToWorld, OutZoneStorage, InternalLinks);
+ 	ConnectLanes(InternalLinks, OutZoneStorage);
+ }
+@@ -437,7 +439,7 @@
+ 			}
+ 		}
+ 
+-		UE::ZoneShape::Utilities::TessellatePolygonShape(AdjustedPoints, ShapeComp.GetPolygonRoutingType(), PolyLaneProfiles, ShapeComp.GetTags(), LocalToWorld, OutZoneStorage, OutInternalLinks);
++		UE::ZoneShape::Utilities::TessellatePolygonShape(ShapeComp, *this, AdjustedPoints, PolyLaneProfiles, LocalToWorld, OutZoneStorage, OutInternalLinks);
+ 	}
+ 	else
+ 	{
+@@ -500,7 +502,7 @@
+ 	const uint32 NewHash = CalculateCombinedShapeHash(ZoneGraphData);
+ 	ZoneGraphData.SetCombinedShapeHash(NewHash);
+ 
+-	ZoneGraphData.UpdateDrawing();
++ZoneGraphData.UpdateDrawing();
+ }
+ 
+ void FZoneGraphBuilder::ConnectLanes(TArray<FZoneShapeLaneInternalLink>& InternalLinks, FZoneGraphStorage& ZoneStorage)
+diff --color -urN Source/ZoneGraph/Private/ZoneGraphSubsystem.cpp /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphSubsystem.cpp
+--- Source/ZoneGraph/Private/ZoneGraphSubsystem.cpp	2024-09-26 22:04:48
++++ /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphSubsystem.cpp	2024-09-26 20:29:34
+@@ -60,7 +60,7 @@
+ 	const UWorld* World = GetWorld();
+ 	if (!World->IsGameWorld())
+ 	{
+-		if (Builder.NeedsRebuild())
++		if (GetBuilder().NeedsRebuild())
+ 		{
+ 			const UZoneGraphSettings* ZoneGraphSettings = GetDefault<UZoneGraphSettings>();
+ 			check(ZoneGraphSettings);
+@@ -73,7 +73,7 @@
+ 	else
+ 	{
+ 		// Zone graph is not meant to update during game tick.
+-		ensureMsgf(!Builder.NeedsRebuild(), TEXT("Builder should not need update during game."));
++		ensureMsgf(!GetBuilder().NeedsRebuild(), TEXT("Builder should not need update during game."));
+ 	}
+ #endif
+ }
+@@ -194,7 +194,7 @@
+ 	{
+ 		if (UZoneShapeComponent* ShapeComp = Actor->FindComponentByClass<UZoneShapeComponent>())
+ 		{
+-			Builder.OnZoneShapeComponentChanged(*ShapeComp);
++			GetBuilder().OnZoneShapeComponentChanged(*ShapeComp);
+ 		}
+ 	}
+ }
+@@ -216,7 +216,7 @@
+ 
+ 	// Find the levels where the splines are located.
+ 	TSet<ULevel*> SupportedLevels;
+-	for (const FZoneGraphBuilderRegisteredComponent& Registered : Builder.GetRegisteredZoneShapeComponents())
++	for (const FZoneGraphBuilderRegisteredComponent& Registered : GetBuilder().GetRegisteredZoneShapeComponents())
+ 	{
+ 		if (Registered.Component)
+ 		{
+@@ -270,7 +270,7 @@
+ 		}
+ 	}
+ 
+-	Builder.BuildAll(AllZoneGraphData, bForceRebuild);
++	GetBuilder().BuildAll(AllZoneGraphData, bForceRebuild);
+ }
+ 
+ #endif // WITH_EDITOR
+@@ -472,6 +472,23 @@
+ 		}
+ 	}
+ 	return FName();
++}
++
++TArray<FName> UZoneGraphSubsystem::GetTagNamesFromTagMask(const FZoneGraphTagMask& TagMask) const
++{
++	TArray<FName> TagNames;
++	
++	const TConstArrayView<FZoneGraphTagInfo>& TagInfos = GetTagInfos();
++	for (const FZoneGraphTagInfo& TagInfo : TagInfos)
++	{
++		if (TagMask.Contains(TagInfo.Tag))
++		{
++			const FName& TagName = GetTagName(TagInfo.Tag);
++			TagNames.Add(TagName);
++		}
++	}
++
++	return TagNames;
+ }
+ 
+ const FZoneGraphTagInfo* UZoneGraphSubsystem::GetTagInfo(FZoneGraphTag Tag) const
+diff --color -urN Source/ZoneGraph/Private/ZoneGraphTypes.cpp /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphTypes.cpp
+--- Source/ZoneGraph/Private/ZoneGraphTypes.cpp	2024-09-26 22:04:48
++++ /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphTypes.cpp	2024-09-17 17:52:05
+@@ -135,6 +135,29 @@
+ 	}
+ }
+ 
++bool FZoneLaneProfile::IsValid(const bool bMustHaveName) const
++{
++	if (bMustHaveName && Name == NAME_None)
++	{
++		return false;
++	}
++		
++	if (!ID.IsValid())
++	{
++		return false;
++	}
++		
++	for (const FZoneLaneDesc& Lane : Lanes)
++	{
++		if (Lane.Width <= 0.0f)
++		{
++			return false;
++		}
++	}
++
++	return true;
++}
++
+ float FZoneGraphBuildSettings::GetLaneTessellationTolerance(const FZoneGraphTagMask LaneTags) const
+ {
+ 	float Tolerance = CommonTessellationTolerance;
+diff --color -urN Source/ZoneGraph/Private/ZoneShapeUtilities.cpp /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp
+--- Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2024-09-26 22:04:48
++++ /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2024-09-17 17:52:05
+@@ -2,9 +2,11 @@
+ 
+ #include "ZoneShapeUtilities.h"
+ #include "Curves/BezierUtilities.h"
++#include "ZoneGraphBuilder.h"
+ #include "Algo/Reverse.h"
+ #include "HAL/IConsoleManager.h"
+ #include "ZoneGraphSettings.h"
++#include "ZoneShapeComponent.h"
+ 
+ namespace UE::ZoneGraph::Debug {
+ 
+@@ -998,23 +1000,6 @@
+ 	}
+ }
+ 
+-
+-struct FLaneConnectionSlot
+-{
+-	FVector Position = FVector::ZeroVector;
+-	FVector Forward = FVector::ZeroVector;
+-	FVector Up = FVector::ZeroVector;
+-	FZoneLaneDesc LaneDesc;
+-	int32 PointIndex = 0;	// Index in dest point array
+-	int32 Index = 0;		// Index within an entry
+-	uint16 EntryID = 0;		// Entry ID from source data
+-	const FZoneLaneProfile* Profile = nullptr;
+-	EZoneShapeLaneConnectionRestrictions Restrictions = EZoneShapeLaneConnectionRestrictions::None;
+-	float DistanceFromProfileEdge = 0.0f;	// Distance from lane profile edge
+-	float DistanceFromFarProfileEdge = 0.0f; // Distance to other lane profile edge
+-	float InnerTurningRadius = 0.0f; // Inner/minimum turning radius when using Arc routing.
+-};
+-
+ struct FLaneConnectionCandidate
+ {
+ 	FLaneConnectionCandidate() = default;
+@@ -1201,6 +1186,7 @@
+ };
+ 
+ static void BuildLanesBetweenPoints(const FConnectionEntry& Source, TConstArrayView<FConnectionEntry> Destinations,
++									const UZoneShapeComponent& PolygonShapeComp, const TMap<int32, const UZoneShapeComponent*>& PointIndexToZoneShapeComponent, const FZoneGraphBuilder& ZoneGraphBuilder,
+ 									const EZoneShapePolygonRoutingType RoutingType, const FZoneGraphTagMask ZoneTags, const FZoneGraphBuildSettings& BuildSettings, const FMatrix& LocalToWorld,
+ 									FZoneGraphStorage& OutZoneStorage, TArray<FZoneShapeLaneInternalLink>& OutInternalLinks)
+ {
+@@ -1611,6 +1597,30 @@
+ 		}
+ 	}
+ 
++	TArray<const UZoneShapeComponent*> ShapeComponentsInMap;
++	PointIndexToZoneShapeComponent.GenerateValueArray(ShapeComponentsInMap);
++
++	const bool bAllZoneShapeComponentsInMapAreValid = !ShapeComponentsInMap.Contains(nullptr);
++	if (bAllZoneShapeComponentsInMapAreValid)
++	{
++		Candidates.RemoveAll([&ZoneGraphBuilder, &PolygonShapeComp, &SourceSlots, &DestSlots, &PointIndexToZoneShapeComponent](const FLaneConnectionCandidate& Candidate)
++		{
++			// The true index to the ZoneShapePoint in this context is the slot's EntryID, not PointIndex field.
++			// In fact, SourceSlots don't even fill-out their PointIndex fields.
++			// So, we look up the ZoneShapeComponent for this slot via EntryID.
++			const FLaneConnectionSlot& SourceSlot = SourceSlots[Candidate.SourceSlot];
++			const UZoneShapeComponent* SourceShapeComp = PointIndexToZoneShapeComponent[SourceSlot.EntryID];
++
++			// The true index to the ZoneShapePoint in this context is the slot's EntryID, not PointIndex field.
++			// DestSlots use PointIndex to point into the Destinations array, not the ZoneShapePoints array.
++			// So, we look up the ZoneShapeComponent for this slot via EntryID.
++			const FLaneConnectionSlot& DestSlot = DestSlots[Candidate.DestSlot];
++			const UZoneShapeComponent* DestShapeComp = PointIndexToZoneShapeComponent[DestSlot.EntryID];
++
++			return ZoneGraphBuilder.ShouldFilterLaneConnection(PolygonShapeComp, *SourceShapeComp, SourceSlots, Candidate.SourceSlot, *DestShapeComp, DestSlots, Candidate.DestSlot);
++		});
++	}
++
+ 	// Sort candidates for lane adjacency. First by source index, then by destination index.
+ 	// Lane adjacency is not that obvious in polygons. With this sort we make sure that they are somewhat in order and that the whole set can be iterated over.
+ 	Candidates.Sort([](const FLaneConnectionCandidate& A, const FLaneConnectionCandidate& B) { return A.SourceSlot < B.SourceSlot || (A.SourceSlot == B.SourceSlot && A.DestSlot < B.DestSlot); });
+@@ -1729,9 +1739,27 @@
+ 	return TessTolerance;
+ }
+ 
+-void TessellatePolygonShape(TConstArrayView<FZoneShapePoint> Points, const EZoneShapePolygonRoutingType RoutingType, TConstArrayView<FZoneLaneProfile> LaneProfiles, const FZoneGraphTagMask ZoneTags, const FMatrix& LocalToWorld,
++void TessellatePolygonShape(const UZoneShapeComponent& PolygonShapeComp, const FZoneGraphBuilder& ZoneGraphBuilder,
++							TConstArrayView<FZoneShapePoint> Points, TConstArrayView<FZoneLaneProfile> LaneProfiles, const FMatrix& LocalToWorld,
+ 							FZoneGraphStorage& OutZoneStorage, TArray<FZoneShapeLaneInternalLink>& OutInternalLinks)
+ {
++	const EZoneShapePolygonRoutingType RoutingType = PolygonShapeComp.GetPolygonRoutingType();
++	const FZoneGraphTagMask ZoneTags = PolygonShapeComp.GetTags();
++
++	TConstArrayView<FZoneShapeConnector> ShapeConnectors = PolygonShapeComp.GetShapeConnectors();
++	TConstArrayView<FZoneShapeConnection> ConnectedShapes = PolygonShapeComp.GetConnectedShapes();
++
++	checkf(ConnectedShapes.Num() == ShapeConnectors.Num(), TEXT("ConnectedShapes and ShapeConnectors should have the same number of entries."));
++	
++	TMap<int32, const UZoneShapeComponent*> PointIndexToZoneShapeComponent;
++	for (int32 ConnectionIndex = 0; ConnectionIndex < ConnectedShapes.Num(); ++ConnectionIndex)
++	{
++		const int32 PointIndex = ShapeConnectors[ConnectionIndex].PointIndex;
++		const UZoneShapeComponent* ZoneShapeComponent = ConnectedShapes[ConnectionIndex].ShapeComponent.Get();
++		
++		PointIndexToZoneShapeComponent.Add(PointIndex, ZoneShapeComponent);
++	}
++	
+ 	const UZoneGraphSettings* ZoneGraphSettings = GetDefault<UZoneGraphSettings>();
+ 	check(ZoneGraphSettings);
+ 	const FZoneGraphBuildSettings& BuildSettings = ZoneGraphSettings->GetBuildSettings();
+@@ -1822,7 +1850,7 @@
+ 		}
+ 		// Connect source to destinations.
+ 		BuildLanesBetweenPoints(FConnectionEntry(SourcePoint, SourceLaneProfile, SourceIdx, OutgoingConnections[SourceIdx], IncomingConnections[SourceIdx]),
+-								Destinations, RoutingType, ZoneTags, BuildSettings, LocalToWorld, OutZoneStorage, OutInternalLinks);
++								Destinations, PolygonShapeComp, PointIndexToZoneShapeComponent, ZoneGraphBuilder, RoutingType, ZoneTags, BuildSettings, LocalToWorld, OutZoneStorage, OutInternalLinks);
+ 	}
+ 
+ 	Zone.LanesEnd = OutZoneStorage.Lanes.Num();
+diff --color -urN Source/ZoneGraph/Public/ZoneGraphBuilder.h /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphBuilder.h
+--- Source/ZoneGraph/Public/ZoneGraphBuilder.h	2024-09-26 22:04:46
++++ /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphBuilder.h	2024-09-17 17:52:05
+@@ -5,6 +5,8 @@
+ #include "CoreMinimal.h"
+ #include "ZoneGraphTypes.h"
+ #include "HierarchicalHashGrid2D.h"
++#include "ZoneShapeComponent.h"
++#include "ZoneShapeUtilities.h"
+ #include "ZoneGraphBuilder.generated.h"
+ 
+ class AZoneGraphData;
+@@ -65,7 +67,7 @@
+ 
+ public:
+ 	FZoneGraphBuilder();
+-	~FZoneGraphBuilder();
++	virtual ~FZoneGraphBuilder();
+ 
+ 	void RegisterZoneShapeComponent(UZoneShapeComponent& ShapeComp);
+ 	void UnregisterZoneShapeComponent(UZoneShapeComponent& ShapeComp);
+@@ -84,7 +86,7 @@
+ 
+ 	/** Converts single zone shape into a zone storage, used in UI for editing and rendering.
+ 	*/
+-	static void BuildSingleShape(const UZoneShapeComponent& ShapeComp, const FMatrix& LocalToWorld, FZoneGraphStorage& OutZoneStorage);
++	void BuildSingleShape(const UZoneShapeComponent& ShapeComp, const FMatrix& LocalToWorld, FZoneGraphStorage& OutZoneStorage);
+ 
+ 	/** Returns items that potentially touch the bounds in the HashGrid. Operates on grid level, can have false positives.
+ 	 * @param Bounds - Query bounding box.
+@@ -92,12 +94,14 @@
+ 	 */
+ 	void QueryHashGrid(const FBox& Bounds, TArray<FZoneGraphBuilderHashGrid2D::ItemIDType>& OutResults);
+ 
++	virtual bool ShouldFilterLaneConnection(const UZoneShapeComponent& PolygonShapeComp, const UZoneShapeComponent& SourceShapeComp, const TArray<FLaneConnectionSlot>& SourceSlots, const int32 SourceSlotQueryIndex, const UZoneShapeComponent& DestShapeComp, const TArray<FLaneConnectionSlot>& DestSlots, const int32 DestSlotQueryIndex) const { return false; };
++
+ protected:
+ 	void Build(AZoneGraphData& ZoneGraphData);
+ 	void RequestRebuild();
+ 	void OnLaneProfileChanged(const FZoneLaneProfileRef& ChangedLaneProfileRef);
+ 	uint32 CalculateCombinedShapeHash(const AZoneGraphData& ZoneGraphData) const;
+-	static void AppendShapeToZoneStorage(const UZoneShapeComponent& ShapeComp, const FMatrix& LocalToWorld, FZoneGraphStorage& OutZoneStorage, TArray<FZoneShapeLaneInternalLink>& OutInternalLinks, FZoneGraphBuildData* InBuildData = nullptr);
++	void AppendShapeToZoneStorage(const UZoneShapeComponent& ShapeComp, const FMatrix& LocalToWorld, FZoneGraphStorage& OutZoneStorage, TArray<FZoneShapeLaneInternalLink>& OutInternalLinks, FZoneGraphBuildData* InBuildData = nullptr);
+ 	static void ConnectLanes(TArray<FZoneShapeLaneInternalLink>& InternalLinks, FZoneGraphStorage& OutZoneStorage);
+ 
+ 	UPROPERTY(Transient)
+diff --color -urN Source/ZoneGraph/Public/ZoneGraphSubsystem.h /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphSubsystem.h
+--- Source/ZoneGraph/Public/ZoneGraphSubsystem.h	2024-09-26 22:04:46
++++ /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphSubsystem.h	2024-09-26 20:29:34
+@@ -47,7 +47,9 @@
+ 	TConstArrayView<FRegisteredZoneGraphData> GetRegisteredZoneGraphData() const { return RegisteredZoneGraphData; }
+ 
+ #if WITH_EDITOR
+-	FZoneGraphBuilder& GetBuilder() { return Builder; }
++	void RegisterBuilder(FZoneGraphBuilder* Builder) { OverrideBuilder = Builder; }
++	void ResetBuilder() { OverrideBuilder = nullptr; }
++	FZoneGraphBuilder& GetBuilder() { return OverrideBuilder != nullptr ? *OverrideBuilder : DefaultBuilder; }
+ #endif
+ 
+ 	// Queries
+@@ -113,11 +115,17 @@
+ 	// Tags
+ 	
+ 	// Returns tag based on name.
++	UFUNCTION(BlueprintCallable, Category = "ZoneGraphSubsystem|Tags")
+ 	FZoneGraphTag GetTagByName(FName TagName) const;
+ 
+ 	// Returns the name of a specific tag.
++	UFUNCTION(BlueprintCallable, Category = "ZoneGraphSubsystem|Tags")
+ 	FName GetTagName(FZoneGraphTag Tag) const;
+ 
++	// Returns the names of all the tags in a given tag mask.
++	UFUNCTION(BlueprintCallable, Category = "ZoneGraphSubsystem|Tags")
++	TArray<FName> GetTagNamesFromTagMask(const FZoneGraphTagMask& TagMask) const;
++
+ 	// Returns info about a specific tag.
+ 	const FZoneGraphTagInfo* GetTagInfo(FZoneGraphTag Tag) const;
+ 
+@@ -159,6 +167,7 @@
+ #if WITH_EDITOR
+ 	FDelegateHandle OnActorMovedHandle;
+ 	FDelegateHandle OnRequestRebuildHandle;
+-	FZoneGraphBuilder Builder;
++	FZoneGraphBuilder* OverrideBuilder;
++	FZoneGraphBuilder DefaultBuilder;
+ #endif
+ };
+diff --color -urN Source/ZoneGraph/Public/ZoneGraphTypes.h /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h
+--- Source/ZoneGraph/Public/ZoneGraphTypes.h	2024-09-26 22:04:46
++++ /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h	2024-09-17 17:52:05
+@@ -192,11 +192,20 @@
+ 
+ // Filter passes if any of the 'AnyTags', and all of the 'AllTags', and none of the 'NotTags' are present.
+ // Setting include or exclude tags to None, will skip that particular check.
+-USTRUCT()
++USTRUCT(BlueprintType)
+ struct ZONEGRAPH_API FZoneGraphTagFilter
+ {
+ 	GENERATED_BODY()
+ 
++	FZoneGraphTagFilter() = default;
++
++	FZoneGraphTagFilter(const FZoneGraphTagMask& InAnyTags, const FZoneGraphTagMask& InAllTags, const FZoneGraphTagMask& InNotTags)
++		: AnyTags(InAnyTags)
++		, AllTags(InAllTags)
++		, NotTags(InNotTags)
++	{
++	}
++
+ 	bool Pass(const FZoneGraphTagMask Tags) const
+ 	{
+ 		return (AnyTags == FZoneGraphTagMask::None || Tags.ContainsAny(AnyTags))
+@@ -207,13 +216,19 @@
+ 	bool operator==(const FZoneGraphTagFilter& RHS) const { return AnyTags == RHS.AnyTags && AllTags == RHS.AllTags && NotTags == RHS.NotTags; }
+ 	bool operator!=(const FZoneGraphTagFilter& RHS) const { return AnyTags != RHS.AnyTags || AllTags != RHS.AllTags || NotTags != RHS.NotTags; }
+ 
+-	UPROPERTY(Category = Zone, EditAnywhere)
++	friend uint32 GetTypeHash(const FZoneGraphTagFilter& ZoneGraphTagFilter)
++	{
++		const uint32 AnyAllHash = HashCombine(GetTypeHash(ZoneGraphTagFilter.AnyTags), GetTypeHash(ZoneGraphTagFilter.AllTags));
++		return HashCombine(AnyAllHash, GetTypeHash(ZoneGraphTagFilter.NotTags));
++	}
++
++	UPROPERTY(Category = Zone, EditAnywhere, BlueprintReadWrite)
+ 	FZoneGraphTagMask AnyTags = FZoneGraphTagMask::None;
+ 
+-	UPROPERTY(Category = Zone, EditAnywhere)
++	UPROPERTY(Category = Zone, EditAnywhere, BlueprintReadWrite)
+ 	FZoneGraphTagMask AllTags = FZoneGraphTagMask::None;
+ 
+-	UPROPERTY(Category = Zone, EditAnywhere)
++	UPROPERTY(Category = Zone, EditAnywhere, BlueprintReadWrite)
+ 	FZoneGraphTagMask NotTags = FZoneGraphTagMask::None;
+ };
+ 
+@@ -290,6 +305,8 @@
+ 
+ 	// Reverses the lane profile. The lanes array will be reversed, as well as the lane directions. 
+ 	void ReverseLanes();
++
++	bool IsValid(const bool bMustHaveName = true) const;
+ 
+ 	UPROPERTY(Category = Lane, EditAnywhere)
+ 	FName Name;
+diff --color -urN Source/ZoneGraph/Public/ZoneShapeComponent.h /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneShapeComponent.h
+--- Source/ZoneGraph/Public/ZoneShapeComponent.h	2024-09-26 22:04:46
++++ /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneShapeComponent.h	2024-09-17 17:52:05
+@@ -5,7 +5,6 @@
+ #include "CoreMinimal.h"
+ #include "UObject/ObjectMacros.h"
+ #include "Components/PrimitiveComponent.h"
+-#include "ZoneGraphSubsystem.h"
+ #include "ZoneGraphTypes.h"
+ #include "ZoneShapeComponent.generated.h"
+ 
+diff --color -urN Source/ZoneGraph/Public/ZoneShapeUtilities.h /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneShapeUtilities.h
+--- Source/ZoneGraph/Public/ZoneShapeUtilities.h	2024-09-26 22:04:46
++++ /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneShapeUtilities.h	2024-09-17 17:52:05
+@@ -5,6 +5,8 @@
+ #include "ZoneGraphTypes.h"
+ #include "ZoneShapeUtilities.generated.h"
+ 
++struct FZoneGraphBuilder;
++
+ /** Struct describing a link for a specified lane, used during building */
+ USTRUCT()
+ struct FZoneShapeLaneInternalLink
+@@ -25,6 +27,22 @@
+ 	FZoneLaneLinkData LinkData = {};
+ };
+ 
++struct FLaneConnectionSlot
++{
++	FVector Position = FVector::ZeroVector;
++	FVector Forward = FVector::ZeroVector;
++	FVector Up = FVector::ZeroVector;
++	FZoneLaneDesc LaneDesc;
++	int32 PointIndex = 0;	// Index in dest point array
++	int32 Index = 0;		// Index within an entry
++	uint16 EntryID = 0;		// Entry ID from source data
++	const FZoneLaneProfile* Profile = nullptr;
++	EZoneShapeLaneConnectionRestrictions Restrictions = EZoneShapeLaneConnectionRestrictions::None;
++	float DistanceFromProfileEdge = 0.0f;	// Distance from lane profile edge
++	float DistanceFromFarProfileEdge = 0.0f; // Distance to other lane profile edge
++	float InnerTurningRadius = 0.0f; // Inner/minimum turning radius when using Arc routing.
++};
++
+ namespace UE { namespace ZoneShape { namespace Utilities
+ {
+ 
+@@ -33,7 +51,8 @@
+ 										 FZoneGraphStorage& OutZoneStorage, TArray<FZoneShapeLaneInternalLink>& OutInternalLinks);
+ 
+ // Converts polygon shape to a zone data.
+-ZONEGRAPH_API void TessellatePolygonShape(TConstArrayView<FZoneShapePoint> Points, const EZoneShapePolygonRoutingType RoutingType, TConstArrayView<FZoneLaneProfile> LaneProfiles, const FZoneGraphTagMask ZoneTags, const FMatrix& LocalToWorld,
++ZONEGRAPH_API void TessellatePolygonShape(const UZoneShapeComponent& SourceShapeComp, const FZoneGraphBuilder& ZoneGraphBuilder,
++										  TConstArrayView<FZoneShapePoint> Points, TConstArrayView<FZoneLaneProfile> LaneProfiles, const FMatrix& LocalToWorld,
+ 										  FZoneGraphStorage& OutZoneStorage, TArray<FZoneShapeLaneInternalLink>& OutInternalLinks);
+ 
+ // Returns cubic bezier points for give shape segment. Adjusts end points based on shape point types. 
+diff --color -urN Source/ZoneGraph/ZoneGraph.Build.cs /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/ZoneGraph.Build.cs
+--- Source/ZoneGraph/ZoneGraph.Build.cs	2024-09-26 22:04:46
++++ /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/ZoneGraph.Build.cs	2024-09-17 17:52:05
+@@ -20,7 +20,6 @@
+ 					"DeveloperSettings",
+ 				}
+ 			);
+-
+ 			if (Target.bBuildEditor == true)
+ 			{
+ 				PrivateDependencyModuleNames.Add("EditorFramework");
+diff --color -urN Source/ZoneGraphTestSuite/ZoneGraphTestSuite.Build.cs /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraphTestSuite/ZoneGraphTestSuite.Build.cs
+--- Source/ZoneGraphTestSuite/ZoneGraphTestSuite.Build.cs	2024-09-26 22:04:46
++++ /Users/pete/TempoUnrealFestDemo/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraphTestSuite/ZoneGraphTestSuite.Build.cs	2024-09-17 17:52:05
+@@ -39,4 +39,4 @@
+ 			}
+ 		}
+ 	}
+-}
+\ No newline at end of file
++}

--- a/EngineMods/5.5/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.2
+++ b/EngineMods/5.5/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.2
@@ -1,0 +1,464 @@
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneGraphBuilder.cpp /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphBuilder.cpp
+--- Source/ZoneGraph/Private/ZoneGraphBuilder.cpp	2025-02-12 20:17:25
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphBuilder.cpp	2025-02-12 14:46:13
+@@ -311,7 +311,7 @@
+ void FZoneGraphBuilder::BuildSingleShape(const UZoneShapeComponent& ShapeComp, const FMatrix& LocalToWorld, FZoneGraphStorage& OutZoneStorage)
+ {
+ 	TArray<FZoneShapeLaneInternalLink> InternalLinks;
+-
++	
+ 	// Const cast is intentional.  Need to update connected shapes before running through the build pathway.
+ 	const_cast<UZoneShapeComponent&>(ShapeComp).UpdateConnectedShapes();
+ 	AppendShapeToZoneStorage(ShapeComp, LocalToWorld, OutZoneStorage, InternalLinks);
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneGraphRenderingUtilities.cpp /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphRenderingUtilities.cpp
+--- Source/ZoneGraph/Private/ZoneGraphRenderingUtilities.cpp	2025-02-12 20:10:52
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphRenderingUtilities.cpp	2025-02-09 13:15:55
+@@ -325,7 +325,7 @@
+ 			for (int32 i = Lane.PointsBegin + 1; i < Lane.PointsEnd; i++)
+ 			{
+ 				const FVector Point = bTransform ? FVector(LocalToWorld.TransformPosition(ZoneStorage.LanePoints[i])) : ZoneStorage.LanePoints[i];
+-				PDI->DrawTranslucentLine(PrevPoint, Point, Color, SDPG_World, LineThickness, DepthBias, true);
++				PDI->DrawTranslucentLine(PrevPoint, Point, Color, SDPG_Foreground, LineThickness, DepthBias, true);
+ 				PrevPoint = Point;
+ 			}
+ 		}
+@@ -334,7 +334,7 @@
+ 			for (int32 i = Lane.PointsBegin + 1; i < Lane.PointsEnd; i++)
+ 			{
+ 				const FVector Point = bTransform ? FVector(LocalToWorld.TransformPosition(ZoneStorage.LanePoints[i])) : ZoneStorage.LanePoints[i];
+-				PDI->DrawLine(PrevPoint, Point, Color, SDPG_World, LineThickness, DepthBias, true);
++				PDI->DrawLine(PrevPoint, Point, Color, SDPG_Foreground, LineThickness, DepthBias, true);
+ 				PrevPoint = Point;
+ 			}
+ 		}
+@@ -359,7 +359,7 @@
+ 				const FVector ArrowOrigin = ArrowPos;
+ 				const FVector ArrowTip = ArrowPos + ArrowDir * ArrowSize;
+ 
+-				FPrimitiveSceneProxy::DrawArrowHead(PDI, ArrowTip, ArrowOrigin, ArrowSize, Color, SDPG_World, LineThickness, true);
++				FPrimitiveSceneProxy::DrawArrowHead(PDI, ArrowTip, ArrowOrigin, ArrowSize, Color, SDPG_Foreground, LineThickness, true);
+ 			}
+ 
+ 			// Draw adjacent lanes
+@@ -373,12 +373,12 @@
+ 			FZoneGraphLinkedLane LeftLinkedLane;
+ 			if (UE::ZoneGraph::Query::GetFirstLinkedLane(ZoneStorage, LaneIdx, EZoneLaneLinkType::Adjacent, EZoneLaneLinkFlags::Left, EZoneLaneLinkFlags::None, LeftLinkedLane) && LeftLinkedLane.IsValid())
+ 			{
+-				PDI->DrawLine(LaneStartPoint, LaneStartPoint + LaneStartSide * Lane.Width * 0.1f, FMath::Lerp(FLinearColor(Color), FLinearColor::Green, 0.3f), SDPG_World, LineThickness, DepthBias, true);
++				PDI->DrawLine(LaneStartPoint, LaneStartPoint + LaneStartSide * Lane.Width * 0.1f, FMath::Lerp(FLinearColor(Color), FLinearColor::Green, 0.3f), SDPG_Foreground, LineThickness, DepthBias, true);
+ 			}
+ 			FZoneGraphLinkedLane RightLinkedLane;
+ 			if (UE::ZoneGraph::Query::GetFirstLinkedLane(ZoneStorage, LaneIdx, EZoneLaneLinkType::Adjacent, EZoneLaneLinkFlags::Right, EZoneLaneLinkFlags::None, RightLinkedLane) && RightLinkedLane.IsValid())
+ 			{
+-				PDI->DrawLine(LaneStartPoint, LaneStartPoint - LaneStartSide * Lane.Width * 0.1f, FMath::Lerp(FLinearColor(Color), FLinearColor::Red, 0.3f), SDPG_World, LineThickness, DepthBias, true);
++				PDI->DrawLine(LaneStartPoint, LaneStartPoint - LaneStartSide * Lane.Width * 0.1f, FMath::Lerp(FLinearColor(Color), FLinearColor::Red, 0.3f), SDPG_Foreground, LineThickness, DepthBias, true);
+ 			}
+ 		}
+ 	}
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneGraphTypes.cpp /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphTypes.cpp
+--- Source/ZoneGraph/Private/ZoneGraphTypes.cpp	2025-02-12 20:17:25
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphTypes.cpp	2025-02-12 15:04:08
+@@ -131,7 +131,10 @@
+ 	Algo::Reverse(Lanes);
+ 	for (FZoneLaneDesc& Lane : Lanes)
+ 	{
+-		Lane.Direction = Lane.Direction == EZoneLaneDirection::Forward ? EZoneLaneDirection::Backward : EZoneLaneDirection::Forward;
++		if (Lane.Direction != EZoneLaneDirection::None)
++		{
++			Lane.Direction = Lane.Direction == EZoneLaneDirection::Forward ? EZoneLaneDirection::Backward : EZoneLaneDirection::Forward;
++		}
+ 	}
+ }
+ 
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneShapeUtilities.cpp /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp
+--- Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2025-02-12 20:17:25
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2025-02-12 20:24:11
+@@ -8,20 +8,6 @@
+ #include "ZoneGraphSettings.h"
+ #include "ZoneShapeComponent.h"
+ 
+-namespace UE::ZoneGraph::Debug {
+-
+-	bool bRemoveOverlap = true;
+-	bool bRemoveSameDestination = true;
+-	bool bFillEmptyDestination = true;
+-
+-	FAutoConsoleVariableRef VarsGeneration[] = {
+-		FAutoConsoleVariableRef(TEXT("ai.debug.zonegraph.generation.RemoveOverlap"), bRemoveOverlap, TEXT("Remove Overlapping lanes.")),
+-		FAutoConsoleVariableRef(TEXT("ai.debug.zonegraph.generation.RemoveSameDestination"), bRemoveSameDestination, TEXT("Remove merging lanes leading to same destination.")),
+-		FAutoConsoleVariableRef(TEXT("ai.debug.zonegraph.generation.FillEmptyDestination"), bFillEmptyDestination, TEXT("Fill stray empty destination lanes.")),
+-	};
+-
+-} // UE::ZoneGraph::Debug
+-
+ namespace UE::ZoneShape::Utilities {
+ 
+ // Normalizes an angle by making it in range -PI..PI. Angle in radians.
+@@ -776,6 +762,10 @@
+ 
+ static void AddAdjacentLaneLinks(const int32 CurrentLaneIndex, const int32 LaneDescIndex, const TArray<FZoneLaneDesc>& LaneDescs, TArray<FZoneShapeLaneInternalLink>& OutInternalLinks)
+ {
++	const UZoneGraphSettings* ZoneGraphSettings = GetDefault<UZoneGraphSettings>();
++	check(ZoneGraphSettings);
++	const FZoneGraphBuildSettings& BuildSettings = ZoneGraphSettings->GetBuildSettings();
++
+ 	const int32 NumLanes = LaneDescs.Num();
+ 	const FZoneLaneDesc& LaneDesc = LaneDescs[LaneDescIndex];
+ 
+@@ -802,30 +792,38 @@
+ 		ensureMsgf(false, TEXT("Lane direction %d not implemented."), int32(LaneDesc.Direction));
+ 	}
+ 
+-	if ((LaneDescIndex + 1) < NumLanes)
++	int32 NextLaneDescIndex = LaneDescIndex; 
++	while (++NextLaneDescIndex < NumLanes)
+ 	{
+-		const FZoneLaneDesc& NextLaneDesc = LaneDescs[LaneDescIndex + 1];
+-		if (NextLaneDesc.Direction != EZoneLaneDirection::None)
++		const FZoneLaneDesc& NextLaneDesc = LaneDescs[NextLaneDescIndex];
++		if (NextLaneDesc.Direction == EZoneLaneDirection::None)
+ 		{
+-			if (LaneDesc.Direction != NextLaneDesc.Direction)
+-			{
+-				NextLinkFlags |= EZoneLaneLinkFlags::OppositeDirection;
+-			}
+-			OutInternalLinks.Emplace(CurrentLaneIndex, FZoneLaneLinkData(CurrentLaneIndex + 1, EZoneLaneLinkType::Adjacent, NextLinkFlags));
++			// Skip spacer lanes and continue until we find a real lane.
++			continue;
+ 		}
++		if (LaneDesc.Direction != NextLaneDesc.Direction)
++		{
++			NextLinkFlags |= EZoneLaneLinkFlags::OppositeDirection;
++		}
++		OutInternalLinks.Emplace(CurrentLaneIndex, FZoneLaneLinkData(CurrentLaneIndex + 1, EZoneLaneLinkType::Adjacent, NextLinkFlags));
++		break;
+ 	}
+ 
+-	if ((LaneDescIndex - 1) >= 0)
++	int32 PrevLaneDescIndex = LaneDescIndex;
++	while (--PrevLaneDescIndex >= 0)
+ 	{
+-		const FZoneLaneDesc& PrevLaneDesc = LaneDescs[LaneDescIndex - 1];
+-		if (PrevLaneDesc.Direction != EZoneLaneDirection::None)
++		const FZoneLaneDesc& PrevLaneDesc = LaneDescs[PrevLaneDescIndex];
++		if (PrevLaneDesc.Direction == EZoneLaneDirection::None)
+ 		{
+-			if (LaneDesc.Direction != PrevLaneDesc.Direction)
+-			{
+-				PrevLinkFlags |= EZoneLaneLinkFlags::OppositeDirection;
+-			}
+-			OutInternalLinks.Emplace(CurrentLaneIndex, FZoneLaneLinkData(CurrentLaneIndex - 1, EZoneLaneLinkType::Adjacent, PrevLinkFlags));
++			// Skip spacer lanes and continue until we find a real lane.
++			continue;
+ 		}
++		if (LaneDesc.Direction != PrevLaneDesc.Direction)
++		{
++			PrevLinkFlags |= EZoneLaneLinkFlags::OppositeDirection;
++		}
++		OutInternalLinks.Emplace(CurrentLaneIndex, FZoneLaneLinkData(CurrentLaneIndex - 1, EZoneLaneLinkType::Adjacent, PrevLinkFlags));
++		break;
+ 	}
+ }
+ 
+@@ -1029,21 +1027,21 @@
+ 	return First;
+ }
+ 
+-static void AddOrUpdateConnection(TArray<FLaneConnectionCandidate>& Candidates, const int32 SourceSlot, const int32 DestSlot, const FZoneGraphTag Tag)
++static void AddOrUpdateConnection(TArray<FLaneConnectionCandidate>& Candidates, const int32 SourceSlot, const int32 DestSlot, const FZoneGraphTagMask& TagMask)
+ {
+ 	FLaneConnectionCandidate* Cand = Candidates.FindByPredicate([SourceSlot, DestSlot](const FLaneConnectionCandidate& Cand) -> bool { return Cand.SourceSlot == SourceSlot&& Cand.DestSlot == DestSlot; });
+ 	if (Cand != nullptr)
+ 	{
+-		Cand->TagMask = Cand->TagMask | FZoneGraphTagMask(Tag);
++		Cand->TagMask = Cand->TagMask | TagMask;
+ 	}
+ 	else
+ 	{
+-		Candidates.Add(FLaneConnectionCandidate(SourceSlot, DestSlot, FZoneGraphTagMask(Tag)));
++		Candidates.Add(FLaneConnectionCandidate(SourceSlot, DestSlot, TagMask));
+ 	}
+ }
+ 	
+ static void AppendLaneConnectionCandidates(TArray<FLaneConnectionCandidate>& Candidates, TConstArrayView<FLaneConnectionSlot> SourceSlots, TConstArrayView<FLaneConnectionSlot> DestSlots,
+-										   const FZoneGraphTag Tag, const int32 MainDestPointIndex)
++										   const FZoneGraphTagMask& TagMask, const int32 MainDestPointIndex, bool bTurning)
+ {
+ 	const int32 SourceNum = SourceSlots.Num();
+ 	const int32 DestNum = DestSlots.Num();
+@@ -1066,7 +1064,7 @@
+ 		const int32 DestIdx = CalcDestinationSide(SourceSlots, DestSlots) ? (DestNum - 1) : 0;
+ 
+ 		// If a connection exists, we'll just update the tags, otherwise create new.
+-		AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, Tag);
++		AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
+ 
+ 		return;
+ 	}
+@@ -1081,7 +1079,7 @@
+ 			const int32 SourceIdx = i;
+ 			const int32 DestIdx = BestDestLaneIndex;
+ 
+-			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, Tag);
++			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
+ 		}
+ 		
+ 		return;
+@@ -1089,41 +1087,55 @@
+ 
+ 	const bool bOneLanePerDestination = EnumHasAnyFlags(ConnectionRestrictions, EZoneShapeLaneConnectionRestrictions::OneLanePerDestination);
+ 
+-	if (SourceNum < DestNum)
++	if (bTurning)
+ 	{
+-		const int32 BestLaneIndex = CalcDestinationSide(SourceSlots, DestSlots) ? (DestNum - 1) : 0;
+-
+-		// Distribute the lanes symmetrically around that best lane.
+-		const int32 FirstIndex = FitRange(BestLaneIndex - SourceNum/2, SourceNum, DestNum);
+-
+-		for (int32 i = 0; i < DestNum; i++)
++		// Turning connections by default get fully-connected slots. The builder may filter them later.
++		for (const FLaneConnectionSlot& SourceSlot : SourceSlots)
+ 		{
+-			const int32 SourceIdxUnClamped = i - FirstIndex;
+-			if (bOneLanePerDestination && (SourceIdxUnClamped < 0 || SourceIdxUnClamped >= SourceNum))
++			for (const FLaneConnectionSlot& DestSlot : DestSlots)
+ 			{
+-				continue;
++				AddOrUpdateConnection(Candidates, SourceSlot.Index, DestSlot.Index, TagMask);
+ 			}
+-
+-			const int32 SourceIdx = FMath::Clamp(SourceIdxUnClamped, 0, SourceNum - 1);
+-			const int32 DestIdx = i;
+-			
+-			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, Tag);
+ 		}
+ 	}
+ 	else
+ 	{
+-		const int32 BestLaneIndex = CalcDestinationSide(SourceSlots, DestSlots) ? 0 : (SourceNum - 1);
+-
+-		// Distribute the lanes symmetrically around that best lane.
+-		const int32 FirstIndex = FitRange(BestLaneIndex - DestNum/2, DestNum, SourceNum);
+-		
+-		for (int32 i = 0; i < SourceNum; i++)
++		// Non-turning connections by default get one-to-one connected slots.
++		if (SourceNum < DestNum)
+ 		{
+-			const int32 SourceIdx = i;
+-			const int32 DestIdx = FMath::Clamp(i - FirstIndex, 0, DestNum - 1);
++			const int32 BestLaneIndex = CalcDestinationSide(SourceSlots, DestSlots) ? (DestNum - 1) : 0;
++
++			// Distribute the lanes symmetrically around that best lane.
++			const int32 FirstIndex = FitRange(BestLaneIndex - SourceNum/2, SourceNum, DestNum);
++
++			for (int32 i = 0; i < DestNum; i++)
++			{
++				const int32 SourceIdxUnClamped = i - FirstIndex;
++				if (bOneLanePerDestination && (SourceIdxUnClamped < 0 || SourceIdxUnClamped >= SourceNum))
++				{
++					continue;
++				}
++
++				const int32 SourceIdx = FMath::Clamp(SourceIdxUnClamped, 0, SourceNum - 1);
++				const int32 DestIdx = i;
+ 			
+-			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, Tag);
++				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++			}
+ 		}
++		else
++		{
++			const int32 BestLaneIndex = CalcDestinationSide(SourceSlots, DestSlots) ? 0 : (SourceNum - 1);
++
++			// Distribute the lanes symmetrically around that best lane.
++			const int32 FirstIndex = FitRange(BestLaneIndex - DestNum/2, DestNum, SourceNum);
++		
++			for (int32 i = 0; i < SourceNum; i++)
++			{
++				const int32 SourceIdx = i;
++				const int32 DestIdx = FMath::Clamp(i - FirstIndex, 0, DestNum - 1);
++				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++			}
++		}
+ 	}
+ }
+ 
+@@ -1244,7 +1256,10 @@
+ 
+ 	int32 MainDestPointIndex = 0;
+ 	float MainDestScore = 0;
+-	
++
++	// Cache these in case we need them later.
++	TMap<int32, EZoneGraphTurnType> DestinationTurnTypes;
++
+ 	for (int32 PointIndex = Destinations.Num() - 1; PointIndex >= 0; PointIndex--)
+ 	{
+ 		const FConnectionEntry& Dest = Destinations[PointIndex];
+@@ -1273,18 +1288,21 @@
+ 																									Dest.Profile, Dest.IncomingConnections);
+ 
+ 		const EZoneShapeLaneConnectionRestrictions Restrictions = Source.Point.GetLaneConnectionRestrictions() | RestrictionsFromRules;
+-		
++
++		// Use closest point on dest so that lane profile widths do not affect direction.
++		const FVector SourceSide = FVector::CrossProduct(SourceForward, SourceUp);
++
++		const bool bIsTurning = FVector::DotProduct(SourceForward, DirToDest) < TurnThresholdAngleCos;
++		const bool bIsLeftTurn = bIsTurning && FVector::DotProduct(SourceSide, DirToDest) > 0.0f;
++
++		DestinationTurnTypes.Add(PointIndex, bIsTurning ? (bIsLeftTurn ? EZoneGraphTurnType::Left : EZoneGraphTurnType::Right) : EZoneGraphTurnType::NoTurn);
++
+ 		// Discard destination that would result in left or right turns.
+ 		if (EnumHasAnyFlags(Restrictions, EZoneShapeLaneConnectionRestrictions::NoLeftTurn | EZoneShapeLaneConnectionRestrictions::NoRightTurn))
+ 		{
+ 			const bool bRemoveLeft = EnumHasAnyFlags(Restrictions, EZoneShapeLaneConnectionRestrictions::NoLeftTurn);
+ 			const bool bRemoveRight = EnumHasAnyFlags(Restrictions, EZoneShapeLaneConnectionRestrictions::NoRightTurn);
+-
+-			// Use closest point on dest so that lane profile widths do not affect direction.
+-			const FVector SourceSide = FVector::CrossProduct(SourceForward, SourceUp);
+ 			
+-			const bool bIsTurning = FVector::DotProduct(SourceForward, DirToDest) < TurnThresholdAngleCos;
+-			const bool bIsLeftTurn = FVector::DotProduct(SourceSide, DirToDest) > 0.0f;
+ 			if (bIsTurning)
+ 			{
+ 				const bool bSkip = bIsLeftTurn ? bRemoveLeft : bRemoveRight;
+@@ -1364,6 +1382,10 @@
+ 				continue;
+ 			}
+ 
++			FZoneGraphTagMask TagMask(Tag);
++
++			const EZoneGraphTurnType TurnType = DestinationTurnTypes[DestSlots[DestSlotsBegin].PointIndex];
++
+ 			// Collect slots that have the current flag set.
+ 			TagSourceSlots.Reset();
+ 			for (const FLaneConnectionSlot& Slot : SourceSlots)
+@@ -1385,9 +1407,23 @@
+ 				}
+ 			}
+ 
++			for (const auto& CompatibleTagsElem : BuildSettings.CompatibleTags.FilterByPredicate([Tag](const FZoneGraphCompatibleTags& Elem) { return Elem.SourceTag == Tag; }))
++			{
++				const FZoneGraphTag& DestTag = CompatibleTagsElem.DestTag;
++				for (int32 j = DestSlotsBegin; j < DestSlotsEnd; j++)
++				{
++					const FLaneConnectionSlot& DestSlot = DestSlots[j];
++					if (DestSlot.LaneDesc.Tags.ContainsAny(DestTag) && CompatibleTagsElem.CompatibleForTurnTypes.Contains(TurnType))
++					{
++						TagDestSlots.Add(DestSlot);
++						TagMask.Add(FZoneGraphTagMask(DestTag));
++					}
++				}
++			}
++
+ 			if (TagSourceSlots.Num() > 0 && TagDestSlots.Num() > 0)
+ 			{
+-				AppendLaneConnectionCandidates(Candidates, TagSourceSlots, TagDestSlots, Tag, MainDestPointIndex);
++				AppendLaneConnectionCandidates(Candidates, TagSourceSlots, TagDestSlots, TagMask, MainDestPointIndex, TurnType != EZoneGraphTurnType::NoTurn);
+ 			}
+ 		}
+ 	}
+@@ -1395,7 +1431,7 @@
+ 	// Remove overlapping lanes.
+ 	// AppendLaneConnectionCandidates() sees only source and one destination at a time.
+ 	// This code removes any overlapping lanes and handles cases such as 4-lane entry might connect to two 2-lane exits.
+-	if (UE::ZoneGraph::Debug::bRemoveOverlap)
++	if (BuildSettings.bRemoveOverlap)
+ 	{
+ 		for (int32 Index = 0; Index < Candidates.Num() - 1; Index++)
+ 		{
+@@ -1441,7 +1477,7 @@
+ 
+ 	// Remove lanes that that connect to same destination as other lanes
+ 	// This reduces the number of merging lanes when there are multiple destinations.
+-	if (UE::ZoneGraph::Debug::bRemoveSameDestination)
++	if (BuildSettings.bRemoveSameDestination)
+ 	{
+ 		TArray<int32> SourceConnectionCount;
+ 		TArray<int32> DestConnectionCount;
+@@ -1538,7 +1574,7 @@
+ 	}
+ 
+ 	
+-	if (UE::ZoneGraph::Debug::bFillEmptyDestination)
++	if (BuildSettings.bFillEmptyDestination)
+ 	{
+ 		// Fill in empty destination connections if possible.
+ 		// This usually happens when overlaps are removed, and i can leave left or right turn destinations empty.
+@@ -1599,7 +1635,7 @@
+ 
+ 	TArray<const UZoneShapeComponent*> ShapeComponentsInMap;
+ 	PointIndexToZoneShapeComponent.GenerateValueArray(ShapeComponentsInMap);
+-
++	
+ 	const bool bAllZoneShapeComponentsInMapAreValid = !ShapeComponentsInMap.Contains(nullptr);
+ 	if (bAllZoneShapeComponentsInMapAreValid)
+ 	{
+@@ -1795,7 +1831,7 @@
+ 	TArray<int32> IncomingConnections;
+ 	OutgoingConnections.Init(0, Points.Num());
+ 	IncomingConnections.Init(0, Points.Num());
+-	
++
+ 	for (int32 SourceIdx = 0; SourceIdx < Points.Num(); SourceIdx++)
+ 	{
+ 		const FZoneShapePoint& SourcePoint = Points[SourceIdx];
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Public/ZoneGraphTypes.h /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h
+--- Source/ZoneGraph/Public/ZoneGraphTypes.h	2025-02-12 20:17:25
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h	2025-02-12 15:04:54
+@@ -968,7 +968,30 @@
+ 	int32 ConnectionRestrictions = 0;
+ };
+ 
++UENUM(BlueprintType)
++enum class EZoneGraphTurnType : uint8
++{
++	Right,
++	Left,
++	NoTurn,
++};
++
+ USTRUCT()
++struct ZONEGRAPH_API FZoneGraphCompatibleTags
++{
++	GENERATED_BODY()
++
++	UPROPERTY(Category = CompatibleTags, EditAnywhere)
++	FZoneGraphTag SourceTag;
++
++	UPROPERTY(Category = CompatibleTags, EditAnywhere)
++	FZoneGraphTag DestTag;
++
++	UPROPERTY(Category = CompatibleTags, EditAnywhere)
++	TSet<EZoneGraphTurnType> CompatibleForTurnTypes;
++};
++
++USTRUCT()
+ struct ZONEGRAPH_API FZoneGraphBuildSettings
+ {
+ 	GENERATED_BODY()
+@@ -1004,6 +1027,22 @@
+ 	/** Routing rules applied to polygon shapes */
+ 	UPROPERTY(Category = Lanes, EditAnywhere)
+ 	TArray<FZoneGraphLaneRoutingRule> PolygonRoutingRules;
++
++	/** Tags which should be connected for certain turn types even when they are not the same. */
++	UPROPERTY(Category = Lanes, EditAnywhere)
++	TArray<FZoneGraphCompatibleTags> CompatibleTags;
++
++	/** Whether to remove overlapping lane connections. */
++	UPROPERTY(Category = Lanes, EditAnywhere)
++	bool bRemoveOverlap = true;
++
++	/** Whether to remove lane connections when another already has the same destination. */
++	UPROPERTY(Category = Lanes, EditAnywhere)
++	bool bRemoveSameDestination = true;
++
++	/** Whether to fill empty destination connections if possible. */
++	UPROPERTY(Category = Lanes, EditAnywhere)
++	bool bFillEmptyDestination = true;
+ 
+ 	/** Max distance between two shape points for them to be snapped together. */
+ 	UPROPERTY(Category = PointSnapping, EditAnywhere)

--- a/EngineMods/5.5/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.3
+++ b/EngineMods/5.5/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.3
@@ -1,0 +1,171 @@
+diff -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneGraphQuery.cpp /home/giovanni/Develop/VayuSim/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphQuery.cpp
+--- Source/ZoneGraph/Private/ZoneGraphQuery.cpp	2023-06-01 09:13:48.000000000 -0400
++++ /home/giovanni/Develop/VayuSim/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Private/ZoneGraphQuery.cpp	2025-03-10 17:18:45.936878604 -0400
+@@ -589,5 +589,135 @@
+ 
+ 	return OutLaneSections.Num() > 0;
+ }
++
++bool FindIntersectionBetweenSegments(const FVector& SegmentAStart, const FVector& SegmentAEnd, const FVector& SegmentBStart, const FVector& SegmentBEnd, float& OutDistanceAlongSegmentA, float Tolerance = KINDA_SMALL_NUMBER)
++{
++	FVector ClosestPointOnSegmentAToSegmentB;
++	FVector ClosestPointOnSegmentBToSegmentA;
++
++	FMath::SegmentDistToSegment(SegmentAStart, SegmentAEnd, SegmentBStart, SegmentBEnd, ClosestPointOnSegmentAToSegmentB, ClosestPointOnSegmentBToSegmentA);
++
++	const float SquaredDistanceBetweenClosestPoints = (ClosestPointOnSegmentBToSegmentA - ClosestPointOnSegmentAToSegmentB).SizeSquared();
++	const float SquaredTolerance = FMath::Square(Tolerance);
++
++	if (SquaredDistanceBetweenClosestPoints < SquaredTolerance)
++	{
++		const float DistanceAlongSegmentA = (ClosestPointOnSegmentAToSegmentB - SegmentAStart).Size();
++		OutDistanceAlongSegmentA = DistanceAlongSegmentA;
++
++		return true;
++	}
++
++	return false;
++}
++
++bool FindFirstIntersectionBetweenLanes(
++		const FZoneGraphStorage& Storage,
++		const FZoneGraphLaneHandle& QueryLaneHandle,
++		const FZoneGraphLaneHandle& OtherLaneHandle,
++		const float LateralOffsetFromCenterOfOtherLane,
++		float& OutDistanceAlongQueryLane,
++		int32* OutQueryLaneIntersectionSegmentIndex,
++		float* OutNormalizedDistanceAlongQueryLaneIntersectionSegment,
++		float Tolerance)
++{
++	if (!EnsureLaneHandle(Storage, QueryLaneHandle, __FUNCTION__))
++	{
++		return false;
++	}
++
++	if (!EnsureLaneHandle(Storage, OtherLaneHandle, __FUNCTION__))
++	{
++		return false;
++	}
++	
++	return FindFirstIntersectionBetweenLanes(
++		Storage,
++		QueryLaneHandle.Index,
++		OtherLaneHandle.Index,
++		LateralOffsetFromCenterOfOtherLane,
++		OutDistanceAlongQueryLane,
++		OutQueryLaneIntersectionSegmentIndex,
++		OutNormalizedDistanceAlongQueryLaneIntersectionSegment,
++		Tolerance);
++}
++
++bool FindFirstIntersectionBetweenLanes(
++		const FZoneGraphStorage& Storage,
++		const uint32 QueryLaneIndex,
++		const uint32 OtherLaneIndex,
++		const float LateralOffsetFromCenterOfOtherLane,
++		float& OutDistanceAlongQueryLane,
++		int32* OutQueryLaneIntersectionSegmentIndex,
++		float* OutNormalizedDistanceAlongQueryLaneIntersectionSegment,
++		float Tolerance)
++{
++	const FZoneLaneData& QueryLane = Storage.Lanes[QueryLaneIndex];
++	const int32 NumQueryLanePoints = QueryLane.PointsEnd - QueryLane.PointsBegin;
++
++	if (!ensureMsgf(NumQueryLanePoints >= 2, TEXT("QueryLane must have at least 2 points in FindFirstIntersectionBetweenLanes.")))
++	{
++		return false;
++	}
++
++	const FZoneLaneData& OtherLane = Storage.Lanes[OtherLaneIndex];
++	const int32 NumOtherLanePoints = OtherLane.PointsEnd - OtherLane.PointsBegin;
++
++	if (!ensureMsgf(NumOtherLanePoints >= 2, TEXT("OtherLane must have at least 2 points in FindFirstIntersectionBetweenLanes.")))
++	{
++		return false;
++	}
++
++	float DistanceAlongQueryLane = 0.0f;
++
++	for (int32 QueryLanePointIndex = QueryLane.PointsBegin; QueryLanePointIndex < QueryLane.PointsEnd - 1; ++QueryLanePointIndex)
++	{
++		const FVector& QueryLaneSegmentStartLocation = Storage.LanePoints[QueryLanePointIndex];
++		const FVector& QueryLaneSegmentEndLocation = Storage.LanePoints[QueryLanePointIndex + 1];
++
++		const float QuerySegmentLength = (QueryLaneSegmentEndLocation - QueryLaneSegmentStartLocation).Size();
++
++		for (int32 OtherLanePointIndex = OtherLane.PointsBegin; OtherLanePointIndex < OtherLane.PointsEnd - 1; ++OtherLanePointIndex)
++		{
++			const FVector OtherLaneSegmentStartTangentVector = Storage.LaneTangentVectors[OtherLanePointIndex];
++			const FVector OtherLaneSegmentStartUpVector = Storage.LaneUpVectors[OtherLanePointIndex];
++			
++			const FVector OtherLaneSegmentStartRightVector = FVector::CrossProduct(OtherLaneSegmentStartTangentVector, OtherLaneSegmentStartUpVector);
++
++			const FVector OtherLaneSegmentEndTangentVector = Storage.LaneTangentVectors[OtherLanePointIndex + 1];
++			const FVector OtherLaneSegmentEndUpVector = Storage.LaneUpVectors[OtherLanePointIndex + 1];
++			
++			const FVector OtherLaneSegmentEndRightVector = FVector::CrossProduct(OtherLaneSegmentEndTangentVector, OtherLaneSegmentEndUpVector);
++			
++			const FVector& OtherLaneSegmentStartLocation = Storage.LanePoints[OtherLanePointIndex] + OtherLaneSegmentStartRightVector * LateralOffsetFromCenterOfOtherLane;
++			const FVector& OtherLaneSegmentEndLocation = Storage.LanePoints[OtherLanePointIndex + 1] + OtherLaneSegmentEndRightVector * LateralOffsetFromCenterOfOtherLane;
++
++			float DistanceAlongQuerySegment = 0.0f;
++			
++			if (FindIntersectionBetweenSegments(QueryLaneSegmentStartLocation, QueryLaneSegmentEndLocation, OtherLaneSegmentStartLocation, OtherLaneSegmentEndLocation, DistanceAlongQuerySegment, Tolerance))
++			{
++				OutDistanceAlongQueryLane = DistanceAlongQueryLane + DistanceAlongQuerySegment;
++
++				if (OutQueryLaneIntersectionSegmentIndex != nullptr)
++				{
++					*OutQueryLaneIntersectionSegmentIndex = QueryLanePointIndex;
++				}
++
++				if (OutNormalizedDistanceAlongQueryLaneIntersectionSegment != nullptr)
++				{
++					const float NormalizedDistanceAlongQuerySegment = QuerySegmentLength > 0.0f ? DistanceAlongQuerySegment / QuerySegmentLength : 0.0f;
++					
++					*OutNormalizedDistanceAlongQueryLaneIntersectionSegment = NormalizedDistanceAlongQuerySegment;
++				}
++				
++				return true;
++			}
++		}
++		
++		DistanceAlongQueryLane += QuerySegmentLength;
++	}
++
++	return false;
++}
+ 	
+ } // UE::ZoneGraph::Query
+diff -urN --strip-trailing-cr Source/ZoneGraph/Public/ZoneGraphQuery.h /home/giovanni/Develop/VayuSim/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphQuery.h
+--- Source/ZoneGraph/Public/ZoneGraphQuery.h	2023-06-01 09:13:48.000000000 -0400
++++ /home/giovanni/Develop/VayuSim/Plugins/Tempo/External/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphQuery.h	2025-03-10 17:18:45.937878581 -0400
+@@ -75,5 +75,27 @@
+ 	
+ /**  Find sections of lanes fully overlapping (including lane width) in ZoneGraph Storage. */
+ ZONEGRAPH_API bool FindLaneOverlaps(const FZoneGraphStorage& Storage, const FVector& Center, const float Radius, const FZoneGraphTagFilter TagFilter, TArray<FZoneGraphLaneSection>& OutLaneSections);
++	
++/**  Find the first intersection between two lanes in terms of distance along QueryLane in ZoneGraph Storage. */
++ZONEGRAPH_API bool FindFirstIntersectionBetweenLanes(
++	const FZoneGraphStorage& Storage,
++	const FZoneGraphLaneHandle& QueryLaneHandle,
++	const FZoneGraphLaneHandle& OtherLaneHandle,
++	const float LateralOffsetFromCenterOfOtherLane,
++	float& OutDistanceAlongQueryLane,
++	int32* OutQueryLaneIntersectionSegmentIndex = nullptr,
++	float* OutNormalizedDistanceAlongQueryLaneIntersectionSegment = nullptr,
++	float Tolerance = KINDA_SMALL_NUMBER);
++	
++/**  Find the first intersection between two lanes in terms of distance along QueryLane in ZoneGraph Storage. */
++ZONEGRAPH_API bool FindFirstIntersectionBetweenLanes(
++	const FZoneGraphStorage& Storage,
++	const uint32 QueryLaneIndex,
++	const uint32 OtherLaneIndex,
++	const float LateralOffsetFromCenterOfOtherLane,
++	float& OutDistanceAlongQueryLane,
++	int32* OutQueryLaneIntersectionSegmentIndex = nullptr,
++	float* OutNormalizedDistanceAlongQueryLaneIntersectionSegment = nullptr,
++	float Tolerance = KINDA_SMALL_NUMBER);
+ 
+ } // UE::ZoneGraph::Query
+\ No newline at end of file

--- a/EngineMods/5.5/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.4
+++ b/EngineMods/5.5/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.4
@@ -1,0 +1,100 @@
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneShapeUtilities.cpp /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp
+--- Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2025-03-20 15:42:00
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2025-03-20 15:14:24
+@@ -7,6 +7,7 @@
+ #include "HAL/IConsoleManager.h"
+ #include "ZoneGraphSettings.h"
+ #include "ZoneShapeComponent.h"
++#include "Kismet/KismetMathLibrary.h"
+ 
+ namespace UE::ZoneShape::Utilities {
+ 
+@@ -1687,7 +1688,46 @@
+ 
+ 		Lane.PointsBegin = OutZoneStorage.LanePoints.Num();
+ 
+-		if (RoutingType == EZoneShapePolygonRoutingType::Bezier)
++		if (RoutingType == EZoneShapePolygonRoutingType::TempoBezier)
++		{
++			// For non-turning connections, use Distance between source and dest slots / 3.0 as the radius.
++			float SourceTangentLength = FVector::Distance(SourceSlot.Position, DestSlot.Position) / 3.0;
++			float DestTangentLength = SourceTangentLength;
++
++			static const float MinAngleCos = FMath::Cos(FMath::DegreesToRadians(BuildSettings.TurnThresholdAngle));
++			const bool bIsTurning = FVector2D::DotProduct(FVector2D(SourceSlot.Forward), FVector2D(-DestSlot.Forward)) < MinAngleCos;
++			if (bIsTurning)
++			{
++				// For turning connections, choose source and dest radius to approximate a circle
++				const FVector2D SourcePoint2D(SourceSlot.Position);
++				const FVector2D DestPoint2D(DestSlot.Position);
++				const FVector2D SourceRadial2D = Rotate90CCW(FVector2D(SourceSlot.Forward));
++				const FVector2D DestRadial2D = Rotate90CCW(FVector2D(DestSlot.Forward));
++				float SourceRadius, DestRadius;
++				if (ensureMsgf(IntersectRayRay2D(FVector2D(SourceSlot.Position), SourceRadial2D.GetSafeNormal(),
++						FVector2D(DestSlot.Position), DestRadial2D.GetSafeNormal(),
++						/*out*/ SourceRadius, /*out*/ DestRadius),
++					TEXT("No intersection found between radial directions while building ZoneShape with TempoBezier routing")))
++				{
++					// Credit: https://stackoverflow.com/questions/1734745/how-to-create-circle-with-b%C3%A9zier-curves
++					const float TurnAngle = UKismetMathLibrary::DegreesToRadians(UKismetMathLibrary::NormalizedDeltaRotator(SourceSlot.Forward.Rotation(), (-DestSlot.Forward).Rotation()).Yaw);
++					const float Mul = FMath::Abs(4.0 / 3.0 * FMath::Tan(TurnAngle / 4.0)) * BuildSettings.TempoBezierTangentLengthMultiplier;
++
++					// Abs because IntersectRayRay2D will return negative radii if the intersection is in the opposite direction of the radial directions supplied.
++					SourceTangentLength = FMath::Abs(SourceRadius) * Mul;
++					DestTangentLength = FMath::Abs(DestRadius) * Mul;
++				}
++			}
++
++			// Calculate Bezier curve connecting the source and destination.
++			const FVector SourceControlPoint = SourceSlot.Position + SourceSlot.Forward * SourceTangentLength;
++			const FVector DestControlPoint = DestSlot.Position + DestSlot.Forward * DestTangentLength;
++
++			OutZoneStorage.LanePoints.Add(SourceSlot.Position); // Explicitly add the start point as tessellate omits the start point.
++			const float TessTolerance = BuildSettings.GetLaneTessellationTolerance(Lane.Tags);
++			UE::CubicBezier::Tessellate(OutZoneStorage.LanePoints, SourceSlot.Position, SourceControlPoint, DestControlPoint, DestSlot.Position, TessTolerance);
++		}
++		else if (RoutingType == EZoneShapePolygonRoutingType::Bezier)
+ 		{
+ 			// Calculate Bezier curve connecting the source and destination.
+ 			const float TangentLength = FVector::Distance(SourceSlot.Position, DestSlot.Position) / 3.0f;
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Public/ZoneGraphTypes.h /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h
+--- Source/ZoneGraph/Public/ZoneGraphTypes.h	2025-03-20 15:42:00
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h	2025-03-20 15:20:28
+@@ -758,6 +758,7 @@
+ UENUM(BlueprintType)
+ enum class EZoneShapePolygonRoutingType : uint8
+ {
++	TempoBezier,	// Use bezier curves with Tempo-adjusted tangents for routing.
+ 	Bezier,			// Use bezier curves for routing.
+ 	Arcs,			// Use arcs for lane routing.
+ };
+@@ -1023,6 +1024,10 @@
+ 	/** When the relative angle (in degrees) to destination on a polygon is more than the specified angle, it is considered left or right turn. */
+ 	UPROPERTY(Category = Lanes, EditAnywhere)
+ 	float TurnThresholdAngle = 5.0f;
++
++	/** When using TemopBezier routing type, scale the nominal tangent lengths for turning connections by this amount. */
++	UPROPERTY(Category = Lanes, EditAnywhere)
++	float TempoBezierTangentLengthMultiplier = 1.0f;
+ 
+ 	/** Routing rules applied to polygon shapes */
+ 	UPROPERTY(Category = Lanes, EditAnywhere)
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Public/ZoneShapeComponent.h /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneShapeComponent.h
+--- Source/ZoneGraph/Public/ZoneShapeComponent.h	2025-03-20 15:42:00
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneShapeComponent.h	2025-03-20 15:16:23
+@@ -202,7 +202,7 @@
+ 
+ 	/** Polygon shape routing type */
+ 	UPROPERTY(Category = Zone, EditAnywhere, BlueprintReadWrite, meta = (AllowPrivateAccess = "true", IncludeInHash, EditCondition = "ShapeType == FZoneShapeType::Polygon"))
+-	EZoneShapePolygonRoutingType PolygonRoutingType = EZoneShapePolygonRoutingType::Bezier;
++	EZoneShapePolygonRoutingType PolygonRoutingType = EZoneShapePolygonRoutingType::TempoBezier;
+ 	
+ 	/** Zone tags, the lanes inherit zone tags. */
+ 	UPROPERTY(Category = Zone, EditAnywhere, BlueprintReadWrite, meta = (AllowPrivateAccess = "true", IncludeInHash))
+@@ -225,4 +225,4 @@
+ #if WITH_EDITORONLY_DATA
+ 	FOnShapeDataChanged ShapeDataChangedEvent;
+ #endif
+-};
+\ No newline at end of file
++};

--- a/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/Configuration/TempoModuleRules.cs
+++ b/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/Configuration/TempoModuleRules.cs
@@ -1,0 +1,69 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved.
+
+using System.IO;
+using UnrealBuildTool;
+
+/// <summary>
+/// TempoModuleRules extends ModuleRules to always add Include paths for generated Protobuf code.
+/// </summary>
+public class TempoModuleRules : ModuleRules
+{
+	/// <summary>
+	/// Constructor. 
+	/// </summary>
+	/// <param name="Target">Rules for building this target</param>
+	public TempoModuleRules(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		string PublicModuleFolder = Path.Combine(ModuleDirectory, "Public");
+		string PrivateModuleFolder = Path.Combine(ModuleDirectory, "Private");
+		string PublicProtobufIncludes = Path.Combine(PublicModuleFolder, "ProtobufGenerated");
+		string PrivateProtobufIncludes = Path.Combine(PrivateModuleFolder, "ProtobufGenerated");
+
+		if (System.IO.Directory.GetFiles(PublicModuleFolder, "*.proto", SearchOption.AllDirectories).Length > 0)
+		{
+			System.IO.Directory.CreateDirectory(PublicProtobufIncludes);
+			PublicIncludePaths.AddRange(
+				new string[]
+				{
+					PublicProtobufIncludes
+				}
+			);
+			System.IO.Directory.CreateDirectory(PrivateProtobufIncludes);
+			PrivateIncludePaths.AddRange(
+				new string[]
+				{
+					PrivateProtobufIncludes
+				}
+			);
+		}
+
+		if (System.IO.Directory.GetFiles(PrivateModuleFolder, "*.proto", SearchOption.AllDirectories).Length > 0)
+		{
+			System.IO.Directory.CreateDirectory(PrivateProtobufIncludes);
+			PrivateIncludePaths.AddRange(
+				new string[]
+				{
+					PrivateProtobufIncludes
+				}
+			);
+		}
+	}
+
+	/// <summary>
+	/// Whether hot reload should be enabled for this module.
+	/// </summary>
+	protected bool bCanHotReload
+	{
+		get
+		{
+			return Context.bCanHotReload;
+		}
+
+		set
+		{  
+			Context.bCanHotReload = value;                
+		}
+	}
+}

--- a/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/Configuration/UEBuildTarget.cs.patch.1
+++ b/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/Configuration/UEBuildTarget.cs.patch.1
@@ -1,0 +1,13 @@
+--- Configuration/UEBuildTarget.cs	2024-09-14 20:57:28
++++ UEBuildTarget.cs	2024-09-14 18:49:50
+@@ -3184,6 +3184,10 @@
+ 				return true;
+ 			}
+ 			if (EngineModuleName == "Voice" && PluginModuleName == "AndroidPermission")
++			{
++				return true;
++			}
++			if (PluginModuleName == "ZoneGraph" || PluginModuleName == "ZoneGraphDebug")
+ 			{
+ 				return true;
+ 			}

--- a/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/Platform/Linux/LinuxToolChain.cs.patch.1
+++ b/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/Platform/Linux/LinuxToolChain.cs.patch.1
@@ -1,0 +1,14 @@
+--- Platform/Linux/LinuxToolChain.cs	2025-04-11 10:07:25
++++ LinuxToolChain.cs	2025-04-11 11:40:07
+@@ -1241,7 +1241,10 @@
+ 			{
+ 				string RelativePath = RuntimeLibaryPath;
+
+-				if (!RelativePath.StartsWith("$"))
++				// TEMPO_MOD Begin - [For Fixing rpaths of Rebuilt Engine Plugins] - Avoid making RelativePath relative
++				// to the build output when it starts with "." (in addition to "$", which was already here).
++				if (!RelativePath.StartsWith("$") && !RelativePath.StartsWith("."))
++				// TEMPO_MOD End
+ 				{
+ 					if (LinkEnvironment.bIsBuildingDLL)
+ 					{

--- a/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/ToolChain/TempoLinuxToolChain.cs
+++ b/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/ToolChain/TempoLinuxToolChain.cs
@@ -1,0 +1,165 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved.
+
+// This file was/will be copied into the UnrealBuildTool directory during Tempo's setup.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using EpicGames.Core;
+using Microsoft.Extensions.Logging;
+using UnrealBuildBase;
+
+namespace UnrealBuildTool
+{
+    // We want dynamic libraries that link static libraries to re-export all the symbols of those libraries, so that
+    // we only have one definition of each in our program. Otherwise, we encounter strange crashes related to global
+    // symbols in gRPC and Protobuf.
+    //
+    // On Linux, we solve this by:
+    // 1. The linker will only re-export symbols from static libraries that are used in the so. However we can
+    //    force it to re-export symbols from certain libraries with the --whole-archive option. We store a list,
+    //    in a .def file, along with the static libraries to specify which ones we want to re-export completely.
+    //    The only reason it's not all of them is because some have repeated symbols, and the Mac linker does not
+    //    support the --allow-multiple-definition option. The clang linker does, but we want to keep the Linux and
+    //    Mac builds as similar as possible.
+    class TempoLinuxToolChain : LinuxToolChain
+    {
+        public TempoLinuxToolChain(ReadOnlyTargetRules Target, ILogger Logger)
+            : this(Target.Architecture,
+                UEBuildPlatform.GetSDK(UnrealTargetPlatform.Linux) as LinuxPlatformSDK ?? throw new System.Exception("Linux SDK not found"),
+                TempoLinuxToolChainClangOptions(Target),
+                Logger)
+        {
+
+        }
+
+        private TempoLinuxToolChain(UnrealArch InArchitecture, LinuxPlatformSDK InSDK, ClangToolChainOptions InOptions, ILogger Logger)
+            : base(InArchitecture, InSDK, InOptions, Logger)
+        {
+            
+        }
+        
+        public override FileItem[] LinkAllFiles(LinkEnvironment LinkEnvironment, bool bBuildImportLibraryOnly,
+            IActionGraphBuilder Graph)
+        {
+            HashSet<string> ExportedLibraries = new HashSet<string>();
+            foreach (var Library in LinkEnvironment.Libraries)
+            {
+                String LibraryPath = Library.ToString();
+                if (Library.GetExtension() == ".def")
+                {
+                    ExportedLibraries = new HashSet<string>(FileReference.ReadAllLines(Library));
+                }
+            }
+            
+            foreach (var Library in LinkEnvironment.Libraries)
+            {
+                String LibraryPath = Library.ToString();
+                if (ExportedLibraries.Contains(Library.GetFileName()))
+                {
+                    LinkEnvironment.AdditionalArguments += $" -Xlinker --whole-archive \"{LibraryPath}\"";
+                }
+            }
+
+            LinkEnvironment.AdditionalArguments += " -Xlinker --allow-multiple-definition";
+            
+            LinkEnvironment.Libraries.RemoveAll(Library => Library.GetExtension() == ".def");
+            
+            return base.LinkAllFiles(LinkEnvironment, bBuildImportLibraryOnly, Graph);
+        }
+        
+        // Copied from LinuxPlatform. Cannot figure out a way to get these from LinuxPlatform.CreateToolChain
+        static ClangToolChainOptions TempoLinuxToolChainClangOptions(ReadOnlyTargetRules Target)
+        {
+            ClangToolChainOptions Options = ClangToolChainOptions.None;
+
+            if (Target.LinuxPlatform.bEnableAddressSanitizer)
+            {
+                Options |= ClangToolChainOptions.EnableAddressSanitizer;
+
+                if (Target.LinkType != TargetLinkType.Monolithic)
+                {
+                    Options |= ClangToolChainOptions.EnableSharedSanitizer;
+                }
+            }
+            if (Target.LinuxPlatform.bEnableThreadSanitizer)
+            {
+                Options |= ClangToolChainOptions.EnableThreadSanitizer;
+
+                if (Target.LinkType != TargetLinkType.Monolithic)
+                {
+                    throw new BuildException("Thread Sanitizer (TSan) unsupported for non-monolithic builds");
+                }
+            }
+            if (Target.LinuxPlatform.bEnableUndefinedBehaviorSanitizer)
+            {
+                Options |= ClangToolChainOptions.EnableUndefinedBehaviorSanitizer;
+
+                if (Target.LinkType != TargetLinkType.Monolithic)
+                {
+                    Options |= ClangToolChainOptions.EnableSharedSanitizer;
+                }
+            }
+            if (Target.LinuxPlatform.bEnableMemorySanitizer)
+            {
+                Options |= ClangToolChainOptions.EnableMemorySanitizer;
+
+                if (Target.LinkType != TargetLinkType.Monolithic)
+                {
+                    throw new BuildException("Memory Sanitizer (MSan) unsupported for non-monolithic builds");
+                }
+            }
+            if (Target.LinuxPlatform.bDisableDumpSyms)
+            {
+                Options |= ClangToolChainOptions.DisableDumpSyms;
+            }
+            if (Target.LinuxPlatform.bEnableLibFuzzer)
+            {
+                Options |= ClangToolChainOptions.EnableLibFuzzer;
+
+                if (Target.LinkType != TargetLinkType.Monolithic)
+                {
+                    throw new BuildException("LibFuzzer is unsupported for non-monolithic builds.");
+                }
+            }
+
+            if (((LinuxPlatform)UEBuildPlatform.GetBuildPlatform(UnrealTargetPlatform.Linux)).IsLTOEnabled(Target))
+            {
+                Options |= ClangToolChainOptions.EnableLinkTimeOptimization;
+
+                if (Target.bPreferThinLTO)
+                {
+                    Options |= ClangToolChainOptions.EnableThinLTO;
+                }
+            }
+            else if (Target.bPreferThinLTO)
+            {
+                // warn about ThinLTO not being useful on its own
+                Log.Logger.LogWarning("Warning: bPreferThinLTO is set, but LTO is disabled. Flag will have no effect");
+            }
+
+            if (Target.bUseAutoRTFMCompiler)
+            {
+                Options |= ClangToolChainOptions.UseAutoRTFMCompiler;
+            }
+
+            if (Target.LinuxPlatform.bTuneDebugInfoForLLDB)
+            {
+                Options |= ClangToolChainOptions.TuneDebugInfoForLLDB;
+            }
+
+            if (Target.LinuxPlatform.bPreservePSYM)
+            {
+                Options |= ClangToolChainOptions.PreservePSYM;
+            }
+
+            // Disable color logging if we are on a build machine
+            if (Environment.GetEnvironmentVariable("IsBuildMachine") == "1")
+            {
+                Log.ColorConsoleOutput = false;
+            }
+
+            return Options;
+        }
+    }
+}

--- a/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/ToolChain/TempoMacToolChain.cs
+++ b/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/ToolChain/TempoMacToolChain.cs
@@ -1,0 +1,94 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved.
+
+// This file was/will be copied into the UnrealBuildTool directory during Tempo's setup.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using EpicGames.Core;
+using Microsoft.Extensions.Logging;
+using UnrealBuildBase;
+
+namespace UnrealBuildTool
+{
+    // We want dynamic libraries that link static libraries to re-export all the symbols of those libraries, so that
+    // we only have one definition of each in our program. Otherwise, we encounter strange crashes related to global
+    // symbols in gRPC and Protobuf.
+    //
+    // On Mac, we solve this by:
+    // 1. The linker will only re-export symbols from static libraries that are used in the dylib. However we can
+    //    force it to re-export symbols from certain libraries with the -force_load option. We store a list,
+    //    in a .def file, along with the static libraries to specify which ones we want to re-export completely.
+    //    The only reason it's not all of them is because some have repeated symbols, and the Mac linker does not
+    //    support the --allow-multiple-definition option.
+    class TempoMacToolChain : MacToolChain
+    {
+        public TempoMacToolChain(ReadOnlyTargetRules Target, ILogger Logger)
+            : this(Target, TempoMacToolChainClangOptions(Target), Logger)
+        {
+            
+        }
+
+        private TempoMacToolChain(ReadOnlyTargetRules Target, ClangToolChainOptions InOptions, ILogger Logger)
+            : base(Target, InOptions, Logger)
+        {
+            
+        }
+
+        public override FileItem[] LinkAllFiles(LinkEnvironment LinkEnvironment, bool bBuildImportLibraryOnly,
+            IActionGraphBuilder Graph)
+        {
+            HashSet<string> ExportedLibraries = new HashSet<string>();
+            foreach (var Library in LinkEnvironment.Libraries)
+            {
+                String LibraryPath = Library.ToString();
+                if (Library.GetExtension() == ".def")
+                {
+                    ExportedLibraries = new HashSet<string>(FileReference.ReadAllLines(Library));
+                }
+            }
+            
+            foreach (var Library in LinkEnvironment.Libraries)
+            {
+                String LibraryPath = Library.ToString();
+                if (ExportedLibraries.Contains(Library.GetFileName()))
+                {
+                    LinkEnvironment.AdditionalArguments += $" -force_load \"{LibraryPath}\"";
+                }
+            }
+            
+            LinkEnvironment.Libraries.RemoveAll(Library => Library.GetExtension() == ".def");
+            
+            return base.LinkAllFiles(LinkEnvironment, bBuildImportLibraryOnly, Graph);
+        }
+        
+        // Copied from MacPlatform. Cannot figure out a way to get these from MacPlatform.CreateToolChain
+        static ClangToolChainOptions TempoMacToolChainClangOptions(ReadOnlyTargetRules Target)
+        {
+            ClangToolChainOptions Options = ClangToolChainOptions.None;
+
+            string? AddressSanitizer = Environment.GetEnvironmentVariable("ENABLE_ADDRESS_SANITIZER");
+            string? ThreadSanitizer = Environment.GetEnvironmentVariable("ENABLE_THREAD_SANITIZER");
+            string? UndefSanitizerMode = Environment.GetEnvironmentVariable("ENABLE_UNDEFINED_BEHAVIOR_SANITIZER");
+
+            if (Target.MacPlatform.bEnableAddressSanitizer || (AddressSanitizer != null && AddressSanitizer == "YES"))
+            {
+                Options |= ClangToolChainOptions.EnableAddressSanitizer;
+            }
+            if (Target.MacPlatform.bEnableThreadSanitizer || (ThreadSanitizer != null && ThreadSanitizer == "YES"))
+            {
+                Options |= ClangToolChainOptions.EnableThreadSanitizer;
+            }
+            if (Target.MacPlatform.bEnableUndefinedBehaviorSanitizer || (UndefSanitizerMode != null && UndefSanitizerMode == "YES"))
+            {
+                Options |= ClangToolChainOptions.EnableUndefinedBehaviorSanitizer;
+            }
+            if (Target.bShouldCompileAsDLL)
+            {
+                Options |= ClangToolChainOptions.OutputDylib;
+            }
+
+            return Options;
+        }
+    }
+}

--- a/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/ToolChain/TempoVCToolChain.cs
+++ b/EngineMods/5.5/Engine/Source/Programs/UnrealBuildTool/ToolChain/TempoVCToolChain.cs
@@ -1,0 +1,77 @@
+﻿// Copyright Tempo Simulation, LLC. All Rights Reserved.
+
+// This file was/will be copied into the UnrealBuildTool directory during Tempo's setup.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using EpicGames.Core;
+using Microsoft.Extensions.Logging;
+using UnrealBuildBase;
+
+namespace UnrealBuildTool
+{
+    // We want dynamic libraries that link static libraries to re-export all the symbols of those libraries, so that
+    // we only have one definition of each in our program. Otherwise, we encounter strange crashes related to global
+    // symbols in gRPC and Protobuf.
+    //
+    // On Windows, we solve this by:
+    // 1. UnrealBuildTool, for any "cross-referenced" module and always on Windows, explicitly creates an import
+    //    library for the dll before the actual link step (and then pushes aside the one created during linking).
+    //    VCToolChain does not include dependent static libraries in the import library it explicitly creates,
+    //    (even though they will be in the one the linker makes) so we add them ourselves.
+    // 2. The linker will only re-export symbols from static libraries that are used in the dll. The option
+    //    /WHOLEARCHIVE advertises that it "can" be used to re-export, which would make it equivalent to the
+    //    -force_load and --whole-archive options on Mac and Linux, but from my testing it does not get all symbols.
+    //    So instead we include a .def file with our ThirdParty dependencies that includes all the symbols from
+    //    all the libraries (deduplicated, with many exceptions, its complicated) and explicitly export them all.s
+    class TempoVCToolChain : VCToolChain
+    {
+        public TempoVCToolChain(ReadOnlyTargetRules Target, ILogger Logger)
+            : base(Target, Logger)
+        {
+            
+        }
+        
+        public override FileItem LinkFiles(LinkEnvironment LinkEnvironment, bool bBuildImportLibraryOnly,
+            IActionGraphBuilder Graph)
+        {
+            foreach (var Library in LinkEnvironment.Libraries)
+            {
+                String LibraryPath = Library.ToString();
+
+                if (bBuildImportLibraryOnly)
+                {
+                    if (LibraryPath.Contains("Tempo") && LibraryPath.Contains("Source") && Library.GetExtension() != ".def")
+                    {
+                        LinkEnvironment.InputFiles.Add(FileItem.GetItemByFileReference(Library));
+                    }
+                }
+                
+                if (Library.GetExtension() == ".def")
+                {
+                    LinkEnvironment.ModuleDefinitionFile = LibraryPath;
+                }
+            }
+
+            LinkEnvironment.Libraries.RemoveAll(Library => Library.GetExtension() == ".def");
+        
+            return base.LinkFiles(LinkEnvironment, bBuildImportLibraryOnly, Graph);
+        }
+
+        protected override void ModifyFinalLinkArguments(LinkEnvironment LinkEnvironment, List<string> Arguments, bool bBuildImportLibraryOnly)
+        {
+            base.ModifyFinalLinkArguments(LinkEnvironment, Arguments, bBuildImportLibraryOnly);
+
+            if (LinkEnvironment.ModuleDefinitionFile != null && LinkEnvironment.ModuleDefinitionFile.Length > 0)
+            {
+                Arguments.RemoveAll(Argument => Argument.StartsWith("/DEF"));
+                Arguments.Add($"/DEF:\"{LinkEnvironment.ModuleDefinitionFile}\"");
+                // When we specify the symbols explicitly through the def file the linker still finds some of them
+                // through the libraries themselves and warns that they've been specified multiple times.
+                // I think these warnings are benign, so we ignore them here.
+                Arguments.Add("/IGNORE:4197");
+            }
+        }
+    }
+}

--- a/EngineMods/EngineMods.json
+++ b/EngineMods/EngineMods.json
@@ -1,5 +1,5 @@
 {
-  "5.4": [
+  "5.5": [
     {
       "Type": "UnrealBuildTool",
       "Root": "Engine/Source/Programs/UnrealBuildTool",
@@ -32,6 +32,49 @@
         "MassCrowd.patch.1",
         "MassCrowd.patch.2",
         "MassCrowd.patch.3"
+      ]
+    }
+  ],
+  "5.4": [
+    {
+      "Type": "UnrealBuildTool",
+      "Root": "Engine/Source/Programs/UnrealBuildTool",
+      "Add": [
+        "Configuration/TempoModuleRules.cs",
+        "ToolChain/TempoLinuxToolChain.cs",
+        "ToolChain/TempoMacToolChain.cs",
+        "ToolChain/TempoVCToolChain.cs"
+      ],
+      "Patch": [
+        "Configuration/UEBuildTarget.cs.patch.1",
+        "Configuration/UEBuildTarget.cs.patch.2",
+        "Platform/Linux/LinuxToolChain.cs.patch.1"
+      ]
+    },
+    {
+      "Type": "Plugin",
+      "Root": "Engine/Plugins/Runtime/ZoneGraph",
+      "Patch": [
+        "ZoneGraph.patch.1",
+        "ZoneGraph.patch.2",
+        "ZoneGraph.patch.3",
+        "ZoneGraph.patch.4"
+      ]
+    },
+    {
+      "Type": "Plugin",
+      "Root": "Engine/Plugins/AI/MassCrowd",
+      "Patch": [
+        "MassCrowd.patch.1",
+        "MassCrowd.patch.2",
+        "MassCrowd.patch.3"
+      ]
+    },
+    {
+      "Type": "Plugin",
+      "Root": "Engine/Plugins/Runtime/MassEntity",
+      "Patch": [
+        "MassEntity.patch.1"
       ]
     }
   ]

--- a/EngineMods/EngineMods.json
+++ b/EngineMods/EngineMods.json
@@ -11,8 +11,7 @@
       ],
       "Patch": [
         "Configuration/UEBuildTarget.cs.patch.1",
-        "Platform/Linux/LinuxToolChain.cs.patch.1",
-        "ToolChain/TempoLinuxToolChain.cs.patch.1"
+        "Platform/Linux/LinuxToolChain.cs.patch.1"
       ]
     },
     {
@@ -48,7 +47,8 @@
       "Patch": [
         "Configuration/UEBuildTarget.cs.patch.1",
         "Configuration/UEBuildTarget.cs.patch.2",
-        "Platform/Linux/LinuxToolChain.cs.patch.1"
+        "Platform/Linux/LinuxToolChain.cs.patch.1",
+        "ToolChain/TempoLinuxToolChain.cs.patch.1"
       ]
     },
     {

--- a/External/RuleProcessor/RuleProcessor.uplugin
+++ b/External/RuleProcessor/RuleProcessor.uplugin
@@ -35,10 +35,6 @@
 		{
 			"Name": "Niagara",
 			"Enabled": true
-		},
-		{
-			"Name": "StructUtils",
-			"Enabled":  true
 		}
 	]
 }

--- a/External/RuleProcessor/Source/PointCloud/PointCloud.Build.cs
+++ b/External/RuleProcessor/Source/PointCloud/PointCloud.Build.cs
@@ -18,8 +18,13 @@ namespace UnrealBuildTool.Rules
 					"CoreUObject",
 					"GeometryCollectionEngine",
 					"SQLiteCore",
-					"StructUtils"
 				});
+
+			// StructUtils plugin was deprecated in 5.5 and moved into CoreUObject
+			if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion < 5)
+			{
+				PublicDependencyModuleNames.Add("StructUtils");
+			}
 
 			if (Target.bBuildEditor)
 			{

--- a/External/RuleProcessor/Source/PointCloud/Public/PointCloudSliceAndDiceCustomOverrides.h
+++ b/External/RuleProcessor/Source/PointCloud/Public/PointCloudSliceAndDiceCustomOverrides.h
@@ -5,7 +5,11 @@
 #include "UObject/Object.h"
 #include "UObject/ObjectMacros.h"
 #include "UObject/StructOnScope.h"
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 5
 #include "InstancedStruct.h"
+#else
+#include "StructUtils/InstancedStruct.h"
+#endif
 
 #include "PointCloudSliceAndDiceCustomOverrides.generated.h"
 

--- a/External/RuleProcessor/Source/PointCloud/Public/PointCloudSliceAndDiceManager.h
+++ b/External/RuleProcessor/Source/PointCloud/Public/PointCloudSliceAndDiceManager.h
@@ -47,7 +47,7 @@ class POINTCLOUD_API USliceAndDiceManagedActors : public UObject
 
 public:
 	UPROPERTY()
-	TSoftObjectPtr<UPointCloudRule> Rule;
+	TSoftObjectPtr<const UPointCloudRule> Rule;
 
 	UPROPERTY()
 	TArray<TSoftObjectPtr<AActor>> ManagedActors_DEPRECATED;

--- a/External/RuleProcessor/Source/PointCloudEditor/Private/Widgets/SPointCloudEditor.cpp
+++ b/External/RuleProcessor/Source/PointCloudEditor/Private/Widgets/SPointCloudEditor.cpp
@@ -183,7 +183,9 @@ TSharedRef<ITableRow> SPointCloudEditor::OnGenerateRowForList(TSharedPtr<FString
 
 TSharedRef<ITableRow> SPointCloudEditor::OnGenerateMetadataRowForList(TSharedPtr<FMetadataHolder> Item, const TSharedRef<STableViewBase>& OwnerTable)
 {
-	return SNew(SMetadataTableRow, OwnerTable);
+	return
+		SNew(SMetadataTableRow, OwnerTable)
+		.Metadata(Item);
 }
 
 /* SPointCloudEditor callbacks

--- a/External/RuleProcessor/Source/PointCloudEditor/Private/Widgets/SPointCloudEditor.cpp
+++ b/External/RuleProcessor/Source/PointCloudEditor/Private/Widgets/SPointCloudEditor.cpp
@@ -133,7 +133,6 @@ void SPointCloudEditor::Construct(const FArguments& InArgs, UPointCloud* InPoint
 			.FillHeight(1.0f)
 			[
 				SNew(SListView<TSharedPtr<FMetadataHolder>>)
-				.ItemHeight(24)
 				.ListItemsSource(&MetadataAttributes)
 				.OnGenerateRow(this, &SPointCloudEditor::OnGenerateMetadataRowForList)
 				.HeaderRow
@@ -152,7 +151,6 @@ void SPointCloudEditor::Construct(const FArguments& InArgs, UPointCloud* InPoint
 			//The actual list view creation			
 			[
 				SAssignNew(LoadedFiles, SListView<TSharedPtr<FString>>)
-				.ItemHeight(24)
 				.ListItemsSource(&(Datasets)) //The Items array is the source of this listview
 				.OnGenerateRow(this, &SPointCloudEditor::OnGenerateRowForList)
 				.HeaderRow
@@ -175,15 +173,17 @@ TSharedRef<ITableRow> SPointCloudEditor::OnGenerateRowForList(TSharedPtr<FString
 		SNew(STableRow< TSharedPtr<FString> >, OwnerTable)
 		.Padding(2.0f)
 		[
-			SNew(STextBlock).Text(FText::FromString(*Item.Get()))
+			SNew(SBox)
+			.HeightOverride(24.0f) // Height previously set in .ItemHeight in the list view above
+			[
+				SNew(STextBlock).Text(FText::FromString(*Item.Get()))
+			]
 		];
 }
 
 TSharedRef<ITableRow> SPointCloudEditor::OnGenerateMetadataRowForList(TSharedPtr<FMetadataHolder> Item, const TSharedRef<STableViewBase>& OwnerTable)
 {
-	return
-		SNew(SMetadataTableRow, OwnerTable)
-		.Metadata(Item);
+	return SNew(SMetadataTableRow, OwnerTable);
 }
 
 /* SPointCloudEditor callbacks
@@ -222,21 +222,31 @@ SPointCloudEditor::SMetadataTableRow::Construct(const FArguments& InArgs, const 
 TSharedRef<SWidget>
 SPointCloudEditor::SMetadataTableRow::GenerateWidgetForColumn(const FName& ColumnId)
 {
-	FText ColumnData = NSLOCTEXT("SMetadataTableRow", "ColumnError", "Unrecognized Column");
-	if (ColumnId == SPointCloudEditor::NAME_MetadataAttributeColumn)
+	const TSharedRef<SWidget> ColumnContent = [&]() -> TSharedRef<SWidget>
 	{
-		ColumnData = FText::FromString(Metadata->MetadataName);
-	}
-	else if (ColumnId == SPointCloudEditor::NAME_PointCountColumn)
-	{
-		ColumnData = FText::FromString(FString::FromInt(Metadata->PointCount));
-	}
-	else if (ColumnId == SPointCloudEditor::NAME_ValueCountColumn)
-	{
-		ColumnData = FText::FromString(FString::FromInt(Metadata->ValueCount));
-	}
+		FText ColumnData = NSLOCTEXT("SMetadataTableRow", "ColumnError", "Unrecognized Column");
+		if (ColumnId == SPointCloudEditor::NAME_MetadataAttributeColumn)
+		{
+			ColumnData = FText::FromString(Metadata->MetadataName);
+		}
+		else if (ColumnId == SPointCloudEditor::NAME_PointCountColumn)
+		{
+			ColumnData = FText::FromString(FString::FromInt(Metadata->PointCount));
+		}
+		else if (ColumnId == SPointCloudEditor::NAME_ValueCountColumn)
+		{
+			ColumnData = FText::FromString(FString::FromInt(Metadata->ValueCount));
+		}
+		return SNew(STextBlock).Text(ColumnData);
+	}();
 
-	return SNew(STextBlock).Text(ColumnData);
+	// Wrap the column content in an SBox with fixed height
+	return SNew(SBox)
+		.HeightOverride(24.0f) // Height previously set in .ItemHeight in the list view above
+		.HAlign(HAlign_Fill)
+		[
+			ColumnContent
+		];
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/External/Traffic/Source/MassTraffic/MassTraffic.Build.cs
+++ b/External/Traffic/Source/MassTraffic/MassTraffic.Build.cs
@@ -50,15 +50,19 @@ public class MassTraffic : ModuleRules
 				"Engine",
 				"NetCore",
 				"StateTreeModule",
-				"StructUtils",
 				"ZoneGraph",
 				"AnimToTexture",
 				"ChaosVehicles",
 				"ChaosVehiclesCore",
 			}
 			);
-			
-		
+
+		// StructUtils plugin was deprecated in 5.5 and moved into CoreUObject
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion < 5)
+		{
+			PublicDependencyModuleNames.Add("StructUtils");
+		}
+
 		PrivateDependencyModuleNames.AddRange(
 			new string[]
 			{

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficFindObstaclesProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficFindObstaclesProcessor.cpp
@@ -172,7 +172,7 @@ void UMassTrafficFindObstaclesProcessor::Execute(FMassEntityManager& EntityManag
 									{
 										UE_VLOG_SEGMENT_THICK(&MassTrafficSubsystem, TEXT("MassTraffic Avoidance"), Log, AvoidingVehicleLocation, TransformFragment.GetTransform().GetLocation(), FColor::Yellow, 5.0f, TEXT("%d Avoiding %d"), PreviousVehicle.Index, ObstacleEntity.Index);
 										const float Radius = PreviousVehicleEntityView.GetFragmentData<FAgentRadiusFragment>().Radius;
-										const float HalfWidth = PreviousVehicleEntityView.GetSharedFragmentData<FMassTrafficVehicleSimulationParameters>().HalfWidth;
+										const float HalfWidth = PreviousVehicleEntityView.GetConstSharedFragmentData<FMassTrafficVehicleSimulationParameters>().HalfWidth;
 
 										DrawDebugBox(GetWorld(),
 											TransformFragment.GetTransform().GetLocation(),

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficInterpolation.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficInterpolation.cpp
@@ -5,8 +5,11 @@
 #include "MassTrafficFragments.h"
 #include "MassTraffic.h"
 
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 5
 #include "BezierUtilities.h"
-
+#else
+#include "Curves/BezierUtilities.h"
+#endif
 
 namespace UE
 {
@@ -140,7 +143,7 @@ void InterpolatePositionAndOrientationAlongLane(
 	const float Alpha = FMath::GetRangePct(InOutLaneSegment.StartProgression, InOutLaneSegment.EndProgression, DistanceAlongLane);
 		
 	// Interpolate along segment 
-	FVector InterpolatedLocation;
+	FVector InterpolatedLocation = FVector::ZeroVector;
 	FVector InterpolatedForwardVector; 
 	switch (InterpolationMethod)
 	{

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficTrailerSimulationTrait.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficTrailerSimulationTrait.cpp
@@ -66,8 +66,7 @@ void UMassTrafficTrailerSimulationTrait::BuildTemplate(FMassEntityTemplateBuildC
 		const FMassTrafficSimpleVehiclePhysicsTemplate* Template = MassTrafficSubsystem->GetOrExtractVehiclePhysicsTemplate(Params.PhysicsVehicleTemplateActor);
 
 		// Register & add shared fragment
-		const uint32 TemplateHash = UE::StructUtils::GetStructCrc32(FConstStructView::Make(*Template));
-		const FConstSharedStruct PhysicsSharedFragment = EntityManager.GetOrCreateConstSharedFragmentByHash<FMassTrafficVehiclePhysicsSharedParameters>(TemplateHash, Template);
+		const FConstSharedStruct PhysicsSharedFragment = EntityManager.GetOrCreateConstSharedFragment<FMassTrafficVehiclePhysicsSharedParameters>(Template);
 		BuildContext.AddConstSharedFragment(PhysicsSharedFragment);
 	}
 	else

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficTrailerSpawnDataGenerator.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficTrailerSpawnDataGenerator.cpp
@@ -42,7 +42,7 @@ void UMassTrafficTrailerSpawnDataGenerator::Generate(UObject& QueryOwner,
 		// Find matching trailer to spawn for these vehicles
 		for (FMassEntitySpawnDataGeneratorResult& Result : Results)
 		{
-			if (EntityTypes[Result.EntityConfigIndex].EntityConfig == TrailerSimulationParams.TrailerAgentConfigAsset)
+			if (EntityTypes[Result.EntityConfigIndex].EntityConfig.Get() == TrailerSimulationParams.TrailerAgentConfigAsset.Get())
 			{
 				// Initialize spawn data for trailer
 				FMassTrafficVehicleTrailersSpawnData* TrailersSpawnData = Result.SpawnData.GetMutablePtr<FMassTrafficVehicleTrailersSpawnData>();

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleSimulationTrait.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleSimulationTrait.cpp
@@ -61,9 +61,14 @@ void UMassTrafficVehicleSimulationTrait::BuildTemplate(FMassEntityTemplateBuildC
 
 	const FConstSharedStruct VariableTickParamsFragment = EntityManager.GetOrCreateConstSharedFragment(VariableTickParams);
 	BuildContext.AddConstSharedFragment(VariableTickParamsFragment);
-	
-	const uint32 VariableTickParamsHash = UE::StructUtils::GetStructCrc32(FConstStructView::Make(VariableTickParams)); 
+
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 5
+	const uint32 VariableTickParamsHash = UE::StructUtils::GetStructCrc32(FConstStructView::Make(VariableTickParams));
 	const FSharedStruct VariableTickSharedFragment = EntityManager.GetOrCreateSharedFragmentByHash<FMassSimulationVariableTickSharedFragment>(VariableTickParamsHash, VariableTickParams);
+#else
+	const FSharedStruct VariableTickSharedFragment = EntityManager.GetOrCreateSharedFragment<FMassSimulationVariableTickSharedFragment>(VariableTickParams);
+#endif
+
 	BuildContext.AddSharedFragment(VariableTickSharedFragment);
 
 	// Various fragments
@@ -103,8 +108,7 @@ void UMassTrafficVehicleSimulationMassControlTrait::BuildTemplate(FMassEntityTem
 		const FMassTrafficSimpleVehiclePhysicsTemplate* Template = MassTrafficSubsystem->GetOrExtractVehiclePhysicsTemplate(PhysicsParams.PhysicsVehicleTemplateActor);
 
 		// Register & add shared fragment
-		const uint32 TemplateHash = UE::StructUtils::GetStructCrc32(FConstStructView::Make(*Template));
-		const FConstSharedStruct PhysicsSharedFragment = EntityManager.GetOrCreateConstSharedFragmentByHash<FMassTrafficVehiclePhysicsSharedParameters>(TemplateHash, Template);
+		const FConstSharedStruct PhysicsSharedFragment = EntityManager.GetOrCreateConstSharedFragment<FMassTrafficVehiclePhysicsSharedParameters>(Template);
 		BuildContext.AddConstSharedFragment(PhysicsSharedFragment);
 	}
 	else

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficConstrainedTrailerTrait.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficConstrainedTrailerTrait.h
@@ -13,7 +13,7 @@
 #include "MassTrafficConstrainedTrailerTrait.generated.h"
 
 USTRUCT()
-struct MASSTRAFFIC_API FMassTrafficConstrainedTrailerParameters : public FMassSharedFragment
+struct MASSTRAFFIC_API FMassTrafficConstrainedTrailerParameters : public FMassConstSharedFragment
 {
 	GENERATED_BODY()
 

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficDrivers.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficDrivers.h
@@ -71,7 +71,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct MASSTRAFFIC_API FMassTrafficDriversParameters : public FMassSharedFragment
+struct MASSTRAFFIC_API FMassTrafficDriversParameters : public FMassConstSharedFragment
 {
 	GENERATED_BODY()
 	

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
@@ -1116,7 +1116,7 @@ struct MASSTRAFFIC_API FMassTrafficAngularVelocityFragment : public FMassFragmen
 
 
 USTRUCT()
-struct MASSTRAFFIC_API FMassTrafficVehiclePhysicsSharedParameters : public FMassSharedFragment
+struct MASSTRAFFIC_API FMassTrafficVehiclePhysicsSharedParameters : public FMassConstSharedFragment
 {
 	GENERATED_BODY()
 

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficLights.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficLights.h
@@ -75,7 +75,7 @@ struct MASSTRAFFIC_API FMassTrafficLightInstanceDesc
 };
 
 USTRUCT(BlueprintType)
-struct MASSTRAFFIC_API FMassTrafficLightsParameters : public FMassSharedFragment
+struct MASSTRAFFIC_API FMassTrafficLightsParameters : public FMassConstSharedFragment
 {
 	GENERATED_BODY()
 	

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficTrailerSimulationTrait.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficTrailerSimulationTrait.h
@@ -37,7 +37,7 @@ struct MASSTRAFFIC_API FMassTrafficTrailerConstraintSettings
 };
 
 USTRUCT()
-struct MASSTRAFFIC_API FMassTrafficTrailerSimulationParameters : public FMassSharedFragment
+struct MASSTRAFFIC_API FMassTrafficTrailerSimulationParameters : public FMassConstSharedFragment
 {
 	GENERATED_BODY()
 	

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficVehicleSimulationTrait.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficVehicleSimulationTrait.h
@@ -12,7 +12,7 @@
 #include "MassTrafficVehicleSimulationTrait.generated.h"
 
 USTRUCT()
-struct MASSTRAFFIC_API FMassTrafficVehicleSimulationParameters : public FMassSharedFragment
+struct MASSTRAFFIC_API FMassTrafficVehicleSimulationParameters : public FMassConstSharedFragment
 {
 	GENERATED_BODY()
 	
@@ -65,7 +65,7 @@ struct MASSTRAFFIC_API FMassTrafficVehicleSimulationParameters : public FMassSha
 };
 
 USTRUCT()
-struct MASSTRAFFIC_API FMassTrafficVehiclePhysicsParameters : public FMassSharedFragment
+struct MASSTRAFFIC_API FMassTrafficVehiclePhysicsParameters : public FMassConstSharedFragment
 {
 	GENERATED_BODY()
 

--- a/External/Traffic/Source/MassTrafficEditor/MassTrafficEditor.Build.cs
+++ b/External/Traffic/Source/MassTrafficEditor/MassTrafficEditor.Build.cs
@@ -27,11 +27,15 @@ public class MassTrafficEditor : ModuleRules
 				"Engine",
 				"ZoneGraph",
 				"MassTraffic",
-				"StructUtils"
 			}
 			);
-			
-		
+
+		// StructUtils plugin was deprecated in 5.5 and moved into CoreUObject
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion < 5)
+		{
+			PublicDependencyModuleNames.Add("StructUtils");
+		}
+
 		PrivateDependencyModuleNames.AddRange(
 			new string[]
 			{

--- a/External/Traffic/Traffic.uplugin
+++ b/External/Traffic/Traffic.uplugin
@@ -45,15 +45,7 @@
 			"Enabled": true
 		},
 		{
-			"Name": "MassEntity",
-			"Enabled": true
-		},
-		{
 			"Name": "MassGameplay",
-			"Enabled": true
-		},
-		{
-			"Name": "StructUtils",
 			"Enabled": true
 		},
 		{
@@ -63,6 +55,6 @@
 		{
 			"Name": "AnimToTexture",
 			"Enabled": true
-		},
+		}
 	]
 }

--- a/TempoAgents/Source/TempoAgentsEditor/TempoAgentsEditor.Build.cs
+++ b/TempoAgents/Source/TempoAgentsEditor/TempoAgentsEditor.Build.cs
@@ -40,11 +40,10 @@ public class TempoAgentsEditor : TempoModuleRules
 				"InputCore",
 				"Projects",
 				"UnrealEd",
-				"MassTraffic",
 				"MassEntity",
+				"MassTraffic",
 				"Slate",
 				"SlateCore",
-				"StructUtils",
 				"ToolMenus",
 				"ZoneGraph",
 				// Tempo
@@ -54,8 +53,17 @@ public class TempoAgentsEditor : TempoModuleRules
 				"TempoCoreShared",
 			}
 			);
-		
-		
+
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion < 5)
+		{
+			PublicDependencyModuleNames.AddRange(
+				new string[]
+				{
+					"StructUtils",
+				}
+			);
+		}
+
 		DynamicallyLoadedModuleNames.AddRange(
 			new string[]
 			{

--- a/TempoAgents/Source/TempoAgentsShared/TempoAgentsShared.Build.cs
+++ b/TempoAgents/Source/TempoAgentsShared/TempoAgentsShared.Build.cs
@@ -33,7 +33,6 @@ public class TempoAgentsShared : ModuleRules
                 "MassActors",
                 "MassSpawner",
                 "MassCommon",
-                "StructUtils",
                 "RHI",
                 // For overriden "stand" state
                 "MassMovement",
@@ -48,5 +47,11 @@ public class TempoAgentsShared : ModuleRules
                 "TempoCoreShared",
             }
         );
+        
+        // StructUtils plugin was deprecated in 5.5 and moved into CoreUObject
+        if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion < 5)
+        {
+            PrivateDependencyModuleNames.Add("StructUtils");
+        }
     }
 }

--- a/TempoCore/Source/TempoCoreShared/Private/TempoCoreUtils.cpp
+++ b/TempoCore/Source/TempoCoreShared/Private/TempoCoreUtils.cpp
@@ -9,16 +9,28 @@ UWorldSubsystem* UTempoCoreUtils::GetSubsystemImplementingInterface(const UObjec
 {
 	if (const UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull))
 	{
+		UWorldSubsystem* SubsystemImplementingInterface = nullptr;
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 5
 		TArray<UWorldSubsystem*> Subsystems = World->GetSubsystemArray<UWorldSubsystem>();
 		for (UWorldSubsystem* Subsystem : Subsystems)
 		{
 			if (Subsystem->GetClass()->ImplementsInterface(Interface))
 			{
-				return Subsystem;
+				SubsystemImplementingInterface = Subsystem;
 			}
 		}
+#else
+		World->ForEachSubsystem<UWorldSubsystem>([&Interface, &SubsystemImplementingInterface](UWorldSubsystem* Subsystem)
+		{
+			if (Subsystem->GetClass()->ImplementsInterface(Interface))
+			{
+				SubsystemImplementingInterface = Subsystem;
+			}
+		});
+#endif
+		return SubsystemImplementingInterface;
 	}
-	
+
 	return nullptr;
 }
 

--- a/TempoCore/Source/TempoScripting/Private/TempoScripting.cpp
+++ b/TempoCore/Source/TempoScripting/Private/TempoScripting.cpp
@@ -31,8 +31,8 @@ void FTempoScriptingModule::StartupModule()
 	IHotReloadModule::Get().OnModuleCompilerStarted().AddLambda([](bool)
 	{
 		// Note: we added these reset methods in TempoThirdParty-v0.4
-		google::protobuf::DescriptorPool::ResetGeneratedDatabase();
-		google::protobuf::MessageFactory::ResetGeneratedFactory();
+		google::protobuf_tempo::DescriptorPool::ResetGeneratedDatabase();
+		google::protobuf_tempo::MessageFactory::ResetGeneratedFactory();
 	});
 #endif
 }

--- a/TempoCore/Source/ThirdParty/ttp_manifest.json
+++ b/TempoCore/Source/ThirdParty/ttp_manifest.json
@@ -1,10 +1,10 @@
 {
   "artifact": "gRPC",
-  "release": "v0.6",
+  "release": "v0.13",
   "md5_hashes": {
-    "Linux": "5fcf2f536662dbc20518278c8a0910f9",
-    "Mac": "c99ed4f480079560bc526734ad59ea37",
-    "Windows": "7b98aa719a90e16bc692d786e3516805",
-    "Windows+Linux": "ca76569f57f15345fd9003200decf1ad"
+    "Linux": "3a73a2f241aabd7c83e0c2b77b41e017",
+    "Mac": "4a83d41c3bf5ed48d0bd92e08b3a6bec",
+    "Windows": "6361245a2fc502a61001b6386ea7d01e",
+    "Windows+Linux": "bdbb1ea81e3d6258f80142da5ad7bdda"
   }
 }

--- a/TempoWorld/Source/TempoDebris/Private/PCGAssignRandomMeshAttribute.cpp
+++ b/TempoWorld/Source/TempoDebris/Private/PCGAssignRandomMeshAttribute.cpp
@@ -21,8 +21,8 @@
 
 #define LOCTEXT_NAMESPACE "PCGAssignRandomMeshAttributeElement"
 
-#if WITH_EDITOR
-// This is defined in PCGActorSelector.h but not exported or inlined. Re-define it here in the editor build,
+#if WITH_EDITOR && ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 5
+// In 5.4 this is defined in PCGActorSelector.h but not exported or inlined. Re-define it here in the editor build,
 // where we're building separate dylibs, but not in the packaged binary, where we're building a single executable.
 uint32 GetTypeHash(const FPCGSelectionKey& In)
 {

--- a/TempoWorld/Source/TempoDebris/Public/PCGCopyAttributeFromNearest.h
+++ b/TempoWorld/Source/TempoDebris/Public/PCGCopyAttributeFromNearest.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "PCGSettings.h"
-#include "Elements/PCGPointProcessingElementBase.h"
+#include "Elements/PCGPointOperationElementBase.h"
 
 #include "PCGCopyAttributeFromNearest.generated.h"
 
@@ -45,7 +45,7 @@ public:
 	double MaximumDistance = 20000.0;
 };
 
-class FPCGCopyAttributeFromNearestElement : public FPCGPointProcessingElementBase
+class FPCGCopyAttributeFromNearestElement : public FPCGPointOperationElementBase
 {
 protected:
 	virtual bool ExecuteInternal(FPCGContext* Context) const override;

--- a/TempoWorld/Source/TempoMapQuery/Private/TempoMapQueryServiceSubsystem.cpp
+++ b/TempoWorld/Source/TempoMapQuery/Private/TempoMapQueryServiceSubsystem.cpp
@@ -78,7 +78,7 @@ void UTempoMapQueryServiceSubsystem::GetLaneData(const LaneDataRequest& Request,
 		AllTags.Add(TagInfo.Name.ToString().ToLower(), TagInfo.Tag);
 	}
 
-	auto BuildTagMask = [&AllTags] (const google::protobuf::RepeatedPtrField<std::string>& RequestedTags)
+	auto BuildTagMask = [&AllTags] (const google::protobuf_tempo::RepeatedPtrField<std::string>& RequestedTags)
 	{
 		FZoneGraphTagMask Mask;
 		for (const std::string& RequestedTag : RequestedTags)

--- a/TempoWorld/Source/TempoMapQuery/TempoMapQuery.Build.cs
+++ b/TempoWorld/Source/TempoMapQuery/TempoMapQuery.Build.cs
@@ -28,11 +28,16 @@ public class TempoMapQuery : TempoModuleRules
 				"MassEntity",
 				"Slate",
 				"SlateCore",
-				"StructUtils",
 				// Tempo
 				"MassTraffic",
 				"ZoneGraph",
 			}
 			);
+
+		// StructUtils plugin was deprecated in 5.5 and moved into CoreUObject
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion < 5)
+		{
+			PrivateDependencyModuleNames.Add("StructUtils");
+		}
 	}
 }

--- a/TempoWorld/Source/TempoWorld/TempoWorld.Build.cs
+++ b/TempoWorld/Source/TempoWorld/TempoWorld.Build.cs
@@ -28,11 +28,16 @@ public class TempoWorld : TempoModuleRules
                 "MassActors",
                 "MassEntity",
                 "MassTraffic",
-                "StructUtils",
                 // Tempo
                 "TempoCore",
                 "TempoMovementShared",
             }
         );
+
+        // StructUtils plugin was deprecated in 5.5 and moved into CoreUObject
+        if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion < 5)
+        {
+            PrivateDependencyModuleNames.Add("StructUtils");
+        }
     }
 }

--- a/TempoWorld/TempoWorld.uplugin
+++ b/TempoWorld/TempoWorld.uplugin
@@ -32,10 +32,6 @@
 	],
 	"Plugins": [
 		{
-			"Name": "MassEntity",
-			"Enabled": true
-		},
-		{
 			"Name": "MassGameplay",
 			"Enabled": true
 		},
@@ -53,10 +49,6 @@
 		},
 		{
 			"Name": "Traffic",
-			"Enabled": true
-		},
-		{
-			"Name": "StructUtils",
 			"Enabled": true
 		},
 		{


### PR DESCRIPTION
Adds support for UE 5.5. The changes include:
- Updates gRPC to TempoThirdParty release v0.13, which includes a gRPC build with `protobuf_tempo` and `absl_tempo` namespaces, avoiding symbol conflicts with other UE plugins that use these libraries
- Duplicates the 5.4 engine mods for 5.5. Only one line required changing, in ZoneGraph.patch.1, an anchor line changed from `#include "BezierUtilities.h"` to `#include "Curves/BezierUtilities.h"`
- Adds a plugin mod for MassEntity for *only* 5.4, backporting `FMassConstSharedFragment`. MassEntity was moved into the core engine in 5.5, and `FMassConstSharedFragment` was added. Unfortunately preprocessor flags don't work well with UBT macros, so this was the only way I could find to let the code support both versions. Note that 5.5 intentionally *does not* include MassEntity mods.
- Removes all dependency on StructUtils plugin when building for 5.5, where it has been incorporated into CoreUObject
- Resolves several build warnings and errors due to updated 5.5 API, while retaining support for 5.4
- Adds 5.5.4 to the test matrix for our github actions workflow, and a few associated fixes
- Repoints TempoROS to include support for 5.5