### PR TITLE
Add RebuildNavigation RPC

### DIFF
--- a/TempoMovement/Source/TempoMovement/Private/TempoMovementControlServiceSubsystem.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TempoMovementControlServiceSubsystem.cpp
@@ -11,6 +11,7 @@
 
 #include "AIController.h"
 #include "Kismet/GameplayStatics.h"
+#include "NavigationSystem.h"
 
 using MovementControlService = TempoMovement::MovementControlService;
 using MovementControlAsyncService = TempoMovement::MovementControlService::AsyncService;
@@ -27,7 +28,8 @@ void UTempoMovementControlServiceSubsystem::RegisterScriptingServices(FTempoScri
 		SimpleRequestHandler(&MovementControlAsyncService::RequestGetCommandableVehicles, &UTempoMovementControlServiceSubsystem::GetCommandableVehicles),
 		SimpleRequestHandler(&MovementControlAsyncService::RequestCommandVehicle, &UTempoMovementControlServiceSubsystem::CommandVehicle),
 		SimpleRequestHandler(&MovementControlAsyncService::RequestGetCommandablePawns, &UTempoMovementControlServiceSubsystem::GetCommandablePawns),
-		SimpleRequestHandler(&MovementControlAsyncService::RequestPawnMoveToLocation, &UTempoMovementControlServiceSubsystem::PawnMoveToLocation)
+		SimpleRequestHandler(&MovementControlAsyncService::RequestPawnMoveToLocation, &UTempoMovementControlServiceSubsystem::PawnMoveToLocation),
+		SimpleRequestHandler(&MovementControlAsyncService::RequestRebuildNavigation, &UTempoMovementControlServiceSubsystem::RebuildNavigation)
 		);
 }
 
@@ -235,4 +237,36 @@ void UTempoMovementControlServiceSubsystem::OnPawnMoveCompleted(FAIRequestID Req
 	}
 
 	UE_LOG(LogTempoMovement, Error, TEXT("Received move completed event for pawn without a pending move"));
+}
+
+void UTempoMovementControlServiceSubsystem::RebuildNavigation(const TempoEmpty& Request, const TResponseDelegate<TempoEmpty>& ResponseContinuation) const
+{
+	auto CanRebuildNavigation = [](const UNavigationSystemV1* NavigationSystem)
+	{
+		for (const ANavigationData* NavData : NavigationSystem->NavDataSet)
+		{
+			if (NavData && NavData->GetRuntimeGenerationMode() == ERuntimeGenerationType::Dynamic)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	};
+
+	UNavigationSystemV1* NavigationSystem = UNavigationSystemV1::GetCurrent(GetWorld());
+	if (!NavigationSystem)
+	{
+		ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status(grpc::FAILED_PRECONDITION, "Navigation system not found"));
+		return;
+	}
+
+	if (!CanRebuildNavigation(NavigationSystem))
+	{
+		ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status(grpc::FAILED_PRECONDITION, "Rebuilding navigation in game is only supported with dynamic generation mode"));
+		return;
+	}
+
+	NavigationSystem->Build();
+	ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status_OK);
 }

--- a/TempoMovement/Source/TempoMovement/Public/MovementControlService.proto
+++ b/TempoMovement/Source/TempoMovement/Public/MovementControlService.proto
@@ -46,4 +46,6 @@ service MovementControlService {
   rpc GetCommandablePawns(TempoScripting.Empty) returns (CommandablePawnsResponse);
 
   rpc PawnMoveToLocation(PawnMoveToLocationRequest) returns (PawnMoveToLocationResponse);
+
+  rpc RebuildNavigation(TempoScripting.Empty) returns (TempoScripting.Empty);
 }

--- a/TempoMovement/Source/TempoMovement/Public/TempoMovementControlServiceSubsystem.h
+++ b/TempoMovement/Source/TempoMovement/Public/TempoMovementControlServiceSubsystem.h
@@ -56,6 +56,8 @@ public:
 
 	void PawnMoveToLocation(const TempoMovement::PawnMoveToLocationRequest& Request, const TResponseDelegate<TempoMovement::PawnMoveToLocationResponse>& ResponseContinuation);
 
+	void RebuildNavigation(const TempoScripting::Empty& Request, const TResponseDelegate<TempoScripting::Empty>& ResponseContinuation) const;
+
 protected:
 	TMap<FAIRequestID, FPendingPawnMoveInfo> PendingPawnMoves;
 

--- a/TempoMovement/Source/TempoMovement/TempoMovement.Build.cs
+++ b/TempoMovement/Source/TempoMovement/TempoMovement.Build.cs
@@ -41,6 +41,7 @@ public class TempoMovement : TempoModuleRules
 			{
 				// Unreal
 				"CoreUObject",
+				"NavigationSystem",
 				// Tempo
 				"TempoMovementShared",
 			}


### PR DESCRIPTION
Some users have reported navigation not being built in the packaged game, despite being built in the editor and using
```
bForceRebuildOnLoad=True
RuntimeGeneration=Dynamic
```
This adds an RPC to TempoMovement to rebuild navigation on demand.