### PR TITLE
Release TempoCamera & TempoLidar Tile ViewStates in OnUnregister

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -353,10 +353,8 @@ ETempoTextureFilterType UTempoCamera::GetEffectiveTextureFilterType() const
 	return ETempoTextureFilterType::Bilinear;
 }
 
-void UTempoCamera::ReconfigureTilesNow()
+void UTempoCamera::DeactivateAllTiles()
 {
-	// Drain all active tiles (releases their view states + PPMs) before re-configuring with
-	// new parameters. Caller must have confirmed no reads are in flight.
 	for (FTempoCameraTile& Tile : Tiles)
 	{
 		if (Tile.bActive)
@@ -364,6 +362,13 @@ void UTempoCamera::ReconfigureTilesNow()
 			DeactivateTile(Tile);
 		}
 	}
+}
+
+void UTempoCamera::ReconfigureTilesNow()
+{
+	// Drain all active tiles (releases their view states + PPMs) before re-configuring with
+	// new parameters. Caller must have confirmed no reads are in flight.
+	DeactivateAllTiles();
 
 	SyncTiles();
 	UpdateInternalMirrors();

--- a/TempoSensors/Source/TempoSensors/Private/TempoLidar.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoLidar.cpp
@@ -141,10 +141,8 @@ bool UTempoLidar::HasDetectedParameterChange() const
 		|| BeamCalibration != BeamCalibration_Internal;
 }
 
-void UTempoLidar::ReconfigureTilesNow()
+void UTempoLidar::DeactivateAllTiles()
 {
-	// Drain all active tiles (releases their view states + PPMs) before re-configuring with new
-	// parameters. Caller must have confirmed no reads are in flight.
 	for (FTempoLidarTile& Tile : Tiles)
 	{
 		if (Tile.bActive)
@@ -152,6 +150,13 @@ void UTempoLidar::ReconfigureTilesNow()
 			DeactivateTile(Tile);
 		}
 	}
+}
+
+void UTempoLidar::ReconfigureTilesNow()
+{
+	// Drain all active tiles (releases their view states + PPMs) before re-configuring with new
+	// parameters. Caller must have confirmed no reads are in flight.
+	DeactivateAllTiles();
 
 	SyncTiles();
 	UpdateInternalMirrors();

--- a/TempoSensors/Source/TempoSensors/Private/TempoTiledSceneCaptureComponent.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoTiledSceneCaptureComponent.cpp
@@ -133,6 +133,15 @@ void UTempoTiledSceneCaptureComponent::Deactivate()
 	}
 }
 
+void UTempoTiledSceneCaptureComponent::OnUnregister()
+{
+	// Destroy tile view states while the scene is still valid, before Super unregisters us from it
+	// (matches USceneCaptureComponent::OnUnregister, which destroys the inherited ViewStates here).
+	DeactivateAllTiles();
+
+	Super::OnUnregister();
+}
+
 void UTempoTiledSceneCaptureComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
 {
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);

--- a/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
@@ -313,6 +313,7 @@ protected:
 	virtual bool HasDetectedParameterChange() const override;
 	virtual void ReconfigureTilesNow() override;
 	virtual void UpdateInternalMirrors() override;
+	virtual void DeactivateAllTiles() override;
 	// End UTempoTiledSceneCaptureComponent tile interface
 
 	// Returns SharedFinalTextureTarget so OnRenderCompleted reads from the merged output.

--- a/TempoSensors/Source/TempoSensors/Public/TempoLidar.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoLidar.h
@@ -257,6 +257,7 @@ protected:
 	virtual bool HasDetectedParameterChange() const override;
 	virtual void ReconfigureTilesNow() override;
 	virtual void UpdateInternalMirrors() override;
+	virtual void DeactivateAllTiles() override;
 	// End UTempoTiledSceneCaptureComponent tile interface
 
 	void ConfigureTile(FTempoLidarTile& Tile, double InYawOffset, double SubHorizontalFOV, int32 SubHorizontalBeams, bool bActivate);

--- a/TempoSensors/Source/TempoSensors/Public/TempoTiledSceneCaptureComponent.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoTiledSceneCaptureComponent.h
@@ -24,6 +24,11 @@ public:
 	virtual void BeginPlay() override;
 	virtual void Activate(bool bReset = false) override;
 	virtual void Deactivate() override;
+	// Release per-tile render resources (view states + PPMs) when the component unregisters from the
+	// scene. USceneCaptureComponent::OnUnregister only destroys the inherited ViewStates array; our
+	// per-tile FSceneViewStateReferences aren't in it, so without this they (and the render-thread
+	// history/MIDPool they hold) leak until GC, accumulating across PIE sessions.
+	virtual void OnUnregister() override;
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
 	virtual bool ShouldManageOwnReadback() const override { return false; }
@@ -60,6 +65,10 @@ protected:
 
 	// Subclasses sync the tile array to the current sensor configuration.
 	virtual void SyncTiles() PURE_VIRTUAL(UTempoTiledSceneCaptureComponent::SyncTiles, );
+
+	// Deactivate every active tile, releasing its view state and PPM. Called from OnUnregister and
+	// ReconfigureTilesNow (which need to drain tiles before teardown / re-sync).
+	virtual void DeactivateAllTiles() PURE_VIRTUAL(UTempoTiledSceneCaptureComponent::DeactivateAllTiles, );
 
 	// Returns true iff any watched property differs from its internal mirror.
 	virtual bool HasDetectedParameterChange() const PURE_VIRTUAL(UTempoTiledSceneCaptureComponent::HasDetectedParameterChange, return false;);


### PR DESCRIPTION
Now that TempoCamera and TempoLidar manage their own tiled view states, they need to explicitly release them in OnUnregister