### PR TITLE
Prevent Security Vulnerability Errors from Magick by Not Treating Warnings as Errors

### DIFF
--- a/EngineMods/5.6/Engine/Source/Programs/AutomationTool/Directory.Build.props
+++ b/EngineMods/5.6/Engine/Source/Programs/AutomationTool/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- Disable NuGet security audit to prevent vulnerability warnings in Unreal Engine's
+         third-party packages (e.g. Magick.NET) from being treated as build errors. -->
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+</Project>

--- a/EngineMods/5.7/Engine/Source/Programs/AutomationTool/Directory.Build.props
+++ b/EngineMods/5.7/Engine/Source/Programs/AutomationTool/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- Disable NuGet security audit to prevent vulnerability warnings in Unreal Engine's
+         third-party packages (e.g. Magick.NET) from being treated as build errors. -->
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+</Project>

--- a/EngineMods/EngineMods.json
+++ b/EngineMods/EngineMods.json
@@ -10,6 +10,9 @@
     {
       "Type": "SourceOnly",
       "Root": "Engine/Source/Programs/AutomationTool",
+      "Add": [
+        "Directory.Build.props"
+      ],
       "Patch": [
         "AutomationTool.csproj.patch.1",
         "AutomationUtils/AutomationUtils.Automation.csproj.patch.1",
@@ -66,6 +69,9 @@
     {
       "Type": "SourceOnly",
       "Root": "Engine/Source/Programs/AutomationTool",
+      "Add": [
+        "Directory.Build.props"
+      ],
       "Patch": [
         "AutomationTool.csproj.patch.1",
         "AutomationUtils/AutomationUtils.Automation.csproj.patch.1",


### PR DESCRIPTION
Every time the NuGet vulnerability database flags a Magick version's security vulnerability, the dotnet build in InstallEngineMods or TempoROSCopyHandler treats it as an error and the build fails. This is because `<NuGetAudit>` is enabled and Unreal's projects have `<TreatWarningsAsErrors>` that promotes `NU1900-series` audit warnings to errors. This adds a Directory.Build.props file to the AutomationTool directory for 5.6 and 5.7 that sets `<NuGetAudit>false</NuGetAudit>`.