### PR TITLE
Fix Build Errors With XCode 16.3

### DIFF
--- a/EngineMods/5.5/Engine/Plugins/Runtime/StateTree/StateTree.patch.1
+++ b/EngineMods/5.5/Engine/Plugins/Runtime/StateTree/StateTree.patch.1
@@ -1,0 +1,47 @@
+diff --git Source/StateTreeModule/Public/StateTreeEvents.h Source/StateTreeModule/Public/StateTreeEvents.h
+index 290894b..b016eb4 100644
+--- Source/StateTreeModule/Public/StateTreeEvents.h
++++ Source/StateTreeModule/Public/StateTreeEvents.h
+@@ -193,9 +193,9 @@ struct STATETREEMODULE_API FStateTreeEventQueue
+ 	 * @param Function a lambda which takes const FStateTreeSharedEvent& Event, and returns EStateTreeLoopEvents.
+ 	 */
+ 	template<typename TFunc>
+-	void ForEachEvent(TFunc&& Function) const
++	void ForEachEvent(TFunc&& Function)
+ 	{
+-		for (TArray<FStateTreeSharedEvent>::TConstIterator It(SharedEvents); It; ++It)
++		for (TArray<FStateTreeSharedEvent>::TIterator It(SharedEvents); It; ++It)
+ 		{
+ 			const EStateTreeLoopEvents Result = Function(*It);
+ 			if (Result == EStateTreeLoopEvents::Break)
+diff --git Source/StateTreeModule/Public/StateTreeExecutionContext.h Source/StateTreeModule/Public/StateTreeExecutionContext.h
+index 69c8c2d..89b07ea 100644
+--- Source/StateTreeModule/Public/StateTreeExecutionContext.h
++++ Source/StateTreeModule/Public/StateTreeExecutionContext.h
+@@ -215,7 +215,7 @@ public:
+ 
+ 	/**
+ 	 * Iterates over all events.
+-	 * @param Function a lambda which takes const FStateTreeSharedEvent& Event, and returns EStateTreeLoopEvents.
++	 * @param Function a lambda which takes const FStateTreeEvent& Event, and returns EStateTreeLoopEvents.
+ 	 */
+ 	template<typename TFunc>
+ 	typename TEnableIf<TIsInvocable<TFunc, FStateTreeSharedEvent>::Value, void>::Type ForEachEvent(TFunc&& Function) const
+@@ -224,7 +224,7 @@ public:
+ 		{
+ 			return;
+ 		}
+-		EventQueue->template ForEachEvent(Function);
++		EventQueue->ForEachEvent(Function);
+ 	}
+ 
+ 	/**
+@@ -239,7 +239,7 @@ public:
+ 		{
+ 			return;
+ 		}
+-		EventQueue->template ForEachEvent([Function](const FStateTreeSharedEvent& Event)
++		EventQueue->ForEachEvent([Function](const FStateTreeSharedEvent& Event)
+ 		{
+ 			return Function(*Event);
+ 		});

--- a/EngineMods/EngineMods.json
+++ b/EngineMods/EngineMods.json
@@ -59,6 +59,13 @@
       ]
     },
     {
+      "Type": "SourceOnly",
+      "Root": "Engine/Plugins/Runtime/StateTree",
+      "Patch": [
+        "StateTree.patch.1"
+      ]
+    },
+    {
       "Type": "Plugin",
       "Root": "Engine/Plugins/Runtime/ZoneGraph",
       "Patch": [

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficLightVisualizationProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficLightVisualizationProcessor.cpp
@@ -205,9 +205,9 @@ void UMassTrafficLightUpdateCustomVisualizationProcessor::Execute(FMassEntityMan
 		TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("DebugDisplayVisualization"))
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6
-		EntityQuery.ForEachEntityChunk(EntityManager, Context, [this, World = EntityManager.GetWorld()](FMassExecutionContext& Context)
+		EntityQuery.ForEachEntityChunk(EntityManager, Context, [this](FMassExecutionContext& Context)
 #else
-		EntityQuery.ForEachEntityChunk(Context, [this, World = EntityManager.GetWorld()](FMassExecutionContext& Context)
+		EntityQuery.ForEachEntityChunk(Context, [this](FMassExecutionContext& Context)
 #endif
 		{
 			const UMassTrafficSubsystem* MassTrafficSubsystem = Context.GetSubsystem<UMassTrafficSubsystem>();

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficParkedVehicleVisualizationProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficParkedVehicleVisualizationProcessor.cpp
@@ -122,9 +122,9 @@ void UMassTrafficParkedVehicleUpdateCustomVisualizationProcessor::Execute(FMassE
 		TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("DebugDisplayVisualization")) 
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6
-		EntityQuery.ForEachEntityChunk(EntityManager, Context, [this, World = EntityManager.GetWorld()](FMassExecutionContext& Context)
+		EntityQuery.ForEachEntityChunk(EntityManager, Context, [this](FMassExecutionContext& Context)
 #else
-		EntityQuery.ForEachEntityChunk(Context, [this, World = EntityManager.GetWorld()](FMassExecutionContext& Context)
+		EntityQuery.ForEachEntityChunk(Context, [this](FMassExecutionContext& Context)
 #endif
 		{
 			const UMassTrafficSubsystem* MassTrafficSubsystem = Context.GetSubsystem<UMassTrafficSubsystem>();

--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficTrailerVisualizationProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficTrailerVisualizationProcessor.cpp
@@ -204,9 +204,9 @@ void UMassTrafficTrailerUpdateCustomVisualizationProcessor::Execute(FMassEntityM
 		TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("DebugDisplayVisualization")) 
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6
-		EntityQuery.ForEachEntityChunk(EntityManager, Context, [this, World = EntityManager.GetWorld()](FMassExecutionContext& Context)
+		EntityQuery.ForEachEntityChunk(EntityManager, Context, [this](FMassExecutionContext& Context)
 #else
-		EntityQuery.ForEachEntityChunk(Context, [this, World = EntityManager.GetWorld()](FMassExecutionContext& Context)
+		EntityQuery.ForEachEntityChunk(Context, [this](FMassExecutionContext& Context)
 #endif
 		{
 			const UMassTrafficSubsystem* MassTrafficSubsystem = Context.GetSubsystem<UMassTrafficSubsystem>();

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Tempo is the foundation on which you can build a simulator for your unique appli
 ## Compatibility
 - Linux (Ubuntu 22.04 and 24.04), MacOS (13.0 "Ventura" or newer, Apple silicon only), Windows 10 and 11
 - Unreal Engine 5.4, and 5.5, and 5.6
-> [!WARNING]
-> A change in XCode 16.3 broke Unreal builds (not just Tempo). This is [fixed](https://github.com/EpicGames/UnrealEngine/commit/36e6414349658ce0ef27d3733a764e392b410a7c)  in 5.6, but we don't expect Epic will make a 5.4 or 5.5 hotfix for it. We recommend downgrading to Xcode to 16.2 on Mac if you must use 5.4 or 5.5 on Mac. You can find previous Xcode releases [here](https://developer.apple.com/download/all/) (you'll need a free Apple developer account).
 
 ## Prerequisites
 - Linux:


### PR DESCRIPTION
Xcode 16.3 changed the apple clang compiler and revealed some build errors in Tempo and Unreal.