### PR TITLE
Fix a Few Bugs in TempoPlayerController and ActionMap

### DIFF
--- a/TempoCore/Source/TempoCore/Private/TempoActionMapEntryWidget.cpp
+++ b/TempoCore/Source/TempoCore/Private/TempoActionMapEntryWidget.cpp
@@ -25,9 +25,15 @@ void UTempoActionMapEntryWidget::Setup(UTempoActionMapWidget* InParent, const FA
 		RebindButton->OnClicked.AddDynamic(this, &UTempoActionMapEntryWidget::OnRebindButtonClicked);
 	}
 
-	// Bindings with modifier keys can't be re-captured by a single keypress, so
-	// disable the whole row (Slate will render it dimmed and ignore input).
-	SetIsEnabled(!BindingInfo.bHasModifiers);
+	if (RebindButton)
+	{
+		// Bindings with modifier keys can't be re-captured by a single keypress. Only the button is
+		// disabled (rendered dimmed by Slate, and ignoring clicks): the action name and its key are
+		// still worth reading, so dimming the whole row would hide information rather than a
+		// disabled control.
+		RebindButton->SetIsEnabled(!BindingInfo.bHasModifiers);
+		RebindButton->SetToolTipText(BindingInfo.bHasModifiers ? NonRebindableToolTip : RebindableToolTip);
+	}
 }
 
 void UTempoActionMapEntryWidget::OnRebindButtonClicked()

--- a/TempoCore/Source/TempoCore/Private/TempoActionMapWidget.cpp
+++ b/TempoCore/Source/TempoCore/Private/TempoActionMapWidget.cpp
@@ -12,6 +12,26 @@
 #include "GameFramework/PlayerController.h"
 #include "Kismet/GameplayStatics.h"
 
