### PR TITLE
Add Ability to Disable Main Viewport Render

### DIFF
--- a/TempoCore/Source/TempoCore/Public/TempoCore.proto
+++ b/TempoCore/Source/TempoCore/Public/TempoCore.proto
@@ -14,6 +14,10 @@ message CurrentLevelResponse {
   string level = 1;
 }
 
+message SetMainViewportRenderEnabledRequest {
+  bool enabled = 1;
+}
+
 service TempoCoreService {
   rpc LoadLevel(LoadLevelRequest) returns (TempoScripting.Empty);
 
@@ -22,4 +26,6 @@ service TempoCoreService {
   rpc GetCurrentLevelName(TempoScripting.Empty) returns (CurrentLevelResponse);
 
   rpc Quit(TempoScripting.Empty) returns (TempoScripting.Empty);
+
+  rpc SetMainViewportRenderEnabled(SetMainViewportRenderEnabledRequest) returns (TempoScripting.Empty);
 }

--- a/TempoCore/Source/TempoCore/Public/TempoCoreServiceSubsystem.h
+++ b/TempoCore/Source/TempoCore/Public/TempoCoreServiceSubsystem.h
@@ -19,6 +19,7 @@ namespace TempoCore
 {
 	class LoadLevelRequest;
 	class CurrentLevelResponse;
+	class SetMainViewportRenderEnabledRequest;
 }
 
 UCLASS()
@@ -50,6 +51,8 @@ public:
 	bool GetStartPaused() const { return bStartPaused; }
 
 	void OnLevelLoaded();
+
+	void SetRenderMainViewportEnabled(const TempoCore::SetMainViewportRenderEnabledRequest& Request, const TResponseDelegate<TempoScripting::Empty>& ResponseContinuation);
 
 protected:
 	TOptional<TResponseDelegate<TempoScripting::Empty>> PendingLevelLoad;

--- a/TempoCore/Source/TempoCore/Public/TempoWorldSettings.h
+++ b/TempoCore/Source/TempoCore/Public/TempoWorldSettings.h
@@ -25,7 +25,13 @@ protected:
 	void SetDefaultAutoExposureBias();
 
 	virtual void BeginPlay() override;
-	
+
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+	void SetMainViewportRenderEnabled(bool bEnabled) const;
+
+	void TempoCoreRenderSettingsChanged() const;
+
 	UPROPERTY(EditAnywhere, Category="Lighting", DisplayName = "Default Exposure Compensation", meta = (UIMin = "-15.0", UIMax = "15.0", EditCondition = "bManualDefaultAutoExposureBias"))
 	float DefaultAutoExposureBias = 0.0;
 
@@ -35,7 +41,5 @@ protected:
 	UPROPERTY()
 	bool bHasBegunPlay = false;
 
-#if WITH_EDITOR
-	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
-#endif
+	FDelegateHandle RenderingSettingsChangedHandle;
 };

--- a/TempoCore/Source/TempoCoreShared/Private/TempoCoreSettings.cpp
+++ b/TempoCore/Source/TempoCoreShared/Private/TempoCoreSettings.cpp
@@ -2,6 +2,9 @@
 
 #include "TempoCoreSettings.h"
 
