### PR TITLE
Parameterize the base Unreal image via ENGINE_BASE_IMAGE build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 ARG UNREAL_VERSION=5.4.4
 
-FROM ghcr.io/epicgames/unreal-engine:dev-slim-${UNREAL_VERSION}
+# Base Unreal image. Defaults to Epic's ghcr.io distribution; override with
+# --build-arg ENGINE_BASE_IMAGE=... to build from a mirror (e.g. a private
+# registry or pull-through cache) without needing a ghcr.io login.
+ARG ENGINE_BASE_IMAGE=ghcr.io/epicgames/unreal-engine:dev-slim-${UNREAL_VERSION}
+FROM ${ENGINE_BASE_IMAGE}
 
 ENV UNREAL_ENGINE_PATH='/home/ue4/UnrealEngine'
 


### PR DESCRIPTION
The Dockerfile hardcodes `FROM ghcr.io/epicgames/unreal-engine:dev-slim-${UNREAL_VERSION}`, which requires a ghcr.io login at build time. Environments that mirror Epic's base image through a private registry or pull-through cache — to avoid distributing ghcr.io credentials to build agents — can't currently point the build at that mirror without editing the Dockerfile.

This adds an `ENGINE_BASE_IMAGE` build arg that defaults to the same ghcr.io reference, so existing builds are unaffected, while allowing `docker build --build-arg ENGINE_BASE_IMAGE=<mirror>/epicgames/unreal-engine:dev-slim-<ver> ...` to build from a mirror using whatever auth that registry already uses.

Backwards-compatible: with no `--build-arg`, the resolved base is byte-for-byte the previous `FROM`.