+namespace
+{
+	/**
+	 * Index of the first keyboard/mouse mapping, or INDEX_NONE if the action is gamepad-only.
+	 *
+	 * This widget is a keyboard rebinding UI — a rebind is driven by a key press captured in
+	 * NativeOnKeyDown — so gamepad mappings are skipped throughout. Taking the first mapping
+	 * regardless of device would let a gamepad mapping hide the keyboard key of an action bound on
+	 * both (the display order follows the input settings, not the device), and a subsequent rebind
+	 * would then silently replace the gamepad mapping instead of the key the user is looking at.
+	 */
+	int32 FindKeyboardMappingIndex(const TArray<FInputActionKeyMapping>& Mappings)
+	{
+		return Mappings.IndexOfByPredicate([](const FInputActionKeyMapping& Mapping)
+		{
+			return !Mapping.Key.IsGamepadKey();
+		});
+	}
+}
+
 void UTempoActionMapWidget::NativeOnInitialized()
 {
 	Super::NativeOnInitialized();
@@ -70,7 +90,8 @@ TArray<FActionBindingInfo> UTempoActionMapWidget::GetPlayerActionBindings()
 		TArray<FInputActionKeyMapping> Mappings;
 		InputSettings->GetActionMappingByName(ActionName, Mappings);
 
-		if (Mappings.Num() > 0)
+		const int32 KeyboardMappingIndex = FindKeyboardMappingIndex(Mappings);
+		if (KeyboardMappingIndex != INDEX_NONE)
 		{
 			FActionBindingInfo Info;
 			Info.ActionName = ActionName;
@@ -87,7 +108,7 @@ TArray<FActionBindingInfo> UTempoActionMapWidget::GetPlayerActionBindings()
 			}
 			Info.ActionDisplayName = DisplayNameString;
 
-			const FInputActionKeyMapping& Mapping = Mappings[0];
+			const FInputActionKeyMapping& Mapping = Mappings[KeyboardMappingIndex];
 			Info.Key = Mapping.Key;
 			Info.bHasModifiers = Mapping.bCtrl || Mapping.bAlt || Mapping.bShift || Mapping.bCmd;
 
@@ -149,6 +170,14 @@ FReply UTempoActionMapWidget::NativeOnKeyDown(const FGeometry& InGeometry, const
 
 	const FKey PressedKey = InKeyEvent.GetKey();
 
+	// Gamepad buttons reach focused widgets as key events too, but binding one here would replace a
+	// keyboard mapping with a key this widget then refuses to list. Stay in the listening state so
+	// the user can still press a key (or Escape).
+	if (PressedKey.IsGamepadKey())
+	{
+		return FReply::Handled();
+	}
+
 	if (PressedKey == EKeys::Escape)
 	{
 		bIsListeningForKey = false;
@@ -169,11 +198,14 @@ void UTempoActionMapWidget::RebindActionKey(FName ActionName, FKey NewKey)
 	TArray<FInputActionKeyMapping> Mappings;
 	InputSettings->GetActionMappingByName(ActionName, Mappings);
 
-	if (Mappings.Num() > 0)
+	// Rebind the mapping the row actually displayed, leaving any gamepad mapping of the same action
+	// in place.
+	const int32 KeyboardMappingIndex = FindKeyboardMappingIndex(Mappings);
+	if (KeyboardMappingIndex != INDEX_NONE)
 	{
 		// Remove the old mapping, update it with the new key, and add it back.
-		FInputActionKeyMapping UpdatedMapping = Mappings[0];
-		InputSettings->RemoveActionMapping(Mappings[0]);
+		FInputActionKeyMapping UpdatedMapping = Mappings[KeyboardMappingIndex];
+		InputSettings->RemoveActionMapping(UpdatedMapping);
 		UpdatedMapping.Key = NewKey;
 		InputSettings->AddActionMapping(UpdatedMapping, true);
 		InputSettings->SaveKeyMappings();

--- a/TempoCore/Source/TempoCore/Private/TempoPlayerController.cpp
+++ b/TempoCore/Source/TempoCore/Private/TempoPlayerController.cpp
@@ -80,20 +80,6 @@ void ATempoPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason)
 
 void ATempoPlayerController::OnPossess(APawn* InPawn)
 {
-	APawn* PreviousPawn = PendingPreviousPawn.Get();
-	PendingPreviousPawn = nullptr;
-
-	// Restore AI controller if necessary.
-	if (PreviousPawn && AIControllerMap.Contains(PreviousPawn))
-	{
-		AController* OriginalController = AIControllerMap[PreviousPawn];
-		if (OriginalController)
-		{
-			OriginalController->Possess(PreviousPawn);
-		}
-		AIControllerMap.Remove(PreviousPawn);
-	}
-
 	// Set spectator position if needed.
 	if (ATempoGameMode* GameMode = Cast<ATempoGameMode>(UGameplayStatics::GetGameMode(this)))
 	{
@@ -106,7 +92,24 @@ void ATempoPlayerController::OnPossess(APawn* InPawn)
 		}
 	}
 
+	// Super::OnPossess() is what unpossesses the outgoing pawn, so PendingPreviousPawn (set by
+	// OnUnPossess) is only valid after it returns.
 	Super::OnPossess(InPawn);
+
+	APawn* PreviousPawn = PendingPreviousPawn.Get();
+	PendingPreviousPawn = nullptr;
+
+	// Restore the outgoing pawn's AI controller if necessary. Skipped when we just re-possessed the
+	// same pawn, which would otherwise hand it straight back to the AI.
+	if (PreviousPawn && PreviousPawn != InPawn && AIControllerMap.Contains(PreviousPawn))
+	{
+		AController* OriginalController = AIControllerMap[PreviousPawn];
+		if (OriginalController)
+		{
+			OriginalController->Possess(PreviousPawn);
+		}
+		AIControllerMap.Remove(PreviousPawn);
+	}
 
 	if (InPawn)
 	{
@@ -505,8 +508,13 @@ void ATempoPlayerController::PossessNextPawn()
 		if (ActivePawnArray.IsValidIndex(CurrentIndex))
 		{
 			APawn* PawnToPossess = ActivePawnArray[CurrentIndex];
-			CacheAIController(PawnToPossess);
-			Possess(PawnToPossess);
+			// Re-possessing the pawn we already control would pointlessly tear down and rebuild the
+			// view (the camera snaps back to the pawn's default framing).
+			if (PawnToPossess != GetPawn())
+			{
+				CacheAIController(PawnToPossess);
+				Possess(PawnToPossess);
+			}
 		}
 	}
 }
@@ -535,8 +543,11 @@ void ATempoPlayerController::PossessPreviousPawn()
 		if (ActivePawnArray.IsValidIndex(CurrentIndex))
 		{
 			APawn* PawnToPossess = ActivePawnArray[CurrentIndex];
-			CacheAIController(PawnToPossess);
-			Possess(PawnToPossess);
+			if (PawnToPossess != GetPawn())
+			{
+				CacheAIController(PawnToPossess);
+				Possess(PawnToPossess);
+			}
 		}
 	}
 }
@@ -603,27 +614,17 @@ UClass* ATempoPlayerController::GetCorrectGroupForPawn(const APawn* InPawn) cons
 		return nullptr;
 	}
 
