### PR TITLE
Encode camera video at RateHz, not the render rate

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -557,6 +557,15 @@ void UTempoCamera::OnRenderCompleted()
 		return;
 	}
 
+	// Encode each captured frame once: OnRenderCompleted fires every render frame but captures happen
+	// at RateHz, so re-encoding the same CapturedVideoSequenceId would emit duplicates and drive the
+	// RateHz-sized bitrate/GOP too fast. After Configure, so a failed reconfigure isn't counted.
+	if (CapturedVideoSequenceId == LastEncodedVideoSequenceId)
+	{
+		return;
+	}
+	LastEncodedVideoSequenceId = CapturedVideoSequenceId;
+
 	// Stamp packets with the captured frame's id. CapturedVideoSequenceId is the id of the frame
 	// currently in SharedFinalTextureTarget, published by RenderCapture on the render thread behind the
 	// RT draws — read here render-thread-locally instead of the game-thread SequenceId, which races and

--- a/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
@@ -445,6 +445,9 @@ protected:
 	// render thread.
 	int32 CapturedVideoSequenceId = INDEX_NONE;
 
+	// Last CapturedVideoSequenceId encoded for video; drives the per-capture dedup in OnRenderCompleted.
+	int32 LastEncodedVideoSequenceId = INDEX_NONE;
+
 	// Tile slots (fixed size: TL, TR, BL, BR). Stable storage — indices are never invalidated
 	// and held addresses remain valid across reconfigures. Transient: runtime-only state.
 	UPROPERTY(Transient)


### PR DESCRIPTION
The in-engine H.264 camera stream comes out at the render frame rate instead of the camera's RateHz. Every other sensor stream is rate-limited by the capture cadence, but the video path encodes SharedFinalTextureTarget in OnRenderCompleted, which fires on every rendered frame, so between captures it just re-encodes the same texture and ships duplicate frames.

Besides the wrong (and machine-dependent) frame rate, this skews the encoder's bitrate and GOP, since both are sized for RateHz.

The fix gates the encode on SequenceId, so each captured frame is encoded once, the same cadence the other streams already use, and drops the redundant per-frame encode work.

Repro'd in-sim: with RateHz=10 the stream came out around the render rate (~115 fps), almost all duplicate frames.