### PR TITLE
Add Overwrite Flag to Save Level RPC

### DIFF
--- a/TempoCore/Source/TempoCoreEditor/Private/TempoCoreEditorServiceSubsystem.cpp
+++ b/TempoCore/Source/TempoCoreEditor/Private/TempoCoreEditorServiceSubsystem.cpp
@@ -115,9 +115,9 @@ void UTempoCoreEditorServiceSubsystem::SaveLevel(const SaveLevelRequest& Request
 		}
 		if (RequestedPath != CurrentLevelName)
 		{
-			if (FPaths::FileExists(RequestedPath))
+			if (FPaths::FileExists(RequestedPath) && !Request.overwrite())
 			{
-				ResponseContinuation.ExecuteIfBound(TempoScripting::Empty(), grpc::Status(grpc::FAILED_PRECONDITION, "Specified level name already exists"));
+				ResponseContinuation.ExecuteIfBound(TempoScripting::Empty(), grpc::Status(grpc::FAILED_PRECONDITION, "Specified level name already exists. Use overwrite flag to replace."));
 				return;
 			}
 		}

--- a/TempoCore/Source/TempoCoreEditor/Public/TempoCoreEditor.proto
+++ b/TempoCore/Source/TempoCoreEditor/Public/TempoCoreEditor.proto
@@ -6,6 +6,7 @@ import "TempoScripting/Empty.proto";
 
 message SaveLevelRequest {
   string path = 1;
+  bool overwrite = 2;
 }
 
 message OpenLevelRequest {


### PR DESCRIPTION
Adds an `overwrite` flag to the Save Level RPC.

Fixes https://github.com/tempo-sim/Tempo/issues/257