### PR TITLE
Add release packaging and strengthen low-memory mode

### DIFF
--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficChooseNextLaneProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficChooseNextLaneProcessor.cpp
@@ -59,9 +59,7 @@ void UMassTrafficChooseNextLaneProcessor::ConfigureQueries(const TSharedRef<FMas
 	EntityQuery_Conditional.AddChunkRequirement<FMassSimulationVariableTickChunkFragment>(EMassFragmentAccess::ReadOnly);
 	EntityQuery_Conditional.SetChunkFilter(&FMassSimulationVariableTickChunkFragment::ShouldTickChunkThisFrame);
 	EntityQuery_Conditional.AddSubsystemRequirement<UMassTrafficSubsystem>(EMassFragmentAccess::ReadWrite);
-#if WITH_MASSTRAFFIC_DEBUG
 	EntityQuery_Conditional.AddSubsystemRequirement<UZoneGraphSubsystem>(EMassFragmentAccess::ReadOnly);
-#endif // WITH_MASSTRAFFIC_DEBUG
 }
 
 void UMassTrafficChooseNextLaneProcessor::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
@@ -79,9 +77,7 @@ void UMassTrafficChooseNextLaneProcessor::Execute(FMassEntityManager& EntityMana
 #endif
 	{	
 		UMassTrafficSubsystem& MassTrafficSubsystem = QueryContext.GetMutableSubsystemChecked<UMassTrafficSubsystem>();
-#if WITH_MASSTRAFFIC_DEBUG
 		const UZoneGraphSubsystem& ZoneGraphSubsystem = QueryContext.GetSubsystemChecked<UZoneGraphSubsystem>();
-#endif // WITH_MASSTRAFFIC_DEBUG
 		const int32 NumEntities = QueryContext.GetNumEntities();
 		const TConstArrayView<FMassZoneGraphLaneLocationFragment> LaneLocationFragments = QueryContext.GetFragmentView<FMassZoneGraphLaneLocationFragment>();
 		const TConstArrayView<FAgentRadiusFragment> AgentRadiusFragments = QueryContext.GetFragmentView<FAgentRadiusFragment>();

--- a/Scripts/Package.sh
+++ b/Scripts/Package.sh
@@ -7,12 +7,18 @@ PROJECT_ROOT=$("$SCRIPT_DIR"/FindProjectRoot.sh)
 cd "$PROJECT_ROOT"
 PROJECT_NAME=$(find . -maxdepth 1 -name "*.uproject" -exec basename {} .uproject \;)
 
-# Check for low memory mode flag
+# Check for project packaging flags.
 LOW_MEMORY_MODE=false
+BUILD_CONFIGURATION=Development
 for arg in "$@"; do
-  if [[ "$arg" == "--low-memory" ]]; then
-    LOW_MEMORY_MODE=true
-  fi
+  case "$arg" in
+    --low-memory)
+      LOW_MEMORY_MODE=true
+      ;;
+    --release)
+      BUILD_CONFIGURATION=Shipping
+      ;;
+  esac
 done
 
 export UNREAL_ENGINE_PATH=$("$SCRIPT_DIR"/FindUnreal.sh)
@@ -83,7 +89,9 @@ fi
 cd "$UNREAL_ENGINE_PATH"
 
 # Build the base command with common arguments
-PACKAGE_COMMAND="Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIfNeeded -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" BuildCookRun -nop4 -utf8output -nocompileeditor -skipbuildeditor -cook -target=\"$PROJECT_NAME\" -platform=$TARGET_PLATFORM -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" -installed -stage -package -pak -build -prereqs -clientconfig=Development"
+PACKAGE_COMMAND="Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIfNeeded -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" BuildCookRun -nop4 -utf8output -nocompileeditor -skipbuildeditor -cook -target=\"$PROJECT_NAME\" -platform=$TARGET_PLATFORM -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" -installed -stage -package -pak -build -prereqs -clientconfig=$BUILD_CONFIGURATION"
+
+echo "Packaging $PROJECT_NAME in $BUILD_CONFIGURATION configuration -> $PROJECT_ROOT/Packaged"
 
 # Add platform-specific parts
 if [ "$HOST_PLATFORM" = "Win64" ]; then
@@ -104,16 +112,25 @@ fi
 
 # Add low memory options if requested
 if [ "$LOW_MEMORY_MODE" = "true" ]; then
-  PACKAGE_COMMAND="$PACKAGE_COMMAND -CookPartialGC -NoXGE -AdditionalCookerOptions=\"-cookprocesscount=1\""
-  echo "Low memory mode enabled: single cook process, partial GC, no XGE"
+  # The cooker and C++ build have independent concurrency controls. A single
+  # cook process alone does not prevent UBT/UBA from scheduling enough compiler
+  # actions to exhaust available memory on lower-memory machines. Three local
+  # actions leave headroom for UAT, the linker, and the cook commandlet while
+  # retaining useful parallelism.
+  PACKAGE_COMMAND="$PACKAGE_COMMAND -CookPartialGC -NoXGE -UbtArgs=\"-MaxParallelActions=3 -NoUBA -NoXGE\" -AdditionalCookerOptions=\"-cookprocesscount=1\""
+  echo "Low memory mode enabled: at most 3 compile actions, single cook process, partial GC, no UBA/XGE"
 fi
 
 # Filter out our custom flags before passing to UAT
 PASSTHROUGH_ARGS=()
 for arg in "$@"; do
-  if [[ "$arg" != "--low-memory" ]]; then
-    PASSTHROUGH_ARGS+=("$arg")
-  fi
+  case "$arg" in
+    --low-memory|--release)
+      ;;
+    *)
+      PASSTHROUGH_ARGS+=("$arg")
+      ;;
+  esac
 done
 
 # Execute the command with any additional arguments

--- a/TempoAgents/Source/TempoAgents/Public/TempoBrightnessTranslator.h
+++ b/TempoAgents/Source/TempoAgents/Public/TempoBrightnessTranslator.h
@@ -5,6 +5,7 @@
 #include "TempoBrightnessMeterComponent.h"
 
 #include "MassCommonFragments.h"
+#include "MassEntityQuery.h"
 #include "MassTranslator.h"
 
 #include "TempoBrightnessTranslator.generated.h"

--- a/TempoAgents/Source/TempoAgents/Public/TempoMassAgentSyncTraits.h
+++ b/TempoAgents/Source/TempoAgents/Public/TempoMassAgentSyncTraits.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "MassAgentTraits.h"
 #include "MassCommonFragments.h"
+#include "MassEntityQuery.h"
 #include "MassEntityTraitBase.h"
 
 #include "TempoMassAgentSyncTraits.generated.h"


### PR DESCRIPTION
Allow opt-in Shipping packages, extend the existing --low-memory flag to cap UBT concurrency and disable UBA, and fix Release-only Mass compilation issues exposed by the package gate.