### PR TITLE
Fix Warning in TempoLinuxToolChain.cs

### DIFF
--- a/EngineMods/5.4/Engine/Source/Programs/UnrealBuildTool/ToolChain/TempoLinuxToolChain.cs.patch.1
+++ b/EngineMods/5.4/Engine/Source/Programs/UnrealBuildTool/ToolChain/TempoLinuxToolChain.cs.patch.1
@@ -1,0 +1,14 @@
+--- ToolChain/TempoLinuxToolChain.cs	2025-04-14 11:00:34
++++ TempoLinuxToolChain.cs	2025-04-14 11:01:16
+@@ -25,7 +25,10 @@
+     class TempoLinuxToolChain : LinuxToolChain
+     {
+         public TempoLinuxToolChain(ReadOnlyTargetRules Target, ILogger Logger)
+-            : this(Target.Architecture, UEBuildPlatform.GetSDK(UnrealTargetPlatform.Linux) as LinuxPlatformSDK, TempoLinuxToolChainClangOptions(Target), Logger)
++            : this(Target.Architecture,
++                UEBuildPlatform.GetSDK(UnrealTargetPlatform.Linux) as LinuxPlatformSDK ?? throw new System.Exception("Linux SDK not found"),
++                TempoLinuxToolChainClangOptions(Target),
++                Logger)
+         {
+
+         }

--- a/EngineMods/EngineMods.json
+++ b/EngineMods/EngineMods.json
@@ -11,7 +11,8 @@
       ],
       "Patch": [
         "Configuration/UEBuildTarget.cs.patch.1",
-        "Platform/Linux/LinuxToolChain.cs.patch.1"
+        "Platform/Linux/LinuxToolChain.cs.patch.1",
+        "ToolChain/TempoLinuxToolChain.cs.patch.1"
       ]
     },
     {


### PR DESCRIPTION
Fixes a warning in TempoLinuxToolChain.cs, by throwing instead of passing null when the cast to LinuxPlatformSDK fails (which is never expected to happen).