### PR TITLE
Fix Bug with Custom Proto Package Names on Mac

### DIFF
--- a/TempoCore/Scripts/GenProtos.sh
+++ b/TempoCore/Scripts/GenProtos.sh
@@ -263,7 +263,7 @@ echo "$MODULE_INFO" | jq -r -c 'to_entries[] | [.key, (.value.Directory // "")] 
   fi
   for PROTO_FILE in $(find "$MODULE_SRC_TEMP_DIR" -name '*.proto' -type f); do
     if grep -q '^\s*package ' "$PROTO_FILE"; then
-      SEARCH="^\s*package ([^\s;]+);"
+      SEARCH="^[[:space:]]*package ([^[:space:];]+);"
       REPLACE="package $MODULE_NAME.\1;"
       sed -E -i '' "s/$SEARCH/$REPLACE/" "$PROTO_FILE"
     else


### PR DESCRIPTION
Fixes a bug where module names are not correctly prepended to optional custom package names on Mac. The root cause is that while `\s` is a shortcut for `:space:` on GNU (Linux) sed, it is not on BSD (Mac) sed. So, we have to use `:space:`.