### PR TITLE
Improve TempoCamera Decode Parallelization

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoSensorServiceSubsystem.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoSensorServiceSubsystem.cpp
@@ -63,6 +63,7 @@ void UTempoSensorServiceSubsystem::OnRenderFrameCompleted() const
 		});
 		if (bAnySensorAwaitingRender)
 		{
+			TRACE_CPUPROFILER_EVENT_SCOPE(TempoSensorsWaitForGPUSync);
 			FRHICommandListImmediate& RHICmdList = FRHICommandListImmediate::Get();
 			RHICmdList.SubmitCommandsAndFlushGPU();
 			RHICmdList.BlockUntilGPUIdle();

--- a/TempoSensors/Source/TempoSensorsShared/Public/TempoSceneCaptureComponent2D.h
+++ b/TempoSensors/Source/TempoSensorsShared/Public/TempoSceneCaptureComponent2D.h
@@ -55,6 +55,7 @@ struct TTextureReadBase : FTextureRead
 
 	virtual void Read(const FRenderTarget* RenderTarget, const FTextureRHIRef& TextureRHICopy) override
 	{
+		TRACE_CPUPROFILER_EVENT_SCOPE(TempoSensorsTextureRead);
 		check(IsInRenderingThread());
 
 		State = State::EReading;


### PR DESCRIPTION
Speeds up TempoCamera decode with ParallelFor and skipping decodes when there are no requests.