### PR TITLE
Use pull_request_target Dispatch So PRs from Forks Can Access Secrets

### DIFF
--- a/.github/workflows/build_and_package.yml
+++ b/.github/workflows/build_and_package.yml
@@ -153,6 +153,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: ${{ inputs.checkout_path }}
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
         fetch-depth: 0
         submodules: recursive
     - name: Find Common Ancestor with Base Branch

--- a/.github/workflows/tempo_build_and_package.yml
+++ b/.github/workflows/tempo_build_and_package.yml
@@ -10,7 +10,8 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The `pull_request` dispatch event does not allow PRs opened from forks (e.g. https://github.com/tempo-sim/Tempo/pull/258) to access repo secrets. This makes sense, for security. But it means that PRs from forks cannot access the Unreal docker images, and therefore cannot run our Build and Package workflow.

The `pull_request_target` dispatch event was [introduced](https://github.blog/news-insights/product-news/github-actions-improvements-for-fork-and-pull-request-workflows/) for this use case:
```
In order to protect public repositories for malicious users we run all pull request workflows raised from repository forks with a read-only token and no access to secrets.
This makes common workflows like labeling or commenting on pull requests very difficult.

In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload.

However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request.

This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request.
```

Since `pull_request_target` by default runs from the base branch, we also must add `ref: ${{ github.event.pull_request.head.sha || github.sha }}` to the `checkout` step, so that we will use the PR branch when triggered by a PR.

This means that PRs from forks will have access to secrets in workflows. However, I've enabled an additional layer of security requiring manual approval of workflow runs from fork PRs in the GitHub actions settings:

<img width="500" alt="Screenshot 2025-05-16 at 7 44 59 AM" src="https://github.com/user-attachments/assets/7454a462-6248-44ad-9019-5405e99e8beb" />