### PR TITLE
Add optional GitHub App auth for private submodules

### DIFF
--- a/.github/workflows/build_and_package.yml
+++ b/.github/workflows/build_and_package.yml
@@ -107,6 +107,14 @@ on:
         type: string
         description: Token to use for fetching submodules during checkout
         default: ''
+      submodules_app_id:
+        type: string
+        description: GitHub App ID used to mint a token for fetching private submodules during checkout (alternative to submodules_token). Requires the submodules_app_private_key secret. Minting happens in this job, so it works across the reusable-workflow boundary where a token passed via submodules_token cannot (GitHub strips token-shaped values from job outputs).
+        default: ''
+      submodules_repositories:
+        type: string
+        description: Comma- or newline-separated repos to scope the minted submodules token to (default - all repos in the App installation). Only used when submodules_app_id is set.
+        default: ''
       gen_rust_api:
         type: boolean
         description: Generate the Tempo Rust API during the build (sets TEMPO_GEN_RUST_API=1 in the container)
@@ -115,6 +123,10 @@ on:
         type: boolean
         description: Generate the Tempo C++ API during the build (sets TEMPO_GEN_CPP_API=1 in the container)
         default: false
+    secrets:
+      submodules_app_private_key:
+        description: Private key (PEM) for the GitHub App identified by submodules_app_id. Required only when submodules_app_id is set.
+        required: false
 
 env:
   UNREAL_VERSION: "${{ inputs.unreal_version }}"
@@ -184,6 +196,15 @@ jobs:
         ref: main
         fetch-depth: 0
         submodules: recursive
+    - name: Mint Submodules Token (GitHub App)
+      id: submodules_app_token
+      if: ${{ inputs.submodules_app_id != '' }}
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.submodules_app_id }}
+        private-key: ${{ secrets.submodules_app_private_key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ inputs.submodules_repositories }}
     - name: Checkout
       uses: actions/checkout@v4
       with:
@@ -191,7 +212,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         fetch-depth: 0
         submodules: recursive
-        token: ${{ inputs.submodules_token != '' && inputs.submodules_token || github.token }}
+        token: ${{ steps.submodules_app_token.outputs.token != '' && steps.submodules_app_token.outputs.token || (inputs.submodules_token != '' && inputs.submodules_token || github.token) }}
     - name: Find Common Ancestor with Base Branch
       if: ${{ ! inputs.clean }}
       id: common_ancestor

--- a/.github/workflows/publish_engine_mods.yml
+++ b/.github/workflows/publish_engine_mods.yml
@@ -45,6 +45,18 @@ on:
         type: string
         description: Token to use for fetching submodules during checkout
         default: ''
+      submodules_app_id:
+        type: string
+        description: GitHub App ID used to mint a token for fetching private submodules during checkout (alternative to submodules_token). Requires the submodules_app_private_key secret. Minting happens in this job, so it works across the reusable-workflow boundary where a token passed via submodules_token cannot (GitHub strips token-shaped values from job outputs).
+        default: ''
+      submodules_repositories:
+        type: string
+        description: Comma- or newline-separated repos to scope the minted submodules token to (default - all repos in the App installation). Only used when submodules_app_id is set.
+        default: ''
+    secrets:
+      submodules_app_private_key:
+        description: Private key (PEM) for the GitHub App identified by submodules_app_id. Required only when submodules_app_id is set.
+        required: false
 
 env:
   UNREAL_VERSION: "${{ inputs.unreal_version }}"
@@ -66,6 +78,15 @@ jobs:
             exit 1
             ;;
         esac
+    - name: Mint Submodules Token (GitHub App)
+      id: submodules_app_token
+      if: ${{ inputs.submodules_app_id != '' }}
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.submodules_app_id }}
+        private-key: ${{ secrets.submodules_app_private_key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ inputs.submodules_repositories }}
     - name: Checkout
       uses: actions/checkout@v4
       with:
@@ -73,7 +94,7 @@ jobs:
         ref: ${{ inputs.checkout_ref }}
         path: checkout
         submodules: recursive
-        token: ${{ inputs.submodules_token != '' && inputs.submodules_token || github.token }}
+        token: ${{ steps.submodules_app_token.outputs.token != '' && steps.submodules_app_token.outputs.token || (inputs.submodules_token != '' && inputs.submodules_token || github.token) }}
     - name: Compute Engine Mods Hash and Tag
       id: tag
       run: |


### PR DESCRIPTION
Adds an optional `submodules_app_id` + `submodules_repositories` input and a `submodules_app_private_key` secret to `build_and_package.yml` and `publish_engine_mods.yml`. When set, each workflow mints a short-lived installation token in its own checkout job and uses it for `actions/checkout`, so projects with private cross-repo submodules can build/publish without a PAT.

This has to be minted in-job: an App token passed in via `submodules_token` from a separate job arrives empty, because GitHub strips `ghs_`-shaped values from job outputs (see github/gh-aw#24897). The existing `submodules_token` and `github.token` paths are kept as fallbacks, so it's fully backward compatible.

Usage:
```yaml
uses: tempo-sim/Tempo/.github/workflows/build_and_package.yml@main
with:
  submodules_app_id: ${{ vars.SUBMODULES_APP_ID }}
  submodules_repositories: my-private-submodule
secrets: inherit
```