### PR TITLE
Fix a render/game-thread race that crashes camera video streaming

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -21,6 +21,7 @@
 #include "Kismet/KismetRenderingLibrary.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Math/Box2D.h"
+#include "Misc/ScopeLock.h"
 #include "TextureResource.h"
 
 // 5.6 only: GetLastAverageSceneLuminance lives on the renderer-private FSceneViewState — it was
@@ -447,7 +448,13 @@ TOptional<TFuture<void>> UTempoCamera::SendMeasurements()
 			{
 				Req.ResponseContinuation.ExecuteIfBound(Frame, grpc::Status_OK);
 			}
-			PendingVideoRequests.Empty();
+			// Empty() under the lock: OnRenderCompleted reads PendingVideoRequests.Last() on the
+			// render thread and must not observe a mid-Empty array. (The broadcast loop above is
+			// safe unlocked — the render thread only ever reads this array, never writes it.)
+			{
+				FScopeLock PendingLock(&PendingVideoRequestsLock);
+				PendingVideoRequests.Empty();
+			}
 		}
 	}
 
@@ -506,7 +513,11 @@ void UTempoCamera::RequestMeasurement(const TempoSensors::BoundingBoxesRequest& 
 
 void UTempoCamera::RequestMeasurement(const TempoSensors::VideoRequest& Request, const TResponseDelegate<TempoSensors::VideoFrame>& ResponseContinuation)
 {
-	PendingVideoRequests.Add({ Request, ResponseContinuation });
+	// Add() under the lock: OnRenderCompleted reads PendingVideoRequests on the render thread.
+	{
+		FScopeLock PendingLock(&PendingVideoRequestsLock);
+		PendingVideoRequests.Add({ Request, ResponseContinuation });
+	}
 
 	// Lazy-construct on first request. Encoder is opened with a real Width/Height the first time
 	// a frame is encoded — we don't know SizeXY until SharedFinalTextureTarget exists.
@@ -529,7 +540,7 @@ void UTempoCamera::OnRenderCompleted()
 {
 	Super::OnRenderCompleted();
 
-	if (!VideoEncoder.IsValid() || PendingVideoRequests.IsEmpty())
+	if (!VideoEncoder.IsValid())
 	{
 		return;
 	}
@@ -547,7 +558,19 @@ void UTempoCamera::OnRenderCompleted()
 	Config.Width = static_cast<uint32>(RT->SizeX);
 	Config.Height = static_cast<uint32>(RT->SizeY);
 	Config.TargetFramerate = static_cast<uint32>(FMath::Max(1.0f, GetRate()));
-	const TempoSensors::VideoRequest& LatestRequest = PendingVideoRequests.Last().Request;
+	// PendingVideoRequests is mutated on the game thread (RequestMeasurement / SendMeasurements),
+	// so snapshot the latest request under the lock before this render-thread read — otherwise a
+	// concurrent Empty() can leave Last() indexing an emptied array. Copy by value so Config stays
+	// valid once the lock releases.
+	TempoSensors::VideoRequest LatestRequest;
+	{
+		FScopeLock PendingLock(&PendingVideoRequestsLock);
+		if (PendingVideoRequests.IsEmpty())
+		{
+			return;
+		}
+		LatestRequest = PendingVideoRequests.Last().Request;
+	}
 	Config.Codec = LatestRequest.codec();
 	Config.BitrateKbps = LatestRequest.bitrate_kbps();
 	Config.KeyframeInterval = LatestRequest.keyframe_interval();

--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -421,6 +421,9 @@ TOptional<TFuture<void>> UTempoCamera::SendMeasurements()
 	// entire access unit into one packet, so in steady state DrainPackets yields exactly one entry;
 	// older entries are stale (only happens under game-thread backlog) and dropping them is
 	// preferable to firing each subscriber's ResponseContinuation multiple times.
+	// Runs on the game thread, as does RequestMeasurement (the only writer of these), so the reads
+	// of VideoEncoder and PendingVideoRequests here need no lock — only the render thread's
+	// OnRenderCompleted does (it takes VideoStateMutex to snapshot them).
 	if (VideoEncoder.IsValid() && !PendingVideoRequests.IsEmpty())
 	{
 		TArray<FTempoEncodedVideoPacket> Packets;
@@ -452,7 +455,7 @@ TOptional<TFuture<void>> UTempoCamera::SendMeasurements()
 			// render thread and must not observe a mid-Empty array. (The broadcast loop above is
 			// safe unlocked — the render thread only ever reads this array, never writes it.)
 			{
-				FScopeLock PendingLock(&PendingVideoRequestsLock);
+				FScopeLock VideoStateLock(&VideoStateMutex);
 				PendingVideoRequests.Empty();
 			}
 		}
@@ -513,17 +516,18 @@ void UTempoCamera::RequestMeasurement(const TempoSensors::BoundingBoxesRequest& 
 
 void UTempoCamera::RequestMeasurement(const TempoSensors::VideoRequest& Request, const TResponseDelegate<TempoSensors::VideoFrame>& ResponseContinuation)
 {
-	// Add() under the lock: OnRenderCompleted reads PendingVideoRequests on the render thread.
+	// Add the request and lazily create the encoder under the lock: OnRenderCompleted reads both
+	// PendingVideoRequests and the VideoEncoder pointer on the render thread, so publishing them
+	// here keeps it from observing a half-constructed encoder. Created once and never reset; the
+	// encoder opens with a real Width/Height the first time a frame is encoded — we don't know
+	// SizeXY until SharedFinalTextureTarget exists.
 	{
-		FScopeLock PendingLock(&PendingVideoRequestsLock);
+		FScopeLock VideoStateLock(&VideoStateMutex);
 		PendingVideoRequests.Add({ Request, ResponseContinuation });
-	}
-
-	// Lazy-construct on first request. Encoder is opened with a real Width/Height the first time
-	// a frame is encoded — we don't know SizeXY until SharedFinalTextureTarget exists.
-	if (!VideoEncoder.IsValid())
-	{
-		VideoEncoder = MakePimpl<FTempoCameraVideoEncoder>();
+		if (!VideoEncoder.IsValid())
+		{
+			VideoEncoder = MakePimpl<FTempoCameraVideoEncoder>();
+		}
 	}
 	bVideoEncoderConfigured = false;
 }
@@ -540,15 +544,28 @@ void UTempoCamera::OnRenderCompleted()
 {
 	Super::OnRenderCompleted();
 
-	if (!VideoEncoder.IsValid())
-	{
-		return;
-	}
-
 	UTextureRenderTarget2D* RT = SharedFinalTextureTarget;
 	if (!RT || RT->SizeX <= 0 || RT->SizeY <= 0)
 	{
 		return;
+	}
+
+	// Snapshot the shared video state under the lock. VideoEncoder is created on the game thread
+	// (RequestMeasurement) and PendingVideoRequests is mutated there too, so read both here under
+	// the lock — otherwise this render-thread path can observe a half-published encoder pointer, or
+	// call Last() on an array a concurrent Empty() just cleared. The encoder is created once and
+	// never reset, so the raw pointer stays valid after the lock releases; we deliberately don't
+	// hold the lock across Configure()/encode.
+	FTempoCameraVideoEncoder* EncoderPtr = nullptr;
+	TempoSensors::VideoRequest LatestRequest;
+	{
+		FScopeLock VideoStateLock(&VideoStateMutex);
+		if (!VideoEncoder.IsValid() || PendingVideoRequests.IsEmpty())
+		{
+			return;
+		}
+		EncoderPtr = VideoEncoder.Get();
+		LatestRequest = PendingVideoRequests.Last().Request;
 	}
 
 	// (Re)configure the encoder. Latest pending request wins — gives a streaming client a way to
@@ -558,24 +575,11 @@ void UTempoCamera::OnRenderCompleted()
 	Config.Width = static_cast<uint32>(RT->SizeX);
 	Config.Height = static_cast<uint32>(RT->SizeY);
 	Config.TargetFramerate = static_cast<uint32>(FMath::Max(1.0f, GetRate()));
-	// PendingVideoRequests is mutated on the game thread (RequestMeasurement / SendMeasurements),
-	// so snapshot the latest request under the lock before this render-thread read — otherwise a
-	// concurrent Empty() can leave Last() indexing an emptied array. Copy by value so Config stays
-	// valid once the lock releases.
-	TempoSensors::VideoRequest LatestRequest;
-	{
-		FScopeLock PendingLock(&PendingVideoRequestsLock);
-		if (PendingVideoRequests.IsEmpty())
-		{
-			return;
-		}
-		LatestRequest = PendingVideoRequests.Last().Request;
-	}
 	Config.Codec = LatestRequest.codec();
 	Config.BitrateKbps = LatestRequest.bitrate_kbps();
 	Config.KeyframeInterval = LatestRequest.keyframe_interval();
 	Config.H264Profile = LatestRequest.profile();
-	if (!VideoEncoder->Configure(Config))
+	if (!EncoderPtr->Configure(Config))
 	{
 		return;
 	}
@@ -598,7 +602,6 @@ void UTempoCamera::OnRenderCompleted()
 	const double CaptureTime = GetWorld() ? GetWorld()->GetTimeSeconds() : 0.0;
 
 	UTextureRenderTarget2D* RTCapture = RT;
-	FTempoCameraVideoEncoder* EncoderPtr = VideoEncoder.Get();
 	ENQUEUE_RENDER_COMMAND(TempoCameraEncodeVideo)(
 		[EncoderPtr, RTCapture, CaptureTime, EncodedSequenceId](FRHICommandListImmediate&)
 		{

--- a/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
@@ -427,11 +427,12 @@ protected:
 	TArray<FBoundingBoxesRequest> PendingBoundingBoxesRequests;
 	TArray<FVideoRequest> PendingVideoRequests;
 
-	// Guards PendingVideoRequests across the game/render thread boundary: it is mutated on the game
-	// thread (Add in RequestMeasurement, Empty in SendMeasurements) and read on the render thread
-	// (OnRenderCompleted, which snapshots the latest request under this lock). Without it a render-
-	// thread Last() can race a game-thread Empty() and index an emptied array.
-	FCriticalSection PendingVideoRequestsLock;
+	// Guards the video state shared between the game and render threads: PendingVideoRequests (Add
+	// in RequestMeasurement, Empty in SendMeasurements) and the lazy publication of the VideoEncoder
+	// pointer below. OnRenderCompleted (render thread) snapshots both under this lock, so it never
+	// observes a half-constructed encoder, or calls Last() on an array a concurrent Empty() just
+	// cleared. (The encoder's own drained-packet handoff is a separate MPSC TQueue, safe on its own.)
+	FCriticalSection VideoStateMutex;
 
 	// H.264 encoder shared across all subscribed video stream clients. Created lazily on the first
 	// VideoRequest, reconfigured on size/codec/profile/bitrate/KFI changes, kept alive while any

--- a/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
@@ -7,6 +7,7 @@
 #include "TempoServer.h"
 
 #include "CoreMinimal.h"
+#include "HAL/CriticalSection.h"
 #include "Templates/PimplPtr.h"
 #include "Engine/Scene.h"
 #include "SceneTypes.h"
@@ -425,6 +426,12 @@ protected:
 	TArray<FDepthImageRequest> PendingDepthImageRequests;
 	TArray<FBoundingBoxesRequest> PendingBoundingBoxesRequests;
 	TArray<FVideoRequest> PendingVideoRequests;
+
+	// Guards PendingVideoRequests across the game/render thread boundary: it is mutated on the game
+	// thread (Add in RequestMeasurement, Empty in SendMeasurements) and read on the render thread
+	// (OnRenderCompleted, which snapshots the latest request under this lock). Without it a render-
+	// thread Last() can race a game-thread Empty() and index an emptied array.
+	FCriticalSection PendingVideoRequestsLock;
 
 	// H.264 encoder shared across all subscribed video stream clients. Created lazily on the first
 	// VideoRequest, reconfigured on size/codec/profile/bitrate/KFI changes, kept alive while any


### PR DESCRIPTION
The sim has been crashing during high-frame-rate camera streaming, usually within a minute or two once the frame rate is up. Every crash report landed in the same spot: an assertion in `UTempoCamera::OnRenderCompleted()` on the render thread, indexing an array of size 0.

The cause is an unsynchronized hand-off. `OnRenderCompleted()` runs on the render thread and reads `PendingVideoRequests` — `IsEmpty()`, then `.Last()` to pull the latest encoder config — while the game thread is mutating that same list (`Add()` in `RequestMeasurement()`, `Empty()` in `SendMeasurements()`). If the game thread empties the list between the check and the `.Last()`, the render thread indexes an empty array and we assert. The higher the frame rate, the more often `OnRenderCompleted()` runs, so the more often we lose that race — which is why it shows up under load.

The fix is a small critical section (`VideoStateMutex`) over the shared state: the render thread snapshots the latest request *by value* under the lock, and the game-thread `Add`/`Empty` take the same lock. We don't hold it across `Configure()` or the encode itself.

While I was in there I closed a second, rarer race on the same path: `VideoEncoder` is created lazily on the game thread but read and used on the render thread with nothing guarding the hand-off. Its creation and the render-thread read now go through the same lock, and `OnRenderCompleted()` snapshots the encoder pointer together with the request.

If you agree with the analysis and solution, feel free to merge, otherwise let me know if a different approach would suffice. 