### PR TITLE
TempoSensors: fix two build failures that only surface outside unity builds

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -314,10 +314,6 @@ UTempoCamera::UTempoCamera()
 	ApplyPhotorealisticRenderSettings(PostProcessSettings, ShowFlags, bUseRayTracingIfEnabled);
 }
 
-// Defaulted here (not in the header) so ~TUniquePtr<FTempoCameraVideoEncoder> is instantiated in
-// this translation unit, where TempoCameraVideoEncoder.h has made the type complete.
-UTempoCamera::~UTempoCamera() = default;
-
 bool UTempoCamera::HasDetectedParameterChange() const
 {
 	return SizeXY != SizeXY_Internal
@@ -517,7 +513,7 @@ void UTempoCamera::RequestMeasurement(const TempoSensors::VideoRequest& Request,
 	// a frame is encoded — we don't know SizeXY until SharedFinalTextureTarget exists.
 	if (!VideoEncoder.IsValid())
 	{
-		VideoEncoder = MakeUnique<FTempoCameraVideoEncoder>();
+		VideoEncoder = MakePimpl<FTempoCameraVideoEncoder>();
 	}
 	bVideoEncoderConfigured = false;
 }

--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -314,6 +314,10 @@ UTempoCamera::UTempoCamera()
 	ApplyPhotorealisticRenderSettings(PostProcessSettings, ShowFlags, bUseRayTracingIfEnabled);
 }
 
