### PR TITLE
Add missing headers required to build in Unreal docker image

### DIFF
--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficParkedVehicleVisualizationProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficParkedVehicleVisualizationProcessor.cpp
@@ -1,6 +1,7 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 #include "MassTrafficParkedVehicleVisualizationProcessor.h"
+#include "MassCommonFragments.h"
 #include "MassTrafficVehicleVisualizationProcessor.h"
 #include "MassTrafficSubsystem.h"
 #include "MassRepresentationSubsystem.h"

--- a/TempoMovement/Source/TempoVehicleMovement/Private/VehicleWheelComponent.cpp
+++ b/TempoMovement/Source/TempoVehicleMovement/Private/VehicleWheelComponent.cpp
@@ -3,6 +3,7 @@
 #include "VehicleWheelComponent.h"
 
 #include "TempoMovementInterface.h"
+#include "GameFramework/PawnMovementComponent.h"
 
 #include "Kismet/KismetMathLibrary.h"
 


### PR DESCRIPTION
These headers were preventing unreal-based docker builds. Seems locally they work with some sort of transitive pre-compiled header system that wasn't working in the container.