### PR TITLE
Use Current Gear in Throttle Mapping

### DIFF
--- a/TempoMovement/Source/TempoVehicleMovement/Private/TempoChaosWheeledVehicleMovementComponent.cpp
+++ b/TempoMovement/Source/TempoVehicleMovement/Private/TempoChaosWheeledVehicleMovementComponent.cpp
@@ -19,7 +19,8 @@ void UTempoChaosWheeledVehicleMovementComponent::HandleDrivingCommand(const FDri
 	{
 		if (Input > 0.0)
 		{
-			if (VehicleState.ForwardSpeed > 0.0)
+			static constexpr float NearlyStoppedSpeed = 1.0;
+			if (VehicleState.ForwardSpeed > -NearlyStoppedSpeed && GetCurrentGear() > -1)
 			{
 				SetThrottleInput(Input);
 				SetBrakeInput(0.0);


### PR DESCRIPTION
We have a scheme in `TempoChaosWheeledVehicleMovementComponent` to map normalized acceleration (-1 to 1) to normalized throttle and brakes (each 0 to 1). We're using >0 current forward velocity to determine if a forwards acceleration should cause us to apply brakes (as we should if we are moving backwards) or throttle (as we should if we are stopped or moving forwards). That's preventing vehicles from applying the throttle when they have zero or very small negative forward velocities.

This changes the logic to apply throttle when forward velocity is above a small negative threshold *and* the gear is not a reverse gear.