### PR TITLE
TempoSensors Don't Share Sequence ID With Render Thread

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -557,8 +557,12 @@ void UTempoCamera::OnRenderCompleted()
 		return;
 	}
 
-	// Stamp packets with the just-rendered frame's id (RenderCapture already incremented past it).
-	const int32 EncodedSequenceId = FMath::Max(0, SequenceId - 1);
+	// Stamp packets with the captured frame's id. CapturedVideoSequenceId is the id of the frame
+	// currently in SharedFinalTextureTarget, published by RenderCapture on the render thread behind the
+	// RT draws — read here render-thread-locally instead of the game-thread SequenceId, which races and
+	// under pipelining can name a capture not yet rendered. Clamp covers the pre-first-capture
+	// INDEX_NONE.
+	const int32 EncodedSequenceId = FMath::Max(0, CapturedVideoSequenceId);
 	const double CaptureTime = GetWorld() ? GetWorld()->GetTimeSeconds() : 0.0;
 
 	UTextureRenderTarget2D* RTCapture = RT;
@@ -1333,6 +1337,17 @@ void UTempoCamera::RenderCapture()
 
 			NewRead->RenderFence = RHICreateGPUFence(TEXT("TempoCameraRenderFence"));
 			RHICmdList.WriteGPUFence(NewRead->RenderFence);
+		});
+
+	// Publish the captured frame's id to the render thread for the video encoder. Queued behind the
+	// RT draws above, so by the time it runs SharedFinalTextureTarget holds this capture and
+	// OnRenderCompleted (also on the render thread) reads CapturedVideoSequenceId coherently — instead
+	// of the game-thread SequenceId, which races and could name a capture not yet rendered.
+	const int32 CapturedVideoSequenceIdThisFrame = SequenceId - 1;
+	ENQUEUE_RENDER_COMMAND(TempoCameraPublishVideoSequenceId)(
+		[this, CapturedVideoSequenceIdThisFrame](FRHICommandListImmediate&)
+		{
+			CapturedVideoSequenceId = CapturedVideoSequenceIdThisFrame;
 		});
 
 	// Pop: restore the prior CVar value. The propagation render command queued by Set() on

--- a/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
@@ -438,6 +438,13 @@ protected:
 	// camera doesn't know its resolution until SharedFinalTextureTarget is allocated.
 	bool bVideoEncoderConfigured = false;
 
+	// SequenceId of the capture currently resident in SharedFinalTextureTarget. Published by
+	// RenderCapture via a render command queued behind the RT draws, so OnRenderCompleted can read it
+	// render-thread-locally instead of the game-thread SequenceId (a cross-thread read that, under
+	// game/render pipelining, can name a capture not yet rendered into the RT). Touched only on the
+	// render thread.
+	int32 CapturedVideoSequenceId = INDEX_NONE;
+
 	// Tile slots (fixed size: TL, TR, BL, BR). Stable storage — indices are never invalidated
 	// and held addresses remain valid across reconfigures. Transient: runtime-only state.
 	UPROPERTY(Transient)


### PR DESCRIPTION
SequenceID is currently written on the game thread and read on the render thread. This is a race condition when using pipelined rendering and wall clock mode, and can lead to skipped and incorrect sequence IDs being sent in that mode.