### PR TITLE
Improve Intersection Connection Filtering

### DIFF
--- a/EngineMods/5.4/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.5
+++ b/EngineMods/5.4/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.5
@@ -1,0 +1,279 @@
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneShapeUtilities.cpp /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp
+--- Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2025-05-02 09:57:02
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2025-05-02 09:46:20
+@@ -999,15 +999,6 @@
+ 	}
+ }
+ 
+-struct FLaneConnectionCandidate
+-{
+-	FLaneConnectionCandidate() = default;
+-	FLaneConnectionCandidate(const int32 InSourceSlot, const int32 InDestSlot, const FZoneGraphTagMask InTagMask) : SourceSlot(InSourceSlot), DestSlot(InDestSlot), TagMask(InTagMask) {}
+-	int32 SourceSlot = 0;
+-	int32 DestSlot = 0;
+-	FZoneGraphTagMask TagMask;
+-};
+-
+ static bool CalcDestinationSide(TConstArrayView<FLaneConnectionSlot> SourceSlots, TConstArrayView<FLaneConnectionSlot> DestSlots)
+ {
+ 	const FVector SourceCenter = (SourceSlots[0].Position + SourceSlots.Last().Position);
+@@ -1028,7 +1019,7 @@
+ 	return First;
+ }
+ 
+-static void AddOrUpdateConnection(TArray<FLaneConnectionCandidate>& Candidates, const int32 SourceSlot, const int32 DestSlot, const FZoneGraphTagMask& TagMask)
++static void AddOrUpdateConnection(TArray<FLaneConnectionCandidate>& Candidates, const int32 SourceSlot, const int32 DestSlot, const FZoneGraphTagMask& TagMask, const EZoneGraphTurnType TurnType)
+ {
+ 	FLaneConnectionCandidate* Cand = Candidates.FindByPredicate([SourceSlot, DestSlot](const FLaneConnectionCandidate& Cand) -> bool { return Cand.SourceSlot == SourceSlot&& Cand.DestSlot == DestSlot; });
+ 	if (Cand != nullptr)
+@@ -1037,12 +1028,12 @@
+ 	}
+ 	else
+ 	{
+-		Candidates.Add(FLaneConnectionCandidate(SourceSlot, DestSlot, TagMask));
++		Candidates.Add(FLaneConnectionCandidate(SourceSlot, DestSlot, TagMask, TurnType));
+ 	}
+ }
+ 	
+ static void AppendLaneConnectionCandidates(TArray<FLaneConnectionCandidate>& Candidates, TConstArrayView<FLaneConnectionSlot> SourceSlots, TConstArrayView<FLaneConnectionSlot> DestSlots,
+-										   const FZoneGraphTagMask& TagMask, const int32 MainDestPointIndex, bool bTurning)
++										   const FZoneGraphTagMask& TagMask, const int32 MainDestPointIndex, EZoneGraphTurnType TurnType)
+ {
+ 	const int32 SourceNum = SourceSlots.Num();
+ 	const int32 DestNum = DestSlots.Num();
+@@ -1065,7 +1056,7 @@
+ 		const int32 DestIdx = CalcDestinationSide(SourceSlots, DestSlots) ? (DestNum - 1) : 0;
+ 
+ 		// If a connection exists, we'll just update the tags, otherwise create new.
+-		AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++		AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask, TurnType);
+ 
+ 		return;
+ 	}
+@@ -1080,7 +1071,7 @@
+ 			const int32 SourceIdx = i;
+ 			const int32 DestIdx = BestDestLaneIndex;
+ 
+-			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask, TurnType);
+ 		}
+ 		
+ 		return;
+@@ -1088,14 +1079,14 @@
+ 
+ 	const bool bOneLanePerDestination = EnumHasAnyFlags(ConnectionRestrictions, EZoneShapeLaneConnectionRestrictions::OneLanePerDestination);
+ 
+-	if (bTurning)
++	if (TurnType != EZoneGraphTurnType::NoTurn)
+ 	{
+ 		// Turning connections by default get fully-connected slots. The builder may filter them later.
+ 		for (const FLaneConnectionSlot& SourceSlot : SourceSlots)
+ 		{
+ 			for (const FLaneConnectionSlot& DestSlot : DestSlots)
+ 			{
+-				AddOrUpdateConnection(Candidates, SourceSlot.Index, DestSlot.Index, TagMask);
++				AddOrUpdateConnection(Candidates, SourceSlot.Index, DestSlot.Index, TagMask, TurnType);
+ 			}
+ 		}
+ 	}
+@@ -1120,7 +1111,7 @@
+ 				const int32 SourceIdx = FMath::Clamp(SourceIdxUnClamped, 0, SourceNum - 1);
+ 				const int32 DestIdx = i;
+ 			
+-				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask, TurnType);
+ 			}
+ 		}
+ 		else
+@@ -1134,7 +1125,7 @@
+ 			{
+ 				const int32 SourceIdx = i;
+ 				const int32 DestIdx = FMath::Clamp(i - FirstIndex, 0, DestNum - 1);
+-				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask, TurnType);
+ 			}
+ 		}
+ 	}
+@@ -1198,6 +1189,56 @@
+ 	const int32 IncomingConnections;
+ };
+ 
++static EZoneGraphTurnType GetTurnTypeBetweenSourceDest(const FConnectionEntry& Source, TConstArrayView<FConnectionEntry> Destinations, int32 DestIdx, const FMatrix& LocalToWorld, const FZoneGraphBuildSettings& BuildSettings)
++{
++	const FVector SourceForward = LocalToWorld.TransformVector(Source.Point.Rotation.RotateVector(FVector::ForwardVector));
++	const FVector SourceUp = LocalToWorld.TransformVector(Source.Point.Rotation.RotateVector(FVector::UpVector));
++
++	float MinAngle = UE_PI;
++	float MaxAngle = -UE_PI;
++	int32 MinDestIdx = -1;
++	int32 MaxDestIdx = -1;
++	for (int32 Idx = 0; Idx < Destinations.Num(); ++Idx)
++	{
++		const FConnectionEntry& Destination = Destinations[Idx];
++		const FVector DestForward = LocalToWorld.TransformVector(Destination.Point.Rotation.RotateVector(FVector::ForwardVector));
++
++		const float AngleMagnitude = FMath::Acos(FVector::DotProduct(SourceForward, -DestForward));
++		const float AngleSign = FMath::Sign(FVector::CrossProduct(SourceForward, -DestForward).Dot(SourceUp));
++		const float Angle = AngleSign * AngleMagnitude;
++
++		if (Angle < MinAngle)
++		{
++			MinAngle = Angle;
++			MinDestIdx = Idx;
++		}
++		if (Angle > MaxAngle)
++		{
++			MaxAngle = Angle;
++			MaxDestIdx = Idx;
++		}
++	}
++
++	const float TurnThresholdAngle = FMath::DegreesToRadians(BuildSettings.TurnThresholdAngle);
++
++	// A connection must have an angle above the threshold *and* be the right-most connection to be a right turn,
++	// unless bSingleTurningConnectionPerTurnType is false.
++	if ((!BuildSettings.bSingleTurningConnectionPerTurnType || DestIdx == MaxDestIdx) && MaxAngle > TurnThresholdAngle)
++	{
++		return EZoneGraphTurnType::Right;
++	}
++
++	// A connection must have an angle below the threshold *and* be the left-most connection to be a left turn,
++	// unless bSingleTurningConnectionPerTurnType is false.
++	if ((!BuildSettings.bSingleTurningConnectionPerTurnType || DestIdx == MinDestIdx) && MinAngle < -TurnThresholdAngle)
++	{
++		return EZoneGraphTurnType::Left;
++	}
++
++	// Otherwise, the connection is not considered a turn.
++	return EZoneGraphTurnType::NoTurn;
++}
++
+ static void BuildLanesBetweenPoints(const FConnectionEntry& Source, TConstArrayView<FConnectionEntry> Destinations,
+ 									const UZoneShapeComponent& PolygonShapeComp, const TMap<int32, const UZoneShapeComponent*>& PointIndexToZoneShapeComponent, const FZoneGraphBuilder& ZoneGraphBuilder,
+ 									const EZoneShapePolygonRoutingType RoutingType, const FZoneGraphTagMask ZoneTags, const FZoneGraphBuildSettings& BuildSettings, const FMatrix& LocalToWorld,
+@@ -1205,7 +1246,6 @@
+ {
+ 	const float LaneConnectionAngle = BuildSettings.LaneConnectionAngle;
+ 	const float MaxConnectionAngleCos = FMath::Cos(FMath::DegreesToRadians(LaneConnectionAngle));
+-	const float TurnThresholdAngleCos = FMath::Cos(FMath::DegreesToRadians(BuildSettings.TurnThresholdAngle));
+ 
+ 	const float SourceTotalWidth = Source.Profile.GetLanesTotalWidth();
+ 
+@@ -1280,6 +1320,7 @@
+ 			continue;
+ 		}
+ 
++		// Use closest point on dest so that lane profile widths do not affect direction.
+ 		const FVector ClosestDestPoint = FMath::ClosestPointOnSegment(SourcePosition, DestLaneLeft, DestLaneRight);
+ 		const FVector DirToDest = (ClosestDestPoint - SourcePosition).GetSafeNormal();
+ 
+@@ -1290,13 +1331,12 @@
+ 
+ 		const EZoneShapeLaneConnectionRestrictions Restrictions = Source.Point.GetLaneConnectionRestrictions() | RestrictionsFromRules;
+ 
+-		// Use closest point on dest so that lane profile widths do not affect direction.
+-		const FVector SourceSide = FVector::CrossProduct(SourceForward, SourceUp);
++		const EZoneGraphTurnType TurnType = GetTurnTypeBetweenSourceDest(Source, Destinations, PointIndex, LocalToWorld, BuildSettings);
+ 
+-		const bool bIsTurning = FVector::DotProduct(SourceForward, DirToDest) < TurnThresholdAngleCos;
+-		const bool bIsLeftTurn = bIsTurning && FVector::DotProduct(SourceSide, DirToDest) > 0.0f;
++		const bool bIsTurning = TurnType != EZoneGraphTurnType::NoTurn;
++		const bool bIsLeftTurn = TurnType == EZoneGraphTurnType::Left;
+ 
+-		DestinationTurnTypes.Add(PointIndex, bIsTurning ? (bIsLeftTurn ? EZoneGraphTurnType::Left : EZoneGraphTurnType::Right) : EZoneGraphTurnType::NoTurn);
++		DestinationTurnTypes.Add(PointIndex, TurnType);
+ 
+ 		// Discard destination that would result in left or right turns.
+ 		if (EnumHasAnyFlags(Restrictions, EZoneShapeLaneConnectionRestrictions::NoLeftTurn | EZoneShapeLaneConnectionRestrictions::NoRightTurn))
+@@ -1424,7 +1464,7 @@
+ 
+ 			if (TagSourceSlots.Num() > 0 && TagDestSlots.Num() > 0)
+ 			{
+-				AppendLaneConnectionCandidates(Candidates, TagSourceSlots, TagDestSlots, TagMask, MainDestPointIndex, TurnType != EZoneGraphTurnType::NoTurn);
++				AppendLaneConnectionCandidates(Candidates, TagSourceSlots, TagDestSlots, TagMask, MainDestPointIndex, TurnType);
+ 			}
+ 		}
+ 	}
+@@ -1629,7 +1669,8 @@
+ 			}
+ 			if (NearestSourceSlot != INDEX_NONE)
+ 			{
+-				Candidates.Add(FLaneConnectionCandidate(NearestSourceSlot, DestSlotIdx, NearestSlotTags));
++				const EZoneGraphTurnType TurnType = GetTurnTypeBetweenSourceDest(Source, Destinations, DestPointIndex, LocalToWorld, BuildSettings);
++				Candidates.Add(FLaneConnectionCandidate(NearestSourceSlot, DestSlotIdx, NearestSlotTags, TurnType));
+ 			}
+ 		}
+ 	}
+@@ -1640,7 +1681,8 @@
+ 	const bool bAllZoneShapeComponentsInMapAreValid = !ShapeComponentsInMap.Contains(nullptr);
+ 	if (bAllZoneShapeComponentsInMapAreValid)
+ 	{
+-		Candidates.RemoveAll([&ZoneGraphBuilder, &PolygonShapeComp, &SourceSlots, &DestSlots, &PointIndexToZoneShapeComponent](const FLaneConnectionCandidate& Candidate)
++		TArray<FLaneConnectionCandidate> AllCandidates = Candidates;
++		Candidates.RemoveAll([&ZoneGraphBuilder, &PolygonShapeComp, &SourceSlots, &DestSlots, &PointIndexToZoneShapeComponent, &AllCandidates](const FLaneConnectionCandidate& Candidate)
+ 		{
+ 			// The true index to the ZoneShapePoint in this context is the slot's EntryID, not PointIndex field.
+ 			// In fact, SourceSlots don't even fill-out their PointIndex fields.
+@@ -1654,7 +1696,7 @@
+ 			const FLaneConnectionSlot& DestSlot = DestSlots[Candidate.DestSlot];
+ 			const UZoneShapeComponent* DestShapeComp = PointIndexToZoneShapeComponent[DestSlot.EntryID];
+ 
+-			return ZoneGraphBuilder.ShouldFilterLaneConnection(PolygonShapeComp, *SourceShapeComp, SourceSlots, Candidate.SourceSlot, *DestShapeComp, DestSlots, Candidate.DestSlot);
++			return ZoneGraphBuilder.ShouldFilterLaneConnection(PolygonShapeComp, *SourceShapeComp, SourceSlots, Candidate.SourceSlot, *DestShapeComp, DestSlots, Candidate.DestSlot, AllCandidates);
+ 		});
+ 	}
+ 
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Public/ZoneGraphBuilder.h /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphBuilder.h
+--- Source/ZoneGraph/Public/ZoneGraphBuilder.h	2025-05-02 09:57:02
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphBuilder.h	2025-04-28 10:43:39
+@@ -60,6 +60,27 @@
+ 	TMap<TObjectPtr<const UZoneShapeComponent>, FZoneShapeComponentBuildData> ZoneShapeComponentBuildData;
+ };
+ 
++USTRUCT(BlueprintType)
++struct FLaneConnectionCandidate
++{
++	GENERATED_BODY()
++
++	FLaneConnectionCandidate() = default;
++	FLaneConnectionCandidate(const int32 InSourceSlot, const int32 InDestSlot, const FZoneGraphTagMask InTagMask, const EZoneGraphTurnType InTurnType) : SourceSlot(InSourceSlot), DestSlot(InDestSlot), TagMask(InTagMask), TurnType(InTurnType) {}
++
++	UPROPERTY()
++	int32 SourceSlot = 0;
++
++	UPROPERTY()
++	int32 DestSlot = 0;
++
++	UPROPERTY()
++	FZoneGraphTagMask TagMask;
++
++	UPROPERTY()
++	EZoneGraphTurnType TurnType;
++};
++
+ USTRUCT()
+ struct ZONEGRAPH_API FZoneGraphBuilder
+ {
+@@ -94,7 +115,7 @@
+ 	 */
+ 	void QueryHashGrid(const FBox& Bounds, TArray<FZoneGraphBuilderHashGrid2D::ItemIDType>& OutResults);
+ 
+-	virtual bool ShouldFilterLaneConnection(const UZoneShapeComponent& PolygonShapeComp, const UZoneShapeComponent& SourceShapeComp, const TArray<FLaneConnectionSlot>& SourceSlots, const int32 SourceSlotQueryIndex, const UZoneShapeComponent& DestShapeComp, const TArray<FLaneConnectionSlot>& DestSlots, const int32 DestSlotQueryIndex) const { return false; };
++	virtual bool ShouldFilterLaneConnection(const UZoneShapeComponent& PolygonShapeComp, const UZoneShapeComponent& SourceShapeComp, const TArray<FLaneConnectionSlot>& SourceSlots, const int32 SourceSlotQueryIndex, const UZoneShapeComponent& DestShapeComp, const TArray<FLaneConnectionSlot>& DestSlots, const int32 DestSlotQueryIndex, const TArray<FLaneConnectionCandidate>& AllCandidates) const { return false; };
+ 
+ protected:
+ 	void Build(AZoneGraphData& ZoneGraphData);
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Public/ZoneGraphTypes.h /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h
+--- Source/ZoneGraph/Public/ZoneGraphTypes.h	2025-05-02 09:57:02
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h	2025-04-27 07:36:20
+@@ -1049,6 +1049,10 @@
+ 	UPROPERTY(Category = Lanes, EditAnywhere)
+ 	bool bFillEmptyDestination = true;
+ 
++	/** Whether to limit turning connections to only the left-most or right-most turning connections. */
++	UPROPERTY(Category = Lanes, EditAnywhere)
++	bool bSingleTurningConnectionPerTurnType = true;
++
+ 	/** Max distance between two shape points for them to be snapped together. */
+ 	UPROPERTY(Category = PointSnapping, EditAnywhere)
+ 	float ConnectionSnapDistance = 25.0f;

--- a/EngineMods/5.5/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.5
+++ b/EngineMods/5.5/Engine/Plugins/Runtime/ZoneGraph/ZoneGraph.patch.5
@@ -1,0 +1,279 @@
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Private/ZoneShapeUtilities.cpp /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp
+--- Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2025-05-02 09:57:02
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Private/ZoneShapeUtilities.cpp	2025-05-02 09:46:20
+@@ -999,15 +999,6 @@
+ 	}
+ }
+ 
+-struct FLaneConnectionCandidate
+-{
+-	FLaneConnectionCandidate() = default;
+-	FLaneConnectionCandidate(const int32 InSourceSlot, const int32 InDestSlot, const FZoneGraphTagMask InTagMask) : SourceSlot(InSourceSlot), DestSlot(InDestSlot), TagMask(InTagMask) {}
+-	int32 SourceSlot = 0;
+-	int32 DestSlot = 0;
+-	FZoneGraphTagMask TagMask;
+-};
+-
+ static bool CalcDestinationSide(TConstArrayView<FLaneConnectionSlot> SourceSlots, TConstArrayView<FLaneConnectionSlot> DestSlots)
+ {
+ 	const FVector SourceCenter = (SourceSlots[0].Position + SourceSlots.Last().Position);
+@@ -1028,7 +1019,7 @@
+ 	return First;
+ }
+ 
+-static void AddOrUpdateConnection(TArray<FLaneConnectionCandidate>& Candidates, const int32 SourceSlot, const int32 DestSlot, const FZoneGraphTagMask& TagMask)
++static void AddOrUpdateConnection(TArray<FLaneConnectionCandidate>& Candidates, const int32 SourceSlot, const int32 DestSlot, const FZoneGraphTagMask& TagMask, const EZoneGraphTurnType TurnType)
+ {
+ 	FLaneConnectionCandidate* Cand = Candidates.FindByPredicate([SourceSlot, DestSlot](const FLaneConnectionCandidate& Cand) -> bool { return Cand.SourceSlot == SourceSlot&& Cand.DestSlot == DestSlot; });
+ 	if (Cand != nullptr)
+@@ -1037,12 +1028,12 @@
+ 	}
+ 	else
+ 	{
+-		Candidates.Add(FLaneConnectionCandidate(SourceSlot, DestSlot, TagMask));
++		Candidates.Add(FLaneConnectionCandidate(SourceSlot, DestSlot, TagMask, TurnType));
+ 	}
+ }
+ 	
+ static void AppendLaneConnectionCandidates(TArray<FLaneConnectionCandidate>& Candidates, TConstArrayView<FLaneConnectionSlot> SourceSlots, TConstArrayView<FLaneConnectionSlot> DestSlots,
+-										   const FZoneGraphTagMask& TagMask, const int32 MainDestPointIndex, bool bTurning)
++										   const FZoneGraphTagMask& TagMask, const int32 MainDestPointIndex, EZoneGraphTurnType TurnType)
+ {
+ 	const int32 SourceNum = SourceSlots.Num();
+ 	const int32 DestNum = DestSlots.Num();
+@@ -1065,7 +1056,7 @@
+ 		const int32 DestIdx = CalcDestinationSide(SourceSlots, DestSlots) ? (DestNum - 1) : 0;
+ 
+ 		// If a connection exists, we'll just update the tags, otherwise create new.
+-		AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++		AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask, TurnType);
+ 
+ 		return;
+ 	}
+@@ -1080,7 +1071,7 @@
+ 			const int32 SourceIdx = i;
+ 			const int32 DestIdx = BestDestLaneIndex;
+ 
+-			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++			AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask, TurnType);
+ 		}
+ 		
+ 		return;
+@@ -1088,14 +1079,14 @@
+ 
+ 	const bool bOneLanePerDestination = EnumHasAnyFlags(ConnectionRestrictions, EZoneShapeLaneConnectionRestrictions::OneLanePerDestination);
+ 
+-	if (bTurning)
++	if (TurnType != EZoneGraphTurnType::NoTurn)
+ 	{
+ 		// Turning connections by default get fully-connected slots. The builder may filter them later.
+ 		for (const FLaneConnectionSlot& SourceSlot : SourceSlots)
+ 		{
+ 			for (const FLaneConnectionSlot& DestSlot : DestSlots)
+ 			{
+-				AddOrUpdateConnection(Candidates, SourceSlot.Index, DestSlot.Index, TagMask);
++				AddOrUpdateConnection(Candidates, SourceSlot.Index, DestSlot.Index, TagMask, TurnType);
+ 			}
+ 		}
+ 	}
+@@ -1120,7 +1111,7 @@
+ 				const int32 SourceIdx = FMath::Clamp(SourceIdxUnClamped, 0, SourceNum - 1);
+ 				const int32 DestIdx = i;
+ 			
+-				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask, TurnType);
+ 			}
+ 		}
+ 		else
+@@ -1134,7 +1125,7 @@
+ 			{
+ 				const int32 SourceIdx = i;
+ 				const int32 DestIdx = FMath::Clamp(i - FirstIndex, 0, DestNum - 1);
+-				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask);
++				AddOrUpdateConnection(Candidates, SourceSlots[SourceIdx].Index, DestSlots[DestIdx].Index, TagMask, TurnType);
+ 			}
+ 		}
+ 	}
+@@ -1198,6 +1189,56 @@
+ 	const int32 IncomingConnections;
+ };
+ 
++static EZoneGraphTurnType GetTurnTypeBetweenSourceDest(const FConnectionEntry& Source, TConstArrayView<FConnectionEntry> Destinations, int32 DestIdx, const FMatrix& LocalToWorld, const FZoneGraphBuildSettings& BuildSettings)
++{
++	const FVector SourceForward = LocalToWorld.TransformVector(Source.Point.Rotation.RotateVector(FVector::ForwardVector));
++	const FVector SourceUp = LocalToWorld.TransformVector(Source.Point.Rotation.RotateVector(FVector::UpVector));
++
++	float MinAngle = UE_PI;
++	float MaxAngle = -UE_PI;
++	int32 MinDestIdx = -1;
++	int32 MaxDestIdx = -1;
++	for (int32 Idx = 0; Idx < Destinations.Num(); ++Idx)
++	{
++		const FConnectionEntry& Destination = Destinations[Idx];
++		const FVector DestForward = LocalToWorld.TransformVector(Destination.Point.Rotation.RotateVector(FVector::ForwardVector));
++
++		const float AngleMagnitude = FMath::Acos(FVector::DotProduct(SourceForward, -DestForward));
++		const float AngleSign = FMath::Sign(FVector::CrossProduct(SourceForward, -DestForward).Dot(SourceUp));
++		const float Angle = AngleSign * AngleMagnitude;
++
++		if (Angle < MinAngle)
++		{
++			MinAngle = Angle;
++			MinDestIdx = Idx;
++		}
++		if (Angle > MaxAngle)
++		{
++			MaxAngle = Angle;
++			MaxDestIdx = Idx;
++		}
++	}
++
++	const float TurnThresholdAngle = FMath::DegreesToRadians(BuildSettings.TurnThresholdAngle);
++
++	// A connection must have an angle above the threshold *and* be the right-most connection to be a right turn,
++	// unless bSingleTurningConnectionPerTurnType is false.
++	if ((!BuildSettings.bSingleTurningConnectionPerTurnType || DestIdx == MaxDestIdx) && MaxAngle > TurnThresholdAngle)
++	{
++		return EZoneGraphTurnType::Right;
++	}
++
++	// A connection must have an angle below the threshold *and* be the left-most connection to be a left turn,
++	// unless bSingleTurningConnectionPerTurnType is false.
++	if ((!BuildSettings.bSingleTurningConnectionPerTurnType || DestIdx == MinDestIdx) && MinAngle < -TurnThresholdAngle)
++	{
++		return EZoneGraphTurnType::Left;
++	}
++
++	// Otherwise, the connection is not considered a turn.
++	return EZoneGraphTurnType::NoTurn;
++}
++
+ static void BuildLanesBetweenPoints(const FConnectionEntry& Source, TConstArrayView<FConnectionEntry> Destinations,
+ 									const UZoneShapeComponent& PolygonShapeComp, const TMap<int32, const UZoneShapeComponent*>& PointIndexToZoneShapeComponent, const FZoneGraphBuilder& ZoneGraphBuilder,
+ 									const EZoneShapePolygonRoutingType RoutingType, const FZoneGraphTagMask ZoneTags, const FZoneGraphBuildSettings& BuildSettings, const FMatrix& LocalToWorld,
+@@ -1205,7 +1246,6 @@
+ {
+ 	const float LaneConnectionAngle = BuildSettings.LaneConnectionAngle;
+ 	const float MaxConnectionAngleCos = FMath::Cos(FMath::DegreesToRadians(LaneConnectionAngle));
+-	const float TurnThresholdAngleCos = FMath::Cos(FMath::DegreesToRadians(BuildSettings.TurnThresholdAngle));
+ 
+ 	const float SourceTotalWidth = Source.Profile.GetLanesTotalWidth();
+ 
+@@ -1280,6 +1320,7 @@
+ 			continue;
+ 		}
+ 
++		// Use closest point on dest so that lane profile widths do not affect direction.
+ 		const FVector ClosestDestPoint = FMath::ClosestPointOnSegment(SourcePosition, DestLaneLeft, DestLaneRight);
+ 		const FVector DirToDest = (ClosestDestPoint - SourcePosition).GetSafeNormal();
+ 
+@@ -1290,13 +1331,12 @@
+ 
+ 		const EZoneShapeLaneConnectionRestrictions Restrictions = Source.Point.GetLaneConnectionRestrictions() | RestrictionsFromRules;
+ 
+-		// Use closest point on dest so that lane profile widths do not affect direction.
+-		const FVector SourceSide = FVector::CrossProduct(SourceForward, SourceUp);
++		const EZoneGraphTurnType TurnType = GetTurnTypeBetweenSourceDest(Source, Destinations, PointIndex, LocalToWorld, BuildSettings);
+ 
+-		const bool bIsTurning = FVector::DotProduct(SourceForward, DirToDest) < TurnThresholdAngleCos;
+-		const bool bIsLeftTurn = bIsTurning && FVector::DotProduct(SourceSide, DirToDest) > 0.0f;
++		const bool bIsTurning = TurnType != EZoneGraphTurnType::NoTurn;
++		const bool bIsLeftTurn = TurnType == EZoneGraphTurnType::Left;
+ 
+-		DestinationTurnTypes.Add(PointIndex, bIsTurning ? (bIsLeftTurn ? EZoneGraphTurnType::Left : EZoneGraphTurnType::Right) : EZoneGraphTurnType::NoTurn);
++		DestinationTurnTypes.Add(PointIndex, TurnType);
+ 
+ 		// Discard destination that would result in left or right turns.
+ 		if (EnumHasAnyFlags(Restrictions, EZoneShapeLaneConnectionRestrictions::NoLeftTurn | EZoneShapeLaneConnectionRestrictions::NoRightTurn))
+@@ -1424,7 +1464,7 @@
+ 
+ 			if (TagSourceSlots.Num() > 0 && TagDestSlots.Num() > 0)
+ 			{
+-				AppendLaneConnectionCandidates(Candidates, TagSourceSlots, TagDestSlots, TagMask, MainDestPointIndex, TurnType != EZoneGraphTurnType::NoTurn);
++				AppendLaneConnectionCandidates(Candidates, TagSourceSlots, TagDestSlots, TagMask, MainDestPointIndex, TurnType);
+ 			}
+ 		}
+ 	}
+@@ -1629,7 +1669,8 @@
+ 			}
+ 			if (NearestSourceSlot != INDEX_NONE)
+ 			{
+-				Candidates.Add(FLaneConnectionCandidate(NearestSourceSlot, DestSlotIdx, NearestSlotTags));
++				const EZoneGraphTurnType TurnType = GetTurnTypeBetweenSourceDest(Source, Destinations, DestPointIndex, LocalToWorld, BuildSettings);
++				Candidates.Add(FLaneConnectionCandidate(NearestSourceSlot, DestSlotIdx, NearestSlotTags, TurnType));
+ 			}
+ 		}
+ 	}
+@@ -1640,7 +1681,8 @@
+ 	const bool bAllZoneShapeComponentsInMapAreValid = !ShapeComponentsInMap.Contains(nullptr);
+ 	if (bAllZoneShapeComponentsInMapAreValid)
+ 	{
+-		Candidates.RemoveAll([&ZoneGraphBuilder, &PolygonShapeComp, &SourceSlots, &DestSlots, &PointIndexToZoneShapeComponent](const FLaneConnectionCandidate& Candidate)
++		TArray<FLaneConnectionCandidate> AllCandidates = Candidates;
++		Candidates.RemoveAll([&ZoneGraphBuilder, &PolygonShapeComp, &SourceSlots, &DestSlots, &PointIndexToZoneShapeComponent, &AllCandidates](const FLaneConnectionCandidate& Candidate)
+ 		{
+ 			// The true index to the ZoneShapePoint in this context is the slot's EntryID, not PointIndex field.
+ 			// In fact, SourceSlots don't even fill-out their PointIndex fields.
+@@ -1654,7 +1696,7 @@
+ 			const FLaneConnectionSlot& DestSlot = DestSlots[Candidate.DestSlot];
+ 			const UZoneShapeComponent* DestShapeComp = PointIndexToZoneShapeComponent[DestSlot.EntryID];
+ 
+-			return ZoneGraphBuilder.ShouldFilterLaneConnection(PolygonShapeComp, *SourceShapeComp, SourceSlots, Candidate.SourceSlot, *DestShapeComp, DestSlots, Candidate.DestSlot);
++			return ZoneGraphBuilder.ShouldFilterLaneConnection(PolygonShapeComp, *SourceShapeComp, SourceSlots, Candidate.SourceSlot, *DestShapeComp, DestSlots, Candidate.DestSlot, AllCandidates);
+ 		});
+ 	}
+ 
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Public/ZoneGraphBuilder.h /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphBuilder.h
+--- Source/ZoneGraph/Public/ZoneGraphBuilder.h	2025-05-02 09:57:02
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphBuilder.h	2025-04-28 10:43:39
+@@ -60,6 +60,27 @@
+ 	TMap<TObjectPtr<const UZoneShapeComponent>, FZoneShapeComponentBuildData> ZoneShapeComponentBuildData;
+ };
+ 
++USTRUCT(BlueprintType)
++struct FLaneConnectionCandidate
++{
++	GENERATED_BODY()
++
++	FLaneConnectionCandidate() = default;
++	FLaneConnectionCandidate(const int32 InSourceSlot, const int32 InDestSlot, const FZoneGraphTagMask InTagMask, const EZoneGraphTurnType InTurnType) : SourceSlot(InSourceSlot), DestSlot(InDestSlot), TagMask(InTagMask), TurnType(InTurnType) {}
++
++	UPROPERTY()
++	int32 SourceSlot = 0;
++
++	UPROPERTY()
++	int32 DestSlot = 0;
++
++	UPROPERTY()
++	FZoneGraphTagMask TagMask;
++
++	UPROPERTY()
++	EZoneGraphTurnType TurnType;
++};
++
+ USTRUCT()
+ struct ZONEGRAPH_API FZoneGraphBuilder
+ {
+@@ -94,7 +115,7 @@
+ 	 */
+ 	void QueryHashGrid(const FBox& Bounds, TArray<FZoneGraphBuilderHashGrid2D::ItemIDType>& OutResults);
+ 
+-	virtual bool ShouldFilterLaneConnection(const UZoneShapeComponent& PolygonShapeComp, const UZoneShapeComponent& SourceShapeComp, const TArray<FLaneConnectionSlot>& SourceSlots, const int32 SourceSlotQueryIndex, const UZoneShapeComponent& DestShapeComp, const TArray<FLaneConnectionSlot>& DestSlots, const int32 DestSlotQueryIndex) const { return false; };
++	virtual bool ShouldFilterLaneConnection(const UZoneShapeComponent& PolygonShapeComp, const UZoneShapeComponent& SourceShapeComp, const TArray<FLaneConnectionSlot>& SourceSlots, const int32 SourceSlotQueryIndex, const UZoneShapeComponent& DestShapeComp, const TArray<FLaneConnectionSlot>& DestSlots, const int32 DestSlotQueryIndex, const TArray<FLaneConnectionCandidate>& AllCandidates) const { return false; };
+ 
+ protected:
+ 	void Build(AZoneGraphData& ZoneGraphData);
+diff --color -urN --strip-trailing-cr Source/ZoneGraph/Public/ZoneGraphTypes.h /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h
+--- Source/ZoneGraph/Public/ZoneGraphTypes.h	2025-05-02 09:57:02
++++ /Users/pete/VayuSim/Plugins/ZoneGraph/Source/ZoneGraph/Public/ZoneGraphTypes.h	2025-04-27 07:36:20
+@@ -1049,6 +1049,10 @@
+ 	UPROPERTY(Category = Lanes, EditAnywhere)
+ 	bool bFillEmptyDestination = true;
+ 
++	/** Whether to limit turning connections to only the left-most or right-most turning connections. */
++	UPROPERTY(Category = Lanes, EditAnywhere)
++	bool bSingleTurningConnectionPerTurnType = true;
++
+ 	/** Max distance between two shape points for them to be snapped together. */
+ 	UPROPERTY(Category = PointSnapping, EditAnywhere)
+ 	float ConnectionSnapDistance = 25.0f;

--- a/EngineMods/EngineMods.json
+++ b/EngineMods/EngineMods.json
@@ -21,7 +21,8 @@
         "ZoneGraph.patch.1",
         "ZoneGraph.patch.2",
         "ZoneGraph.patch.3",
-        "ZoneGraph.patch.4"
+        "ZoneGraph.patch.4",
+        "ZoneGraph.patch.5"
       ]
     },
     {
@@ -58,7 +59,8 @@
         "ZoneGraph.patch.1",
         "ZoneGraph.patch.2",
         "ZoneGraph.patch.3",
-        "ZoneGraph.patch.4"
+        "ZoneGraph.patch.4",
+        "ZoneGraph.patch.5"
       ]
     },
     {

--- a/TempoAgents/Source/TempoAgentsEditor/Private/TempoZoneGraphBuilder.cpp
+++ b/TempoAgents/Source/TempoAgentsEditor/Private/TempoZoneGraphBuilder.cpp
@@ -8,7 +8,7 @@
 
 #include "TempoCoreUtils.h"
 
-bool FTempoZoneGraphBuilder::ShouldFilterLaneConnection(const UZoneShapeComponent& PolygonShapeComp, const UZoneShapeComponent& SourceShapeComp, const TArray<FLaneConnectionSlot>& SourceSlots, const int32 SourceSlotQueryIndex, const UZoneShapeComponent& DestShapeComp, const TArray<FLaneConnectionSlot>& DestSlots, const int32 DestSlotQueryIndex) const
+bool FTempoZoneGraphBuilder::ShouldFilterLaneConnection(const UZoneShapeComponent& PolygonShapeComp, const UZoneShapeComponent& SourceShapeComp, const TArray<FLaneConnectionSlot>& SourceSlots, const int32 SourceSlotQueryIndex, const UZoneShapeComponent& DestShapeComp, const TArray<FLaneConnectionSlot>& DestSlots, const int32 DestSlotQueryIndex, const TArray<FLaneConnectionCandidate>& AllCandidates) const
 {
 	const AActor* IntersectionQueryActor = GetIntersectionQueryActor(PolygonShapeComp);
 
@@ -25,7 +25,7 @@ bool FTempoZoneGraphBuilder::ShouldFilterLaneConnection(const UZoneShapeComponen
 
 	bool bShouldFilterLaneConnection;
 	{
-		bShouldFilterLaneConnection = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_ShouldFilterTempoLaneConnection, SourceRoadQueryActor, SourceLaneConnectionInfos, SourceSlotQueryIndex, DestRoadQueryActor, DestLaneConnectionInfos, DestSlotQueryIndex);
+		bShouldFilterLaneConnection = UTempoCoreUtils::CallBlueprintFunction(IntersectionQueryActor, ITempoIntersectionInterface::Execute_ShouldFilterTempoLaneConnection, SourceRoadQueryActor, SourceLaneConnectionInfos, SourceSlotQueryIndex, DestRoadQueryActor, DestLaneConnectionInfos, DestSlotQueryIndex, AllCandidates);
 	}
 
 	return bShouldFilterLaneConnection;

--- a/TempoAgents/Source/TempoAgentsEditor/Public/TempoZoneGraphBuilder.h
+++ b/TempoAgents/Source/TempoAgentsEditor/Public/TempoZoneGraphBuilder.h
@@ -14,7 +14,7 @@ struct TEMPOAGENTSEDITOR_API FTempoZoneGraphBuilder : public FZoneGraphBuilder
 
 public:
 	
-	virtual bool ShouldFilterLaneConnection(const UZoneShapeComponent& PolygonShapeComp, const UZoneShapeComponent& SourceShapeComp, const TArray<FLaneConnectionSlot>& SourceSlots, const int32 SourceSlotQueryIndex, const UZoneShapeComponent& DestShapeComp, const TArray<FLaneConnectionSlot>& DestSlots, const int32 DestSlotQueryIndex) const override;
+	virtual bool ShouldFilterLaneConnection(const UZoneShapeComponent& PolygonShapeComp, const UZoneShapeComponent& SourceShapeComp, const TArray<FLaneConnectionSlot>& SourceSlots, const int32 SourceSlotQueryIndex, const UZoneShapeComponent& DestShapeComp, const TArray<FLaneConnectionSlot>& DestSlots, const int32 DestSlotQueryIndex, const TArray<FLaneConnectionCandidate>& AllCandidates) const override;
 
 protected:
 

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionInterface.h
@@ -173,7 +173,7 @@ public:
 	// Lane Filtering Queries
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category="Tempo Agents|Intersection Interface|Queries")
-	bool ShouldFilterTempoLaneConnection(const AActor* SourceConnectionActor, const TArray<FTempoLaneConnectionInfo>& SourceLaneConnectionInfos, const int32 SourceSlotQueryIndex, const AActor* DestConnectionActor, const TArray<FTempoLaneConnectionInfo>& DestLaneConnectionInfos, const int32 DestSlotQueryIndex) const;
+	bool ShouldFilterTempoLaneConnection(const AActor* SourceConnectionActor, const TArray<FTempoLaneConnectionInfo>& SourceLaneConnectionInfos, const int32 SourceSlotQueryIndex, const AActor* DestConnectionActor, const TArray<FTempoLaneConnectionInfo>& DestLaneConnectionInfos, const int32 DestSlotQueryIndex, const TArray<FLaneConnectionCandidate>& AllCandidates) const;
 
 	// Traffic Controller Queries
 	

--- a/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
+++ b/TempoAgents/Source/TempoAgentsShared/Public/TempoIntersectionQueryComponent.h
@@ -35,7 +35,7 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
 	virtual bool ShouldFilterLaneConnection(const AActor* SourceConnectionActor, const TArray<FTempoLaneConnectionInfo>& SourceLaneConnectionInfos, const int32 SourceLaneConnectionQueryIndex,
-									const AActor* DestConnectionActor, const TArray<FTempoLaneConnectionInfo>& DestLaneConnectionInfos, const int32 DestLaneConnectionQueryIndex) const;
+									const AActor* DestConnectionActor, const TArray<FTempoLaneConnectionInfo>& DestLaneConnectionInfos, const int32 DestLaneConnectionQueryIndex, const TArray<FLaneConnectionCandidate>& AllCandidates) const;
 
 	UFUNCTION(BlueprintCallable, Category = "Tempo Intersections")
 	virtual bool TryGetCrosswalkIntersectionConnectorInfo(const AActor* IntersectionQueryActor, int32 CrosswalkRoadModuleIndex, FCrosswalkIntersectionConnectorInfo& OutCrosswalkIntersectionConnectorInfo) const;
