### PR TITLE
Use fork-pr-environment in PR Workflows Triggered By Fork PRs

### DIFF
--- a/.github/workflows/build_and_package.yml
+++ b/.github/workflows/build_and_package.yml
@@ -90,6 +90,11 @@ on:
         type: string
         description: Uploaded artifact compression level (refer to github.com/actions/upload-artifact)
         default: '6'
+      environment:
+        type: string
+        description: Environment to deploy to (optional, default None)
+        required: false
+        default: ""
 
 env:
   UNREAL_VERSION: "${{ inputs.unreal_version }}"
@@ -98,6 +103,7 @@ jobs:
   build:
     name: Build and Package Project
     runs-on: ${{ inputs.platform }}
+    environment: ${{ inputs.environment != '' && inputs.environment || null }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}-${{ inputs.unreal_version }}
       cancel-in-progress: true

--- a/.github/workflows/tempo_build_and_package.yml
+++ b/.github/workflows/tempo_build_and_package.yml
@@ -35,4 +35,5 @@ jobs:
       checkout_path: TempoSample/Plugins/Tempo
       cache_repo_root: TempoSample/Plugins/Tempo
       cache_branch: main
+      environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-environment' || '' }}
     secrets: inherit


### PR DESCRIPTION
I recently added https://github.com/tempo-sim/Tempo/pull/260 to allow forks from PRs to access repo secrets. I enabled a repo setting to require approval before running pull requests from forks in order to control which PRs secrets would be shared with.

Unfortunately, to my surprise, that setting only applies the `pull_request` trigger, and not the the `pull_request_target` trigger. So, that setting didn't actually do anything.

This adds an alternative strategy that achieves the same result I was trying for: PRs from forks must be explicitly approved, while non-fork PRs can run workflows without approval. It does so by:
- Adding an [environment](https://github.com/tempo-sim/Tempo/settings/environments/6782376989/edit) with the necessary secrets requiring approval to be used
- Using that environment when a fork PR triggered the workflow

This is difficult to test in-place, which is part of what led to the original oversight. The `pull_request_target` event runs in the context of the base branch, not the PR branch, so changes introduced to workflows in the PR are not reflected in the workflow run. To test this strategy, I made a test repo: https://github.com/tempo-sim/GitHubActionsPlayground and fork (from my personal account): https://github.com/pmelick/GitHubActionsPlayground.

This strategy works as expected on the test repo.

Fork PR: https://github.com/tempo-sim/GitHubActionsPlayground/pull/4
This PR required me to approve the workflow run from my Tempo account:
<img width="600" alt="Screenshot 2025-05-18 at 1 59 50 PM" src="https://github.com/user-attachments/assets/6dd45f88-e454-4c02-925d-1ee9575891da" />

Non-Fork PR: https://github.com/tempo-sim/GitHubActionsPlayground/pull/5
This PR did not require approval to run the workflow.