### PR TITLE
Add Workaround for Potential Buffer Overrun in FRayTracingScene

### DIFF
--- a/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
+++ b/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
@@ -81,8 +81,8 @@ void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* 
 				RayTracingScene->FeedbackReadback[Index].GeometryHandleReadbackBuffer = new FRHIGPUBufferReadback(TEXT("FRayTracingScene::FeedbackReadbackBuffer::GeometryHandles"));
 				RayTracingScene->FeedbackReadback[Index].GeometryCountReadbackBuffer = new FRHIGPUBufferReadback(TEXT("FRayTracingScene::FeedbackReadbackBuffer::GeometryCount"));			
 			}
-#endif
 		}
+#endif
 	}
 #endif
 

--- a/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
+++ b/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
@@ -47,7 +47,6 @@ void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* 
 // When only rendering the main viewport the default size (4) is sufficient.
 // But when running potentially many scene captures per frame they can easily be overrun, leading to reuse of in-use readbacks and crashes.
 // Here we are "hacking" into the persistent RayTracingScene of the scene and increasing the size of these buffers.
-// We have filed UE-XXXXXX to report this.
 #if RHI_RAYTRACING && ENGINE_MAJOR_VERSION == 5 && ((ENGINE_MINOR_VERSION == 5 && STATS) || ENGINE_MINOR_VERSION > 5)
 	const UTempoSensorsSettings* TempoSensorsSettings = GetDefault<UTempoSensorsSettings>();
 	if (TempoSensorsSettings && TempoSensorsSettings->GetRayTracingSceneReadbackBuffersOverrunWorkaroundEnabled())
@@ -81,9 +80,9 @@ void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* 
 #endif
 
 	if (!TextureTarget)
