### PR TITLE
Update RayTracing Workaround Post Migration

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -896,6 +896,13 @@ void UTempoCamera::RenderCapture()
 		return;
 	}
 
+	// The multi-view tile path below renders via its own FSceneRenderer and never calls
+	// UpdateSceneCaptureContents, so it must expand FRayTracingScene's readback rings itself. This
+	// has to happen before RenderTiles enqueues its scene render: a ray-tracing render that runs
+	// against the engine-default ring of 4 overruns immediately once several sensors capture per
+	// frame. The call is idempotent and persistent, so the first camera each frame covers the rest.
+	EnsureRayTracingReadbackBuffersExpanded(Scene);
+
 	int32 NumActiveTiles = 0;
 	for (const FTempoCameraTile& Tile : Tiles)
 	{

--- a/TempoSensors/Source/TempoSensors/Private/TempoLidar.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoLidar.cpp
@@ -884,6 +884,11 @@ void UTempoLidar::RenderCapture()
 		return;
 	}
 
+	// Like the camera, the lidar renders its tiles via RenderTiles' own FSceneRenderer and never
+	// calls UpdateSceneCaptureContents, so expand FRayTracingScene's readback rings here before
+	// rendering or the engine-default ring of 4 overruns once several sensors capture per frame.
+	EnsureRayTracingReadbackBuffersExpanded(Scene);
+
 	// Per-tile view origin (shared across tiles) — the lidar's world location.
 	const FTransform LidarWorld = GetComponentToWorld();
 	const FVector ViewLocation = LidarWorld.GetTranslation();

--- a/TempoSensors/Source/TempoSensors/Private/TempoSceneCaptureComponent2D.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoSceneCaptureComponent2D.cpp
@@ -99,14 +99,6 @@ void UTempoSceneCaptureComponent2D::Deactivate()
 	}
 }
 
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6
-void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* Scene)
-#else
-void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* Scene, ISceneRenderBuilder& SceneRenderBuilder)
-#endif
-{
-	TextureInitFence.Wait();
-
 // FRayTracingScene's StatsReadback / FeedbackReadback are fixed-size rings (MaxReadbackBuffers, 4
 // by default). The main viewport doesn't overrun them, but running many scene captures per frame
 // does — FinishTracingFeedback in particular writes unconditionally without checking
@@ -114,10 +106,21 @@ void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* 
 // overwritten and EnqueueCopy / Lock later trips. Expand the rings to a configurable size.
 //
 // All FRayTracingScene state lives on the render thread; the expansion must happen there too. We
-// enqueue a render command rather than mutating from the game thread. The hack is idempotent —
-// repeated calls early-return once the rings are already at the target size, so issuing it from
-// every TempoSceneCaptureComponent2D's UpdateSceneCaptureContents is fine.
+// enqueue a render command rather than mutating from the game thread. The change persists for the
+// FScene's lifetime and the hack is idempotent — repeated calls early-return once the rings are
+// already at the target size. It MUST run before any ray-tracing scene render this frame: the
+// engine indexes the ring with the FScene's (now-expanded) MaxReadbackBuffers, so a render that
+// slips in before the expansion runs against the default ring of 4 and overruns immediately. The
+// camera's multi-view tile path renders via its own FSceneRenderer and never reaches
+// UpdateSceneCaptureContents, so it calls this directly from RenderCapture before RenderTiles.
+void UTempoSceneCaptureComponent2D::EnsureRayTracingReadbackBuffersExpanded(FSceneInterface* Scene)
+{
 #if RHI_RAYTRACING && ENGINE_MAJOR_VERSION == 5 && ((ENGINE_MINOR_VERSION == 5 && STATS) || ENGINE_MINOR_VERSION > 5)
+	if (!Scene)
+	{
+		return;
+	}
+
 	const UTempoSensorsSettings* TempoSensorsSettings = GetDefault<UTempoSensorsSettings>();
 	if (TempoSensorsSettings && TempoSensorsSettings->GetRayTracingSceneReadbackBuffersOverrunWorkaroundEnabled())
 	{
@@ -176,6 +179,17 @@ void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* 
 			});
 	}
 #endif
+}
+
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6
+void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* Scene)
+#else
+void UTempoSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* Scene, ISceneRenderBuilder& SceneRenderBuilder)
+#endif
+{
+	TextureInitFence.Wait();
+
+	EnsureRayTracingReadbackBuffersExpanded(Scene);
 
 	if (!TextureTarget)
 	{

--- a/TempoSensors/Source/TempoSensors/Public/TempoSceneCaptureComponent2D.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoSceneCaptureComponent2D.h
@@ -335,6 +335,15 @@ public:
 	virtual void UpdateSceneCaptureContents(FSceneInterface* Scene, ISceneRenderBuilder& SceneRenderBuilder) override;
 #endif
 
+	// Expand FRayTracingScene's fixed-size readback rings on the render thread to work around the
+	// engine's buffer overrun (see definition for detail). Idempotent and persistent for the FScene's
+	// lifetime, so it's safe — and necessary — to call before *any* ray-tracing scene render this
+	// component issues. The standard capture path calls it from UpdateSceneCaptureContents, but
+	// components that render via a custom FSceneRenderer (e.g. the camera's multi-view tile path,
+	// which bypasses UpdateSceneCaptureContents entirely) must call it themselves before rendering,
+	// or the ring stays at the engine default of 4 and overruns immediately under many sensors.
+	static void EnsureRayTracingReadbackBuffersExpanded(FSceneInterface* Scene);
+
 protected:
 	// Derived components must override this to return whether they have pending requests.
 	virtual bool HasPendingRequests() const PURE_VIRTUAL(UTempoSceneCaptureComponent2D::HasPendingRequests, return false; );


### PR DESCRIPTION
TempoCamera and TempoLidar no longer use `UpdateSceneCaptureContents` for multi-tile renders, instead constructing their own `FSceneRenderer`. This means the workaround to expand the ray tracing readback buffers was never being called and the original crash could still happen.