### PR TITLE
Fix Bug Related to Hashing Physics Parameters

### DIFF
--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficTrailerRepresentationActorManagement.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficTrailerRepresentationActorManagement.cpp
@@ -121,10 +121,10 @@ EMassActorSpawnRequestAction  UMassTrafficTrailerRepresentationActorManagement::
 		{
 			// Init using simple velocity 
 			const FMassTrafficVehiclePhysicsSharedParameters& PhysicsSharedFragment = TrailerMassEntityView.GetConstSharedFragmentData<FMassTrafficVehiclePhysicsSharedParameters>();
-			if (PhysicsSharedFragment.Template)
+			if (PhysicsSharedFragment.IsValid())
 			{
 				FBaseSnapshotData BaseSnapshotData;
-				BaseSnapshotData.Transform = PhysicsSharedFragment.Template->SimpleVehiclePhysicsConfig.BodyToActor * TrailerPawn->GetTransform();
+				BaseSnapshotData.Transform = PhysicsSharedFragment.SimpleVehiclePhysicsConfig.BodyToActor * TrailerPawn->GetTransform();
 				BaseSnapshotData.LinearVelocity = TrailerMassEntityView.GetFragmentData<FMassVelocityFragment>().Value;
 				BaseSnapshotData.AngularVelocity = TrailerMassEntityView.GetFragmentData<FMassTrafficAngularVelocityFragment>().AngularVelocity;
 				TrailerVehicleMovementComponent->SetBaseSnapshot(BaseSnapshotData);

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficUpdateTrailersProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficUpdateTrailersProcessor.cpp
@@ -75,9 +75,9 @@ void UMassTrafficUpdateTrailersProcessor::Execute(FMassEntityManager& EntityMana
 					// Add simulation fragment
 					if (SimpleVehiclePhysicsFragments.IsEmpty())
 					{
-						if (PhysicsParams.Template)
+						if (PhysicsParams.IsValid())
 						{
-							Context.Defer().PushCommand<FMassCommandAddFragmentInstances>(Context.GetEntity(EntityIndex), PhysicsParams.Template->SimpleVehiclePhysicsFragmentTemplate);
+							Context.Defer().PushCommand<FMassCommandAddFragmentInstances>(Context.GetEntity(EntityIndex), PhysicsParams.SimpleVehiclePhysicsFragmentTemplate);
 						}
 					}
 				}

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleSimulationLODProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficVehicleSimulationLODProcessor.cpp
@@ -131,12 +131,12 @@ void UMassTrafficVehicleSimulationLODProcessor::Execute(FMassEntityManager& Enti
 					{
 						if (SimpleVehiclePhysicsFragments.IsEmpty())
 						{
-							if (PhysicsSharedFragment.Template)
+							if (PhysicsSharedFragment.IsValid())
 							{
 								// Add FDataFragment_PIDVehicleControl & FDataFragment_SimpleVehiclePhysics fragments
 								QueryContext.Defer().PushCommand<FMassCommandAddFragmentInstances>(QueryContext.GetEntity(EntityIdx)
-										, PhysicsSharedFragment.Template->SimpleVehiclePhysicsFragmentTemplate
-										, FMassTrafficPIDVehicleControlFragment(PhysicsSharedFragment.Template->SimpleVehiclePhysicsConfig.MaxSteeringAngle)
+										, PhysicsSharedFragment.SimpleVehiclePhysicsFragmentTemplate
+										, FMassTrafficPIDVehicleControlFragment(PhysicsSharedFragment.SimpleVehiclePhysicsConfig.MaxSteeringAngle)
 										, FMassTrafficPIDControlInterpolationFragment()
 										, FMassTrafficVehicleDamageFragment());
 							}

--- a/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
+++ b/External/Traffic/Source/MassTraffic/Public/MassTrafficFragments.h
@@ -1121,7 +1121,19 @@ struct MASSTRAFFIC_API FMassTrafficVehiclePhysicsSharedParameters : public FMass
 	GENERATED_BODY()
 
 	FMassTrafficVehiclePhysicsSharedParameters() = default;
-	FMassTrafficVehiclePhysicsSharedParameters(const FMassTrafficSimpleVehiclePhysicsTemplate* InTemplate) : Template(InTemplate) {} 
+	FMassTrafficVehiclePhysicsSharedParameters(const FMassTrafficSimpleVehiclePhysicsTemplate* InTemplate)
+		: PhysicsVehicleTemplateActor(InTemplate->PhysicsVehicleTemplateActor),
+		  SimpleVehiclePhysicsConfig(InTemplate->SimpleVehiclePhysicsConfig),
+		  SimpleVehiclePhysicsFragmentTemplate(InTemplate->SimpleVehiclePhysicsFragmentTemplate) {}
 
-	const FMassTrafficSimpleVehiclePhysicsTemplate* Template = nullptr;
+	bool IsValid() const { return PhysicsVehicleTemplateActor.Get() != nullptr; }
+
+	UPROPERTY()
+	TSubclassOf<AWheeledVehiclePawn> PhysicsVehicleTemplateActor;
+
+	UPROPERTY()
+	FMassTrafficSimpleVehiclePhysicsConfig SimpleVehiclePhysicsConfig;
+
+	UPROPERTY()
+	FMassTrafficVehiclePhysicsFragment SimpleVehiclePhysicsFragmentTemplate;
 };


### PR DESCRIPTION
The change to add support for 5.5 (https://github.com/tempo-sim/Tempo/pull/243) introduced a bug related to vehicle physics in MassTraffic plugin.  The symptom is that some vehicles drive erratically. The bug is that all vehicles have the same physics parameters. The root cause is an unnoticed difference in the way we create the physics fragment. Previously were doing this:
```
const FMassTrafficSimpleVehiclePhysicsTemplate* Template = MassTrafficSubsystem->GetOrExtractVehiclePhysicsTemplate(PhysicsParams.PhysicsVehicleTemplateActor);
const uint32 TemplateHash = UE::StructUtils::GetStructCrc32(FConstStructView::Make(*Template));
const FConstSharedStruct PhysicsSharedFragment = EntityManager.GetOrCreateConstSharedFragmentByHash<FMassTrafficVehiclePhysicsSharedParameters>(TemplateHash, Template);
```
5.5 deprecated `GetOrCreateConstSharedFragmentByHash`'s public accessibility. So, we must use `GetOrCreateConstSharedFragment`, like this:
```
const FMassTrafficSimpleVehiclePhysicsTemplate* Template = MassTrafficSubsystem->GetOrExtractVehiclePhysicsTemplate(Params.PhysicsVehicleTemplateActor);
const FConstSharedStruct PhysicsSharedFragment = EntityManager.GetOrCreateConstSharedFragment<FMassTrafficVehiclePhysicsSharedParameters>(Template);
```
The call to `GetOrCreateConstSharedFragment` is implicitly constructing a `FMassTrafficVehiclePhysicsSharedParameters` from the `FMassTrafficSimpleVehiclePhysicsTemplate`, computing the hash and calling the now-private `GetOrCreateConstSharedFragmentByHash`, nearly the same as what we were doing:
```
template<typename T>
const FConstSharedStruct& GetOrCreateConstSharedFragment(const T& Fragment)
{
	const uint32 Hash = UE::StructUtils::GetStructCrc32(FConstStructView::Make(Fragment));
	return GetOrCreateConstSharedFragmentByHash(Hash, Fragment);
}
```
However there is a key difference. The old code uses the hash of the `FMassTrafficSimpleVehiclePhysicsTemplate`, and the new uses the hash of the `FMassTrafficVehiclePhysicsSharedParameters`, which simply has a pointer to the former. And that pointer is not a UProperty (it's not allowed to be) and only UProperties contribute to the hash, so all of the hashes are the same, causing one fragment to be reused for all the vehicles.

We cannot use the old pattern of using the template's hash because of the API change. So I think the best thing to do is to make `FMassTrafficVehiclePhysicsSharedParameters` copy and store the parameters of `FMassTrafficSimpleVehiclePhysicsTemplate`, rather than simply keeping a pointer (a deep copy instead of a shallow copy). Doing so fixes the bug.