-  {
+	{
 		return;
-  }
+	}
 
 	if (TextureTarget->SizeX != SizeXY.X || TextureTarget->SizeY != SizeXY.Y)
 	{

--- a/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
+++ b/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
@@ -52,9 +52,9 @@ void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* 
 	const UTempoSensorsSettings* TempoSensorsSettings = GetDefault<UTempoSensorsSettings>();
 	if (TempoSensorsSettings && TempoSensorsSettings->GetRayTracingSceneReadbackBuffersOverrunWorkaroundEnabled())
 	{
-		const int32 NewMaxReadbackBuffers = TempoSensorsSettings->GetRayTracingSceneMaxReadbackBuffersOverride();
+		const uint32 NewMaxReadbackBuffers = TempoSensorsSettings->GetRayTracingSceneMaxReadbackBuffersOverride();
 		FRayTracingScene* RayTracingScene = &Scene->GetRenderScene()->RayTracingScene;
-		const size_t PrevReadbackBuffersSize = RayTracingScene->StatsReadbackBuffers.Num();
+		const uint32 PrevReadbackBuffersSize = RayTracingScene->StatsReadbackBuffers.Num();
 		if (PrevReadbackBuffersSize < NewMaxReadbackBuffers)
 		{
 			// MaxReadbackBuffers is not only private but const, so we need an additional trick.
@@ -79,6 +79,11 @@ void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* 
 		}
 	}
 #endif
+
+	if (!TextureTarget)
+  {
+		return;
+  }
 
 	if (TextureTarget->SizeX != SizeXY.X || TextureTarget->SizeY != SizeXY.Y)
 	{

--- a/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
+++ b/TempoSensors/Source/TempoSensorsShared/Private/TempoSceneCaptureComponent2D.cpp
@@ -10,6 +10,13 @@
 #include "Engine/TextureRenderTarget2D.h"
 #include "Kismet/GameplayStatics.h"
 
+#if RHI_RAYTRACING && ENGINE_MAJOR_VERSION == 5 && ((ENGINE_MINOR_VERSION == 5 && STATS) || ENGINE_MINOR_VERSION > 5)
+// Hack to get access to private members of FRayTracingScene. See comment in UpdateSceneCaptureContents for more detail.
+#define private public
+#include "RayTracing/RayTracingScene.h"
+#include "ScenePrivate.h"
+#endif
+
 UTempoSceneCaptureComponent2D::UTempoSceneCaptureComponent2D()
 {
 	PrimaryComponentTick.bStartWithTickEnabled = false;
@@ -35,6 +42,43 @@ void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* 
 #endif
 {
 	TextureInitFence.Wait();
+
+// FRayTracingScene includes buffers, StatsReadbackBuffers and FeedbackReadback, of fixed size.
+// When only rendering the main viewport the default size (4) is sufficient.
+// But when running potentially many scene captures per frame they can easily be overrun, leading to reuse of in-use readbacks and crashes.
+// Here we are "hacking" into the persistent RayTracingScene of the scene and increasing the size of these buffers.
+// We have filed UE-XXXXXX to report this.
+#if RHI_RAYTRACING && ENGINE_MAJOR_VERSION == 5 && ((ENGINE_MINOR_VERSION == 5 && STATS) || ENGINE_MINOR_VERSION > 5)
+	const UTempoSensorsSettings* TempoSensorsSettings = GetDefault<UTempoSensorsSettings>();
+	if (TempoSensorsSettings && TempoSensorsSettings->GetRayTracingSceneReadbackBuffersOverrunWorkaroundEnabled())
+	{
+		const int32 NewMaxReadbackBuffers = TempoSensorsSettings->GetRayTracingSceneMaxReadbackBuffersOverride();
+		FRayTracingScene* RayTracingScene = &Scene->GetRenderScene()->RayTracingScene;
+		const size_t PrevReadbackBuffersSize = RayTracingScene->StatsReadbackBuffers.Num();
+		if (PrevReadbackBuffersSize < NewMaxReadbackBuffers)
+		{
+			// MaxReadbackBuffers is not only private but const, so we need an additional trick.
+			size_t MaxReadbackBuffersOffset = offsetof(FRayTracingScene, MaxReadbackBuffers);
+			*(reinterpret_cast<char*>(RayTracingScene) + MaxReadbackBuffersOffset) = NewMaxReadbackBuffers;
+
+			RayTracingScene->StatsReadbackBuffers.SetNum(NewMaxReadbackBuffers);
+			for (uint32 Index = PrevReadbackBuffersSize; Index < NewMaxReadbackBuffers; ++Index)
+			{
+				RayTracingScene->StatsReadbackBuffers[Index] = new FRHIGPUBufferReadback(TEXT("FRayTracingScene::StatsReadbackBuffer"));
+			}
+
+			// FeedbackReadback added in 5.6
+#if ENGINE_MINOR_VERSION > 5
+			RayTracingScene->FeedbackReadback.SetNum(NewMaxReadbackBuffers);
+			for (uint32 Index = 0; Index < NewMaxReadbackBuffers; ++Index)
+			{
+				RayTracingScene->FeedbackReadback[Index].GeometryHandleReadbackBuffer = new FRHIGPUBufferReadback(TEXT("FRayTracingScene::FeedbackReadbackBuffer::GeometryHandles"));
+				RayTracingScene->FeedbackReadback[Index].GeometryCountReadbackBuffer = new FRHIGPUBufferReadback(TEXT("FRayTracingScene::FeedbackReadbackBuffer::GeometryCount"));			
+			}
+#endif
+		}
+	}
+#endif
 
 	if (TextureTarget->SizeX != SizeXY.X || TextureTarget->SizeY != SizeXY.Y)
 	{

--- a/TempoSensors/Source/TempoSensorsShared/Public/TempoSensorsSettings.h
+++ b/TempoSensors/Source/TempoSensorsShared/Public/TempoSensorsSettings.h
@@ -44,7 +44,7 @@ public:
 
 	// RayTracingScene Buffer Overrun Workaround
 	bool GetRayTracingSceneReadbackBuffersOverrunWorkaroundEnabled() const { return bEnableRayTracingSceneReadbackBuffersOverrunWorkaround; }
-	int32 GetRayTracingSceneMaxReadbackBuffersOverride() const { return RayTracingSceneMaxReadbackBuffersOverride; }
+	uint32 GetRayTracingSceneMaxReadbackBuffersOverride() const { return RayTracingSceneMaxReadbackBuffersOverride; }
 
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
@@ -101,5 +101,5 @@ private:
 
 	// The size of buffer to use as an override in FRayTracingScene, if enabled.
 	UPROPERTY(EditAnywhere, Config, AdvancedDisplay, meta=(EditCondition=bEnableRayTracingSceneBufferOverrunWorkaround))
-	int32 RayTracingSceneMaxReadbackBuffersOverride = 40;
+	uint32 RayTracingSceneMaxReadbackBuffersOverride = 40;
 };

--- a/TempoSensors/Source/TempoSensorsShared/Public/TempoSensorsSettings.h
+++ b/TempoSensors/Source/TempoSensorsShared/Public/TempoSensorsSettings.h
@@ -96,10 +96,10 @@ private:
 	FName OverridingLabelRowName = NAME_None;
 
 	// Whether to enable a hack to work around a buffer overrun bug in FRayTracingScene.
-	UPROPERTY(EditAnywhere, Config, AdvancedDisplay)
+	UPROPERTY(EditAnywhere, Config, Category="Advanced")
 	bool bEnableRayTracingSceneReadbackBuffersOverrunWorkaround = true;
 
 	// The size of buffer to use as an override in FRayTracingScene, if enabled.
-	UPROPERTY(EditAnywhere, Config, AdvancedDisplay, meta=(EditCondition=bEnableRayTracingSceneBufferOverrunWorkaround))
+	UPROPERTY(EditAnywhere, Config, Category="Advanced", meta=(EditCondition=bEnableRayTracingSceneReadbackBuffersOverrunWorkaround))
 	uint32 RayTracingSceneMaxReadbackBuffersOverride = 40;
 };

--- a/TempoSensors/Source/TempoSensorsShared/Public/TempoSensorsSettings.h
+++ b/TempoSensors/Source/TempoSensorsShared/Public/TempoSensorsSettings.h
@@ -42,6 +42,10 @@ public:
 	int32 GetMaxCameraRenderBufferSize() const { return MaxCameraRenderBufferSize; }
 	FTempoSensorsLabelSettingsChanged TempoSensorsLabelSettingsChangedEvent;
 
+	// RayTracingScene Buffer Overrun Workaround
+	bool GetRayTracingSceneReadbackBuffersOverrunWorkaroundEnabled() const { return bEnableRayTracingSceneReadbackBuffersOverrunWorkaround; }
+	int32 GetRayTracingSceneMaxReadbackBuffersOverride() const { return RayTracingSceneMaxReadbackBuffersOverride; }
+
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif
@@ -90,4 +94,12 @@ private:
 	// Anywhere a non-zero subsurface color is found on an object of type OverridableLabelRowName, this label will be used instead.
 	UPROPERTY(EditAnywhere, Config, Category="Camera")
 	FName OverridingLabelRowName = NAME_None;
+
+	// Whether to enable a hack to work around a buffer overrun bug in FRayTracingScene.
+	UPROPERTY(EditAnywhere, Config, AdvancedDisplay)
+	bool bEnableRayTracingSceneReadbackBuffersOverrunWorkaround = true;
+
+	// The size of buffer to use as an override in FRayTracingScene, if enabled.
+	UPROPERTY(EditAnywhere, Config, AdvancedDisplay, meta=(EditCondition=bEnableRayTracingSceneBufferOverrunWorkaround))
+	int32 RayTracingSceneMaxReadbackBuffersOverride = 40;
 };

--- a/TempoSensors/Source/TempoSensorsShared/TempoSensorsShared.Build.cs
+++ b/TempoSensors/Source/TempoSensorsShared/TempoSensorsShared.Build.cs
@@ -1,4 +1,7 @@
-﻿using UnrealBuildTool;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using UnrealBuildTool;
 
 public class TempoSensorsShared : TempoModuleRules
 {
@@ -29,5 +32,10 @@ public class TempoSensorsShared : TempoModuleRules
                 "TempoScripting",
             }
         );
+
+        // Hack to get access to private members of FRayTracingScene in TempoSceneCaptureComponent.
+        // See comment in UTempoSceneCaptureComponent::UpdateSceneCaptureContents for more detail.
+        PrivateIncludePaths.Add(Path.Combine(GetModuleDirectory("Renderer"), "Private"));
+        PrivateIncludePaths.Add(Path.Combine(GetModuleDirectory("Renderer"), "Internal"));
     }
 }


### PR DESCRIPTION
Since 5.5 FRayTracingScene includes buffers, StatsReadbackBuffers and FeedbackReadback, of fixed size. When only rendering the main viewport the default size (4) is sufficient. But when running potentially many scene captures per frame they can easily be overrun, leading to reuse of in-use readbacks and crashes. So in this change we are "hacking" into the persistent RayTracingScene of the scene and increasing the size of these buffers.