-	TArray<TSubclassOf<APawn>> AllGroupClasses;
-	AllGroupClasses.Add(ACharacter::StaticClass());
-	AllGroupClasses.Add(AWheeledVehiclePawn::StaticClass());
-	AllGroupClasses.Append(ConfiguredPawnGroupClasses);
-	TSet<TSubclassOf<APawn>> UniqueClasses(AllGroupClasses);
-	AllGroupClasses = UniqueClasses.Array();
-
-	AllGroupClasses.Sort([](const TSubclassOf<APawn>& A, const TSubclassOf<APawn>& B) {
-		if (!A || !B) return false;
-		if (A->IsChildOf(B)) return true;
-		if (B->IsChildOf(A)) return false;
-		return A->GetName() < B->GetName();
-	});
-
-	// Find the first matching group.
-	for (TSubclassOf<APawn> GroupClass : AllGroupClasses)
+	// Report the group the pawn was actually placed in by UpdatePawnGroups. Re-deriving it from a
+	// class list here instead would disagree with the real grouping whenever the two lists differ
+	// (e.g. a Character when ConfiguredPawnGroupClasses has no Character group, which lands the pawn
+	// in the fallback group), and OnPossess would then leave ActiveGroupIndex/PawnGroupIndices
+	// pointing at the group and index of some other pawn.
+	for (const auto& Pair : PawnGroups)
 	{
-		if (InPawn->IsA(GroupClass))
+		if (Pair.Value.Pawns.Contains(InPawn))
 		{
-			return GroupClass;
+			return Pair.Key;
 		}
 	}
-	return FallbackGroupClass;
+	return nullptr;
 }

--- a/TempoCore/Source/TempoCore/Public/TempoActionMapEntryWidget.h
+++ b/TempoCore/Source/TempoCore/Public/TempoActionMapEntryWidget.h
@@ -37,6 +37,15 @@ public:
 	UPROPERTY(meta = (BindWidget))
 	UButton* RebindButton;
 
+protected:
+	/** Hover text on the rebind button for a binding that can be rebound. */
+	UPROPERTY(EditDefaultsOnly, Category = "Input")
+	FText RebindableToolTip = NSLOCTEXT("TempoActionMap", "RebindableToolTip", "Left click and press the key you want to rebind");
+
+	/** Hover text on the rebind button for a binding this widget can't capture (see bHasModifiers). */
+	UPROPERTY(EditDefaultsOnly, Category = "Input")
+	FText NonRebindableToolTip = NSLOCTEXT("TempoActionMap", "NonRebindableToolTip", "This binding uses a modifier key and can't be rebound here. Change it in Project Settings > Engine > Input.");
+
 private:
 	UFUNCTION()
 	void OnRebindButtonClicked();

--- a/TempoCore/Source/TempoCore/Public/TempoActionMapWidget.h
+++ b/TempoCore/Source/TempoCore/Public/TempoActionMapWidget.h
@@ -33,6 +33,13 @@ struct FActionBindingInfo
 	bool bHasModifiers = false;
 };
 
+/**
+ * Lists the player's action bindings and rebinds one to whatever key the user presses next.
+ *
+ * Keyboard and mouse only: gamepad mappings are never listed, gamepad-only actions are omitted
+ * entirely, and gamepad presses are ignored while listening for a new key. An action bound on both
+ * devices therefore shows — and rebinds — its keyboard key, leaving its gamepad key untouched.
+ */
 UCLASS()
 class TEMPOCORE_API UTempoActionMapWidget : public UUserWidget
 {

--- a/TempoCore/Source/TempoCore/Public/TempoPlayerController.h
+++ b/TempoCore/Source/TempoCore/Public/TempoPlayerController.h
@@ -135,7 +135,8 @@ protected:
 	TMap<APawn*, AController*> AIControllerMap;
 
 	// Captured in OnUnPossess (where GetPawn() still returns the outgoing pawn) so OnPossess can see
-	// the actual previous pawn — by the time OnPossess runs, SetPawn(InPawn) has already happened.
+	// the actual previous pawn. Only valid after OnPossess calls Super::OnPossess(), which is what
+	// unpossesses the outgoing pawn in the first place.
 	UPROPERTY()
 	TWeakObjectPtr<APawn> PendingPreviousPawn;
 


### PR DESCRIPTION
- Hide gamepad keys in TempoActionMap (only show keyboard)
- Grey out only the rebind button (not the whole row) for keyboard buttons with modifier keys
- Fix a bug in TempoPlayerController that could cause it to lose track of the next posses-able pawn