+// Defaulted here (not in the header) so ~TUniquePtr<FTempoCameraVideoEncoder> is instantiated in
+// this translation unit, where TempoCameraVideoEncoder.h has made the type complete.
+UTempoCamera::~UTempoCamera() = default;
+
 bool UTempoCamera::HasDetectedParameterChange() const
 {
 	return SizeXY != SizeXY_Internal

--- a/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
@@ -7,6 +7,7 @@
 #include "TempoServer.h"
 
 #include "CoreMinimal.h"
+#include "Templates/PimplPtr.h"
 #include "Engine/Scene.h"
 #include "SceneTypes.h"
 #include "ShowFlags.h"
@@ -254,10 +255,6 @@ class TEMPOSENSORS_API UTempoCamera : public UTempoTiledSceneCaptureComponent
 
 public:
 	UTempoCamera();
-	// Declared here and defaulted in the .cpp so the TUniquePtr<FTempoCameraVideoEncoder> member is
-	// destroyed in a translation unit where FTempoCameraVideoEncoder is complete (it is only
-	// forward-declared in this header).
-	~UTempoCamera();
 
 	// UTempoSceneCaptureComponent2D hooks. UTempoCamera drives its own timer and manages its own
 	// readback from SharedFinalTextureTarget (not the inherited TextureTarget, which is used as
@@ -425,8 +422,11 @@ protected:
 
 	// H.264 encoder shared across all subscribed video stream clients. Created lazily on the first
 	// VideoRequest, reconfigured on size/codec/profile/bitrate/KFI changes, kept alive while any
-	// requests are pending. Owned via TUniquePtr to keep the wrapper out of the header.
-	TUniquePtr<class FTempoCameraVideoEncoder> VideoEncoder;
+	// requests are pending. TPimplPtr keeps the wrapper out of the header: its deleter is captured
+	// (with a complete type) at MakePimpl time, so the compiler-generated members of this UObject --
+	// including the UHT vtable-helper constructor emitted in the .gen.cpp -- never need the complete
+	// type. (A plain TUniquePtr<incomplete> member fails there with -Wdelete-incomplete.)
+	TPimplPtr<class FTempoCameraVideoEncoder> VideoEncoder;
 
 	// Encoder is reconfigured the first time we encode a frame whose params don't match — the
 	// camera doesn't know its resolution until SharedFinalTextureTarget is allocated.

--- a/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
@@ -254,6 +254,10 @@ class TEMPOSENSORS_API UTempoCamera : public UTempoTiledSceneCaptureComponent
 
 public:
 	UTempoCamera();
+	// Declared here and defaulted in the .cpp so the TUniquePtr<FTempoCameraVideoEncoder> member is
+	// destroyed in a translation unit where FTempoCameraVideoEncoder is complete (it is only
+	// forward-declared in this header).
+	~UTempoCamera();
 
 	// UTempoSceneCaptureComponent2D hooks. UTempoCamera drives its own timer and manages its own
 	// readback from SharedFinalTextureTarget (not the inherited TextureTarget, which is used as

--- a/TempoSensors/Source/TempoSensors/Public/TempoSceneCaptureComponent2D.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoSceneCaptureComponent2D.h
@@ -11,7 +11,7 @@
 
 #include "TempoSceneCaptureComponent2D.generated.h"
 
-namespace TempoSensorsShared
+namespace TempoSensors
 {
 	class MeasurementHeader;
 }


### PR DESCRIPTION
## Summary

Two latent issues in `TempoSensors` produce hard compile errors when the affected
translation units are built **outside a unity (jumbo) build** — e.g. a non-unity
build, or a host project whose unity grouping compiles these files on their own.
Under unity builds (the default) they're masked, because a neighbouring file in the
same blob happens to supply the missing declaration / complete type. We hit both in
a downstream project on UE 5.7 (clang, `-Werror`).

### 1. `FTextureRead::ExtractMeasurementHeader` uses the wrong namespace

`TempoSceneCaptureComponent2D.h` forward-declares `MeasurementHeader` in
`namespace TempoSensorsShared`, but the signature uses `TempoSensors::MeasurementHeader`
— the namespace the proto actually generates into (`TempoSensors/Common.pb.h`). The
header never includes that generated header, so it only compiles when something earlier
in the TU has already pulled in `Common.pb.h`.

Symptom (compiled standalone):
```
TempoSceneCaptureComponent2D.h:53:73: error: use of undeclared identifier 'TempoSensors'
Fix: forward-declare `MeasurementHeader` in the correct namespace (`TempoSensors`).
```

### 2. `UTempoCamera`'s encoder deletes an incomplete type in the generated vtable-helper ctor
`FTempoCameraVideoEncoder` is forward-declared (pimpl). As a `TUniquePtr` member, its
destructor gets instantiated in `TempoCamera.gen.cpp` via UHT's
`DEFINE_VTABLE_PTR_HELPER_CTOR_NS(, UTempoCamera)` — a TU where the type is incomplete —
so `delete` is emitted on an incomplete type. (An out-of-line `~UTempoCamera()` is not
enough: the generated `FVTableHelper` constructor independently instantiates the member's
destructor for exception cleanup.)

Symptom (editor build, clang):

```
UniquePtr.h:66:3: error: deleting pointer to incomplete type 'FTempoCameraVideoEncoder'
is incompatible with C++2c and may cause undefined behavior [-Werror,-Wdelete-incomplete]
... in instantiation requested here
TempoCamera.gen.cpp:709 | DEFINE_VTABLE_PTR_HELPER_CTOR_NS(, UTempoCamera);
```

Fix: hold the encoder in `TPimplPtr` instead of `TUniquePtr` (`MakePimpl` at the
construction site). Its deleter is captured with a complete type at `MakePimpl` time, so
none of `UTempoCamera`'s compiler-generated members — including the generated vtable-helper
ctor — need the complete type.

## Why this isn't caught today

Both compile cleanly under unity builds. The errors appear only when an affected file is compiled as its own translation unit, without the unity neighbour that happened to supply the missing `#include` / complete type. We hit this in a clean (no-cache) downstream build, where adaptive unity isolated these files into individual TUs.

## Suggestion to catch this class of bug

The reliable way to surface this class of issue is a periodic CI build with unity disabled (`-DisableUnity` / `bUseUnityBuild = false`) and warnings-as-errors: every `.cpp` compiles as its own TU, so missing-include and incomplete-type problems show up deterministically. A clean/non-cached build can expose it incidentally — that's how we hit it — but it isn't dependable, since whether a file compiles in isolation depends on adaptive-unity heuristics. Non-unity needn't run per-PR; weekly (or scoped to the Tempo plugin modules) is enough, and it's especially worthwhile for a plugin that downstream projects build.