+UTempoCoreSettings::UTempoCoreSettings()
+	: bRenderMainViewport(!FParse::Param(FCommandLine::Get() , TEXT("RenderOffScreen"))) {}
+
 void UTempoCoreSettings::PostInitProperties()
 {
 	Super::PostInitProperties();
@@ -27,6 +30,15 @@ void UTempoCoreSettings::SetSimulatedStepsPerSecond(int32 SimulatedStepsPerSecon
 	TempoCoreTimeSettingsChangedEvent.Broadcast();
 }
 
+void UTempoCoreSettings::SetRenderMainViewport(bool bInRenderMainViewport)
+{
+	if (bRenderMainViewport != bInRenderMainViewport)
+	{
+		bRenderMainViewport = bInRenderMainViewport;
+		TempoCoreRenderingSettingsChanged.Broadcast();
+	}
+}
+
 #if WITH_EDITOR
 void UTempoCoreSettings::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
 {
@@ -36,6 +48,10 @@ void UTempoCoreSettings::PostEditChangeProperty(FPropertyChangedEvent& PropertyC
 		(TimeMode == ETimeMode::FixedStep && PropertyChangedEvent.Property->GetName() == GET_MEMBER_NAME_CHECKED(UTempoCoreSettings, SimulatedStepsPerSecond)))
 	{
 		TempoCoreTimeSettingsChangedEvent.Broadcast();
+	}
+	else if (PropertyChangedEvent.Property->GetName() == GET_MEMBER_NAME_CHECKED(UTempoCoreSettings, bRenderMainViewport))
+	{
+		TempoCoreRenderingSettingsChanged.Broadcast();
 	}
 }
 #endif

--- a/TempoCore/Source/TempoCoreShared/Public/TempoCoreSettings.h
+++ b/TempoCore/Source/TempoCoreShared/Public/TempoCoreSettings.h
@@ -10,6 +10,7 @@
 #include "TempoCoreSettings.generated.h"
 
 DECLARE_MULTICAST_DELEGATE(FTempoCoreTimeSettingsChanged);
+DECLARE_MULTICAST_DELEGATE(FTempoCoreRenderingSettingsChanged);
 
 UCLASS(Config=Game)
 class TEMPOCORESHARED_API UTempoCoreSettings : public UDeveloperSettings
@@ -17,9 +18,11 @@ class TEMPOCORESHARED_API UTempoCoreSettings : public UDeveloperSettings
 	GENERATED_BODY()
 
 public:
+	UTempoCoreSettings();
+
 	// Allow command-line overrides
 	virtual void PostInitProperties() override;
-	
+
 	// Time Settings.
 	void SetTimeMode(ETimeMode TimeModeIn);
 	void SetSimulatedStepsPerSecond(int32 SimulatedStepsPerSecondIn);
@@ -27,6 +30,7 @@ public:
 	double GetMaxWallClockTimeStep() const { return MaxWallClockTimeStep; }
 	int32 GetSimulatedStepsPerSecond() const { return SimulatedStepsPerSecond; }
 	FTempoCoreTimeSettingsChanged TempoCoreTimeSettingsChangedEvent;
+	FTempoCoreRenderingSettingsChanged TempoCoreRenderingSettingsChanged;
 
 	// Scripting Settings.
 	int32 GetScriptingPort() const { return ScriptingPort; }
@@ -34,8 +38,12 @@ public:
 	int32 GetMaxEventProcessingTime() const { return MaxEventProcessingTimeMicroSeconds; }
 	int32 GetMaxEventWaitTime() const { return MaxEventWaitTimeNanoSeconds; }
 
-	// Packaging Settings
+	// Packaging Settings.
 	bool GetAssignLevelsToIndividualChunks() const { return bAssignLevelsToIndividualChunks; }
+
+	// Rendering Settings.
+	bool GetRenderMainViewport() const { return bRenderMainViewport; }
+	void SetRenderMainViewport(bool bInRenderMainViewport);
 
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
@@ -81,4 +89,8 @@ private:
 	// **NOTE** Requires enabling project packaging settings UsePakFile and GenerateChunks.
 	UPROPERTY(EditAnywhere, Config, Category="Packaging")
 	bool bAssignLevelsToIndividualChunks = false;
+
+	// Whether to render the main viewport (or not, saving performance).
+	UPROPERTY(EditAnywhere, Config, Category="Rendering")
+	bool bRenderMainViewport;
 };

--- a/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
+++ b/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
@@ -8,6 +8,7 @@
 #include "TempoCoreSettings.h"
 
 #include "Engine/TextureRenderTarget2D.h"
+#include "Kismet/GameplayStatics.h"
 
 UTempoSceneCaptureComponent2D::UTempoSceneCaptureComponent2D()
 {
@@ -212,5 +213,25 @@ void UTempoSceneCaptureComponent2D::MaybeCapture()
 		return;
 	}
 
-	CaptureSceneDeferred();
+	bool bWorldRenderingDisabled = false;
+	if (const APlayerController* PlayerController = UGameplayStatics::GetPlayerController(GetWorld(), 0))
+	{
+		if (const ULocalPlayer* ClientPlayer = PlayerController->GetLocalPlayer())
+		{
+			if (const UGameViewportClient* ViewportClient = ClientPlayer->ViewportClient)
+			{
+				bWorldRenderingDisabled = ViewportClient->bDisableWorldRendering;
+			}
+		}
+	}
+
+	// If world rendering is enabled, we'll capture the scene with the main render. Otherwise, we'll capture it now.
+	if (bWorldRenderingDisabled)
+	{
+		CaptureScene();
+	}
+	else
+	{
+		CaptureSceneDeferred();
+	}
 }


### PR DESCRIPTION
Adds the ability to disable the main viewport render, saving any performance that would have been used to render it in situations where it is not needed. This is controllable through the TempoCore API (set_main_viewport_render_enabled) or TempoCoreSettings and the default, if not set through config or API, is determined by the presence of the `renderoffscreen` command line flag.