### PR TITLE
Roll Back grpc for 5.6 on Windows

### DIFF
--- a/Scripts/SyncDeps.sh
+++ b/Scripts/SyncDeps.sh
@@ -15,6 +15,12 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 UNREAL_ENGINE_PATH=$("$SCRIPT_DIR"/FindUnreal.sh)
 UNREAL_ENGINE_PATH="${UNREAL_ENGINE_PATH//\\//}"
 
+# Get engine release (e.g. 5.6)
+if [ -f "$UNREAL_ENGINE_PATH/Engine/Intermediate/Build/BuildRules/UE5RulesManifest.json" ]; then
+  UNREAL_VERSION_WITH_HOTFIX=$(jq -r '.EngineVersion' "$UNREAL_ENGINE_PATH/Engine/Intermediate/Build/BuildRules/UE5RulesManifest.json")
+  UNREAL_VERSION="${UNREAL_VERSION_WITH_HOTFIX%.*}"
+fi
+
 # Check for jq
 if ! which jq &> /dev/null; then
   echo "Couldn't find jq"
@@ -66,12 +72,21 @@ SYNC_THIRD_PARTY_DEPS () {
   MANIFEST_FILE=$1
   FORCE_ARG=$2
   THIRD_PARTY_DIR=$(dirname "$MANIFEST_FILE")
-  ARTIFACT=$(jq -r '.artifact' < "$MANIFEST_FILE")
-  RELEASE_NAME=$(jq -r '.release' < "$MANIFEST_FILE")
+
+  if ! jq -e --arg unreal_version "$UNREAL_VERSION" 'has($unreal_version)' < "$MANIFEST_FILE" > /dev/null; then
+    echo "Error: TempoCore does not support Unreal Engine release $UNREAL_VERSION (found via UNREAL_ENGINE_PATH environment variable at $UNREAL_ENGINE_PATH)"
+    SUPPORTED_RELEASES=$(jq -r 'keys | join(", ")' "$MANIFEST_FILE")
+    echo "Supported Unreal Engine releases are: $SUPPORTED_RELEASES"
+    echo "Please install a supported Unreal Engine release and try again"
+    exit 1
+  fi
+
+  ARTIFACT=$(jq -r --arg unreal_version "$UNREAL_VERSION" '.[$unreal_version].artifact' < "$MANIFEST_FILE")
+  RELEASE_NAME=$(jq -r --arg unreal_version "$UNREAL_VERSION" --arg platform "$PLATFORM" '.[$unreal_version].release[$platform]' < "$MANIFEST_FILE")
   if [ "$PLATFORM" = "Windows" ] && [ $LINUX_CC -ne 0 ]; then
-    EXPECTED_HASH=$(jq -r '.md5_hashes."Windows+Linux"' < "$MANIFEST_FILE")
+    EXPECTED_HASH=$(jq -r --arg unreal_version "$UNREAL_VERSION" '.[$unreal_version].md5_hashes."Windows+Linux"' < "$MANIFEST_FILE")
   else
-    EXPECTED_HASH=$(jq -r --arg platform "$PLATFORM" '.md5_hashes | .[$platform]' < "$MANIFEST_FILE")
+    EXPECTED_HASH=$(jq -r --arg unreal_version "$UNREAL_VERSION" --arg platform "$PLATFORM" '.[$unreal_version].md5_hashes | .[$platform]' < "$MANIFEST_FILE")
   fi
   
   DO_UPDATE="N"

--- a/TempoCore/Source/ThirdParty/ttp_manifest.json
+++ b/TempoCore/Source/ThirdParty/ttp_manifest.json
@@ -1,10 +1,30 @@
 {
-  "artifact": "gRPC",
-  "release": "v0.15",
-  "md5_hashes": {
-    "Linux": "b8a26505fd434d79491688e8a2303bef",
-    "Mac": "c218349b8def11a325496dce3a4b1ab5",
-    "Windows": "3d9118bab56110fcfe8c4990aedf19fa",
-    "Windows+Linux": "b02e60c4094a9d0ed395c6bac5d24384"
+  "5.7": {
+    "artifact": "gRPC",
+    "release": {
+      "Linux": "v0.15",
+      "Mac": "v0.15",
+      "Windows": "v0.15"
+    },
+    "md5_hashes": {
+      "Linux": "b8a26505fd434d79491688e8a2303bef",
+      "Mac": "c218349b8def11a325496dce3a4b1ab5",
+      "Windows": "3d9118bab56110fcfe8c4990aedf19fa",
+      "Windows+Linux": "b02e60c4094a9d0ed395c6bac5d24384"
+    }
+  },
+  "5.6": {
+    "artifact": "gRPC",
+    "release": {
+      "Linux": "v0.15",
+      "Mac": "v0.15",
+      "Windows": "v0.13"
+    },
+    "md5_hashes": {
+      "Linux": "b8a26505fd434d79491688e8a2303bef",
+      "Mac": "c218349b8def11a325496dce3a4b1ab5",
+      "Windows": "2655a87e72be7c6621ada3ef4b882c97",
+      "Windows+Linux": "af84345ee2cb61b7b85327310b36b47d"
+    }
   }
 }


### PR DESCRIPTION
Also adds the ability to have different thirdparty releases for different platforms and engine versions