### PR TITLE
Update InstallEngineMods.sh

### DIFF
--- a/Scripts/InstallEngineMods.sh
+++ b/Scripts/InstallEngineMods.sh
@@ -77,7 +77,7 @@ elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
     # In UE 5.4 there is only one dotnet on Linux. 5.5 added arm64 support.
     DOTNET="$DOTNETS"
   else
-    ARCH=$(arch)
+    ARCH=$(uname -m)
     if [[ "$ARCH" = "arm64" ]]; then
       DOTNET=$(echo "${DOTNETS[@]}" | grep -E "linux-arm64/dotnet")
     elif [[ "$ARCH" = "x86_64" ]]; then


### PR DESCRIPTION
'uname -m' is more universal than arch

Tested this on Arch Linux and it works as expected.