@@ -113,8 +113,8 @@ protected:
 	
 	virtual bool TryGetNearestRoadControlPointIndex(const AActor& IntersectionQueryActor, int32 ConnectionIndex, int32& OutNearestRoadControlPointIndex) const;
 	virtual AActor* GetConnectedRoadActor(const AActor& IntersectionQueryActor, int32 ConnectionIndex) const;
-	
-	virtual TempoZoneGraphTagMaskGroups GroupLaneConnectionsByTags(const AActor* SourceConnectionActor, const TArray<FTempoLaneConnectionInfo>& SourceLaneConnectionInfos, const TArray<FTempoLaneConnectionInfo>& DestLaneConnectionInfos) const;
+
+	virtual TempoZoneGraphTagMaskGroups GroupLaneConnectionsByTags(const TArray<FTempoLaneConnectionInfo>& LaneConnectionInfos) const;
 
 	virtual FZoneGraphTagFilter GetLaneConnectionTagFilter(const AActor* SourceConnectionActor, const FTempoLaneConnectionInfo& SourceLaneConnectionInfo) const;
 


### PR DESCRIPTION
There are currently intersection geometries that can result in lanes with no connection, creating "dead end" lanes. There are also geometries that can result in "redundant" connections, creating unnecessary merge conflicts. There are several ways these can happen, but they are generally more likely when the different roads entering and leaving an intersection have different numbers of lanes.

