### PR TITLE
Correct Calculation of Skeletal Mesh Bounds

### DIFF
--- a/TempoWorld/Source/TempoWorld/Private/TempoWorldStateServiceSubsystem.cpp
+++ b/TempoWorld/Source/TempoWorld/Private/TempoWorldStateServiceSubsystem.cpp
@@ -161,9 +161,11 @@ TempoWorld::ActorState GetActorState(const AActor* Actor, const UWorld* World, b
 		Actor->GetTransform().TransformPosition(ActorLocalBounds.Max)
 	);
 
+	const FVector ScaledLocalExtent = Actor->GetTransform().GetScale3D() * ActorLocalBounds.GetExtent();
+
 	if (GDebugTempoWorld)
 	{
-		DrawDebugBox(World, ActorWorldBounds.GetCenter(), ActorLocalBounds.GetExtent(),Actor->GetActorRotation().Quaternion(),
+		DrawDebugBox(World, ActorWorldBounds.GetCenter(), ScaledLocalExtent,Actor->GetActorRotation().Quaternion(),
 			FColor::Red, false, -1, 0, 3.0);
 	}
 


### PR DESCRIPTION
`BodyInstance.GetBodySetup()` returns null for a SkeletalMeshComponent. To get the bounds of one you need to use its physics asset.

Also fixes a bug where the debug visualization of bounding boxes did not take scale into account.