This makes three separate improvements to our lane filtering logic.

The first involves connections that are incorrectly identified as turning connections in TempoIntersectionQueryComponent.
- TempoIntersectionQueryComponent uses a lane-based heuristic, while ZoneShapeUtilities uses a road-based one. This can result in TempoIntersectionQueryComponent identifying different lanes within the same road as having different turn types. This changes them both to use the same road-based heuristic.
- The road-based heuristic for turning lanes in ZoneShapeUtilities itself actually has two problems:
  - It identifies turning roads using geometry only, and if multiple left or right turning roads meet the criteria they will all be identified as turning destinations. This can result in, for example, an intersection having two left turn destinations but no straight destination. In these cases, we only want to consider the left-most or right-most destination as a turning destination, and consider everything else as straight. This adds an option to enable that and turns it on by default.
  - It uses the direction from the center of the source to the closest point of the destination to determine whether a destination is a turn. This is fragile. For example, a certain intersection geometry might have a destination that is clearly a right turn yet be positioned such that the closest point is nearly straight ahead of a source. This changes that to use the direction of the destination, which should be more robust.

The second involves connections from "center" lanes at the base of a T-intersection
- We currently only allow left or right turns from the left-most or right-most lanes. That means that if there are ever more than two lanes in a group at the base of a T-intersection the center lanes will have no connection. This adds a rule to allow right turns from these lanes while minimizing redundant connections.

The third involves redundant straight connections.
- It's possible to have redundant straight connections between the turning and non-turning lanes, when a source has more lanes than a destination, resulting in unnecessary merge conflict lanes. This adds a rule to identify and reject the redundant connections, with a clear rule for preferring which to keep.

These examples demonstrate the new behavior on previously-problematic intersections.

On main, this four-way intersection has no connection from the middle right driving lane on the lower road. That's because its connections to the lanes on the road opposite the intersection are being misidentified as turning lanes and filtered out. After fixing that, however, it would have redundant connections between the turning and non-turning lanes. With this change all the lanes connect and no redundant connections are made.
<img width="981" alt="Screenshot 2025-05-04 at 10 21 05 AM" src="https://github.com/user-attachments/assets/ea4ed607-66a9-4fe3-bc83-01eeda99717b" />

On main, this T-intersection has no connection from the driving lane adjacent to the bike lane on the top left road. That's because it is not the right-most or left-most lane, and therefore its turning connections are filtered. With this change it's allowed to turn right, without making a redundant connection from the right-most lane.
<img width="938" alt="Screenshot 2025-05-06 at 7 51 20 AM" src="https://github.com/user-attachments/assets/1910479c-c31a-4208-8038-6ecd2dc6880a" />

There are many combinations to consider. I also uploaded a bunch of examples of those [here](https://drive.google.com/drive/folders/1oyyQGx8lIaZ_BVeAfkV_xIwFY_AXxUy9?usp=drive_link). Note that we see no redundant connections or dead end lanes in any of those examples.