### PR TITLE
Fix Potential Oscillations in Ground Snap Component

### DIFF
--- a/TempoMovement/Source/TempoMovement/Private/GroundSnapComponent.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/GroundSnapComponent.cpp
@@ -8,7 +8,6 @@
 #include "TempoCoreUtils.h"
 
 #include "DrawDebugHelpers.h"
-#include "Kismet/KismetMathLibrary.h"
 
 UGroundSnapComponent::UGroundSnapComponent()
 {
@@ -20,10 +19,16 @@ UGroundSnapComponent::UGroundSnapComponent()
 	bTickInEditor = true;
 }
 
-FRotator RotationFromNormal(const FVector& Normal, const FRotator& StartRotation)
+void UGroundSnapComponent::BeginPlay()
 {
-	const FVector PitchAxis = StartRotation.RotateVector(FVector::RightVector);
-	return UKismetMathLibrary::MakeRotFromXZ(FQuat(PitchAxis, UE_PI / 2.0).RotateVector(Normal), Normal);
+	Super::BeginPlay();
+
+	check(GetOwner());
+
+	if (!bOverrideOwnerExtents && bCacheOwnerExtents)
+	{
+		CachedExtents = FVector2D(UTempoCoreUtils::GetActorLocalBounds(GetOwner(), bIncludeHiddenComponentsInExtents).GetExtent());
+	}
 }
 
 void UGroundSnapComponent::TickComponent(float DeltaTime, ELevelTick TickType,
@@ -38,28 +43,33 @@ void UGroundSnapComponent::TickComponent(float DeltaTime, ELevelTick TickType,
 	const bool bIsGameWorld = UTempoCoreUtils::IsGameWorld(this);
 
 	// Both of these are in unscaled owner-local space, matching what GetActorLocalBounds returns.
-	const FVector2D Extents = bOverrideOwnerExtents ? ExtentsOverride : FVector2D(UTempoCoreUtils::GetActorLocalBounds(GetOwner(), bIncludeHiddenComponentsInExtents).GetExtent());
+	const FVector2D Extents = bOverrideOwnerExtents ? ExtentsOverride :
+		bCacheOwnerExtents && CachedExtents.IsSet() ? CachedExtents.GetValue() :
+		FVector2D(UTempoCoreUtils::GetActorLocalBounds(GetOwner(), bIncludeHiddenComponentsInExtents).GetExtent());
 	const FVector2D Center = bOverrideOwnerExtents ? ExtentsCenter : FVector2D::ZeroVector;
 
 	// GetActorLocalBounds divides out the owner's transform, so we have to apply the owner's scale ourselves.
 	// The extents take the magnitude only: a negative scale would mirror our four corners into the opposite
-	// winding order, which flips every normal we compute below. The center is a point, so it keeps the sign.
+	// winding order. The center is a point, so it keeps the sign.
 	const FVector OwnerScale = GetOwner()->GetActorScale();
-	const FVector2D ExtentsScale = FVector2D(FMath::Abs(OwnerScale.X), FMath::Abs(OwnerScale.Y));
-	const FVector2D CenterScale = FVector2D(OwnerScale.X, OwnerScale.Y);
+	const FVector2D ScaledExtents = Extents * FVector2D(FMath::Abs(OwnerScale.X), FMath::Abs(OwnerScale.Y));
+	const FVector2D ScaledCenter = Center * FVector2D(OwnerScale.X, OwnerScale.Y);
 
-	const FRotator OwnerRotation = GetOwner()->GetActorRotation();
 	const FVector OwnerLocation = GetOwner()->GetActorLocation();
-	const FCollisionQueryParams Params(TEXT("GroundSnap"), false, GetOwner());
 
-	// The corners we trace from, in world space at the owner's origin height. Consecutive corners are
-	// adjacent, which both the debug rectangle and the per-corner normals below rely on.
-	TArray<FVector> TraceCorners;
-	const TArray<FVector2D> Offsets = { FVector2D(1, 1), FVector2D(1, -1), FVector2D(-1, -1), FVector2D(-1, 1) };
-	for (const FVector2D& Offset : Offsets)
+	// Yaw only. The corners must not depend on the pitch and roll we write at the end of this function: if
+	// they did, the footprint we sample would be a function of our own last answer, and anywhere the ground
+	// is not locally planar the two would chase each other frame to frame instead of settling.
+	const FRotator OwnerYaw(0.0, GetOwner()->GetActorRotation().Yaw, 0.0);
+
+	// Where we trace from, as XY offsets from the owner's origin. Consecutive corners are adjacent, which the
+	// debug rectangle relies on. Keeping them as offsets rather than world points also keeps the plane fit
+	// below in small numbers, however far from the world origin the owner is.
+	TArray<FVector2D> CornerOffsets;
+	const TArray<FVector2D> CornerSigns = { FVector2D(1, 1), FVector2D(1, -1), FVector2D(-1, -1), FVector2D(-1, 1) };
+	for (const FVector2D& CornerSign : CornerSigns)
 	{
-		const FVector2D LocalOffset = Center * CenterScale + Offset * Extents * ExtentsScale;
-		TraceCorners.Add(OwnerLocation + OwnerRotation.RotateVector(FVector(LocalOffset, 0.0)));
+		CornerOffsets.Add(FVector2D(OwnerYaw.RotateVector(FVector(ScaledCenter + CornerSign * ScaledExtents, 0.0))));
 	}
 
 #if WITH_EDITOR
@@ -67,10 +77,11 @@ void UGroundSnapComponent::TickComponent(float DeltaTime, ELevelTick TickType,
 	// preview viewports only: during play we are snapping, and a rectangle stuck to the owner says nothing.
 	if (bDrawDebug && !bIsGameWorld)
 	{
-		for (int32 I = 0; I < TraceCorners.Num(); ++I)
+		for (int32 I = 0; I < CornerOffsets.Num(); ++I)
 		{
-			const int32 J = I == TraceCorners.Num() - 1 ? 0 : I + 1;
-			DrawDebugLine(GetWorld(), TraceCorners[I], TraceCorners[J], FColor::Red, false, -1, 0, 3.0);
+			const int32 J = I == CornerOffsets.Num() - 1 ? 0 : I + 1;
+			DrawDebugLine(GetWorld(), OwnerLocation + FVector(CornerOffsets[I], 0.0),
+				OwnerLocation + FVector(CornerOffsets[J], 0.0), FColor::Red, false, -1, 0, 3.0);
 		}
 	}
 #endif
@@ -81,9 +92,12 @@ void UGroundSnapComponent::TickComponent(float DeltaTime, ELevelTick TickType,
 		return;
 	}
 
+	const FCollisionQueryParams Params(TEXT("GroundSnap"), false, GetOwner());
+
 	TArray<FHitResult> GroundHits;
-	for (const FVector& TraceCorner : TraceCorners)
+	for (const FVector2D& CornerOffset : CornerOffsets)
 	{
+		const FVector TraceCorner = OwnerLocation + FVector(CornerOffset, 0.0);
 		FHitResult GroundHit;
 		const FVector Start = TraceCorner + SearchDistance * FVector::UpVector;
 		const FVector End = TraceCorner - SearchDistance * FVector::UpVector;
@@ -96,81 +110,81 @@ void UGroundSnapComponent::TickComponent(float DeltaTime, ELevelTick TickType,
 		GroundHits.Add(GroundHit);
 	}
 
-	ensure(GroundHits.Num() == 4);
-
-	// Compute the normals from every combination of three ground hits, by looking to the left and right of each corner.
-	TArray<FVector> AllNormals;
-	TArray<FVector> AllPoints;
-	for (int32 I = 0; I < 4; ++I)
+	// Moments of the ground hits, in XY relative to the owner's origin and Z relative to its height, for the
+	// least squares fit of the plane Z = A * X + B * Y + C below. Fitting every corner at once, with none of
+	// them judged on its own, is what makes this hold up on rough ground: the plane is the orientation of the
+	// footprint as a whole, and detail smaller than the footprint averages out of it rather than steering it.
+	double Sxx = 0.0, Sxy = 0.0, Syy = 0.0, Sx = 0.0, Sy = 0.0, Sxz = 0.0, Syz = 0.0, Sz = 0.0;
+	for (int32 I = 0; I < GroundHits.Num(); ++I)
 	{
-		int32 J = I == 3 ? 0 : I + 1; // (I + 1) % 4
-		int32 K = I == 0 ? 3 : I - 1; // (I - 1) % 4
-		const FVector& GroundHitI = GroundHits[I].Location;
-		const FVector& GroundHitJ = GroundHits[J].Location;
-		const FVector& GroundHitK = GroundHits[K].Location;
-		const FVector IJ = GroundHitJ - GroundHitI;
-		const FVector IK = GroundHitK - GroundHitI;
-		AllNormals.Add(FVector::CrossProduct(IK, IJ).GetSafeNormal());
-		AllPoints.Add(GroundHitI);
+		const double X = CornerOffsets[I].X;
+		const double Y = CornerOffsets[I].Y;
+		const double Z = GroundHits[I].Location.Z - OwnerLocation.Z;
+
+		Sxx += X * X;
+		Sxy += X * Y;
+		Syy += Y * Y;
+		Sx += X;
+		Sy += Y;
+		Sxz += X * Z;
+		Syz += Y * Z;
+		Sz += Z;
+	}
+	const double NumHits = GroundHits.Num();
+
+	// Bias the fit gently toward flat. Without this the normal equations are singular whenever the corners do
+	// not span both axes - a footprint with no extent in one of them - and ill conditioned just before that,
+	// where a plane can be fit but says more about the last bits of the corner heights than about the ground.
+	// Degrading smoothly toward flat beats falling off a cliff at whatever conditioning threshold we picked,
+	// and at any usable footprint size the bias is far below anything measurable.
+	constexpr double RegularizationFactor = 1.0e-3;
+	const double Regularization = NumHits * FMath::Max(RegularizationFactor * ScaledExtents.SizeSquared(), UE_DOUBLE_SMALL_NUMBER);
+
+	// Solve the symmetric normal equations by Cramer's rule. The regularization above makes them positive
+	// definite, so the determinant is never zero.
+	const double M00 = Sxx + Regularization, M01 = Sxy, M02 = Sx;
+	const double M11 = Syy + Regularization, M12 = Sy, M22 = NumHits;
+	const double Adj00 = M11 * M22 - M12 * M12;
+	const double Adj01 = M02 * M12 - M01 * M22;
+	const double Adj02 = M01 * M12 - M02 * M11;
+	const double Adj11 = M00 * M22 - M02 * M02;
+	const double Adj12 = M01 * M02 - M00 * M12;
+	const double Adj22 = M00 * M11 - M01 * M01;
+	const double Det = M00 * Adj00 + M01 * Adj01 + M02 * Adj02;
+
+	const double A = (Adj00 * Sxz + Adj01 * Syz + Adj02 * Sz) / Det;
+	const double B = (Adj01 * Sxz + Adj11 * Syz + Adj12 * Sz) / Det;
+	const double C = (Adj02 * Sxz + Adj12 * Syz + Adj22 * Sz) / Det;
+
+	// The plane was fit about the owner's origin, so C is the ground height there and (-A, -B, 1) is its
+	// normal, both without any further evaluation.
+	FVector Normal = FVector(-A, -B, 1.0).GetSafeNormal();
+
+	// Cap how far the ground may tilt the owner. The cap is on the fitted plane rather than on any one corner
+	// because a corner can only be judged alone by the surface normal underneath it, and on rough ground that
+	// normal describes whichever facet the trace happened to land on rather than the ground the owner stands
+	// on - and steps every time the trace crosses from one triangle to the next.
+	const FVector TiltAxis = FVector::CrossProduct(FVector::UpVector, Normal);
+	const double MaxSlopeRad = QuantityConverter<Deg2Rad>::Convert(static_cast<double>(MaxSlopeAngle));
+	if (bLimitSlopeAngle && !TiltAxis.IsNearlyZero() && FMath::Acos(FMath::Clamp(Normal.Z, -1.0, 1.0)) > MaxSlopeRad)
+	{
+		// Only the amount of tilt is capped, never the direction, so this stays continuous as the fit crosses
+		// the limit: right at the limit it leaves the normal exactly where the fit put it.
+		Normal = FQuat(TiltAxis.GetUnsafeNormal(), MaxSlopeRad).RotateVector(FVector::UpVector);
 	}
 
-	ensure(AllNormals.Num() == 4);
-	ensure(AllPoints.Num() == 4);
-
-	// Reject any normals that are too steep
-	TArray<FVector> Normals;
-	TArray<FVector> Points;
-	for (int32 I = 0; I < 4; ++I)
-	{
-		if (bLimitSlopeAngle && FVector::DotProduct(AllNormals[I], FVector::UpVector) < FMath::Cos(QuantityConverter<Deg2Rad>::Convert(MaxSlopeAngle)))
-		{
-			// This normal is too steep.
-			continue;
-		}
-		Normals.Add(AllNormals[I]);
-		Points.Add(AllPoints[I]);
-	}
-
-	// Normals and Points are appended together above, so they always describe the same surviving corners.
-	ensure(Normals.Num() == Points.Num());
-
-	FRotator NewRotation = GetOwner()->GetActorRotation();
-	FVector NewLocation = GetOwner()->GetActorLocation();
-
-	const double AvgDenominator = Normals.Num();
-	if (AvgDenominator > 0.0)
-	{
-		FVector NormalAvgNumerator = FVector::ZeroVector;
-		for (const FVector& Normal : Normals)
-		{
-			NormalAvgNumerator += Normal;
-		}
-		const FVector NewNormal = NormalAvgNumerator / AvgDenominator;
-		NewRotation = RotationFromNormal(NewNormal, GetOwner()->GetActorRotation());
-
-		FVector PointAvgNumerator = FVector::ZeroVector;
-		for (const FVector& Point : Points)
-		{
-			PointAvgNumerator += Point;
-		}
-		const FVector PlanePoint = PointAvgNumerator / AvgDenominator;
-
-		// The owner's origin is assumed to sit on the ground, so rather than take the average corner height
-		// we fit the plane (PlanePoint, NewNormal) to the surviving corners and evaluate it at the origin's
-		// XY. The two agree whenever the surviving corners are symmetric about the origin, and diverge on a
-		// slope when they are not: a non-zero ExtentsCenter, or a corner dropped by the slope limit.
-		const FVector2D OriginFromPlanePoint = FVector2D(NewLocation - PlanePoint);
-		if (FMath::Abs(NewNormal.Z) > UE_KINDA_SMALL_NUMBER)
-		{
-			NewLocation.Z = PlanePoint.Z - FVector2D::DotProduct(FVector2D(NewNormal), OriginFromPlanePoint) / NewNormal.Z;
-		}
-		else
-		{
-			// The fit is near-vertical, so it tells us nothing about the height at the origin. Only reachable
-			// with bLimitSlopeAngle off, which otherwise keeps NewNormal.Z at or above cos(MaxSlopeAngle).
-			NewLocation.Z = PlanePoint.Z;
-		}
-	}
+	// Solve for the pitch and roll that put the owner's up axis on that normal, and leave its yaw exactly as we
+	// found it. Rotated into the owner's yaw frame, the normal is the up axis of FRotator(Pitch, 0, Roll),
+	// which is (-cos(Roll) * sin(Pitch), sin(Roll), cos(Roll) * cos(Pitch)), so the two angles read straight
+	// off it. Deriving the yaw from the normal instead - orthogonalizing a forward vector against it, say -
+	// would feed a slope-dependent yaw back in every frame, and an owner standing still on a slope would creep
+	// around toward its contour line.
+	const FVector NormalInYawFrame = FRotator(0.0, -OwnerYaw.Yaw, 0.0).RotateVector(Normal);
+	const FRotator NewRotation = FRotator(
+		QuantityConverter<Rad2Deg>::Convert(FMath::Atan2(-NormalInYawFrame.X, NormalInYawFrame.Z)),
+		OwnerYaw.Yaw,
+		QuantityConverter<Rad2Deg>::Convert(FMath::Asin(FMath::Clamp(NormalInYawFrame.Y, -1.0, 1.0))));
+	const FVector NewLocation = FVector(OwnerLocation.X, OwnerLocation.Y, OwnerLocation.Z + C);
 
 	GetOwner()->SetActorTransform(FTransform(NewRotation, NewLocation, GetOwner()->GetActorScale()));
 }

--- a/TempoMovement/Source/TempoMovement/Public/GroundSnapComponent.h
+++ b/TempoMovement/Source/TempoMovement/Public/GroundSnapComponent.h
@@ -14,6 +14,8 @@ class TEMPOMOVEMENT_API UGroundSnapComponent : public UActorComponent
 public:
 	UGroundSnapComponent();
 
+	virtual void BeginPlay() override;
+
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType,
 							   FActorComponentTickFunction* ThisTickFunction) override;
 
@@ -23,8 +25,8 @@ protected:
 	bool bOverrideOwnerExtents = false;
 
 	// We will trace rays from the four corners indicated either by these extents or the owner's extents, and
-	// determine the snapped location and rotation from the average of what we find. These are unscaled
-	// owner-local extents, like the owner's own extents, so the owner's scale is applied on top of them.
+	// fit the ground plane to what we find. These are unscaled owner-local extents, like the owner's own
+	// extents, so the owner's scale is applied on top of them.
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta=(EditCondition=bOverrideOwnerExtents))
 	FVector2D ExtentsOverride = FVector2D(100.0, 100.0);
 
@@ -38,21 +40,34 @@ protected:
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
 	float SearchDistance = 1000000.0; // 10km
 
-	// If true, we will reject normals from surfaces steeper than MaxSlopeAngle.
+	// If true, we will not tilt the owner further than MaxSlopeAngle to match the ground.
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
 	bool bLimitSlopeAngle = true;
 
-	// The surface angle, in degrees, above which we will reject normals.
-	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta=(UIMin=0.0, UIMax=60.0, ClampMin=0.0, ClampMax=60.0, EditCondition=bLimitSnapAngle))
+	// The angle, in degrees, past which we stop tilting the owner to match the ground. This limits the fitted
+	// ground plane as a whole: the plane is fit to all four corners at once, and no corner is judged alone.
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta=(UIMin=0.0, UIMax=60.0, ClampMin=0.0, ClampMax=60.0, EditCondition=bLimitSlopeAngle))
 	float MaxSlopeAngle = 45.0;
 
 	// If true, we will include hidden components in our extents calculation.
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta=(EditCondition="!bOverrideOwnerExtents"))
 	bool bIncludeHiddenComponentsInExtents = false;
 
+	// If true, we will measure the owner's extents once at BeginPlay and reuse them. The owner's local bounds
+	// come from its physics bodies in their current pose, so for an animated owner they change every frame,
+	// which would move the points we trace from for reasons that have nothing to do with the ground. Turn this
+	// off only if the owner's footprint genuinely changes during play. Only used when bOverrideOwnerExtents
+	// is false: an editor tick always measures the owner as it stands, so live edits are reflected there.
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta=(EditCondition="!bOverrideOwnerExtents"))
+	bool bCacheOwnerExtents = true;
+
 	// If true, we will draw the rectangle we trace the four corners from, at the owner's origin height.
 	// Editor only: it draws in the level editor and Blueprint preview viewports, is never drawn during play
 	// (including Play In Editor), and is compiled out of a packaged game entirely.
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, AdvancedDisplay)
 	bool bDrawDebug = false;
+
+private:
+	// Unscaled owner-local extents, set at BeginPlay when bCacheOwnerExtents is true. Never set in the editor.
+	TOptional<FVector2D> CachedExtents;
 };


### PR DESCRIPTION
Fixes a rapid oscillation between two orientations on non-planar ground. The snap was feeding its own output back into its next input in three places, each cut here.

**Trace corners use yaw only.** They were rotated by the owner's full rotation, so last frame's snapped pitch and roll moved the points we sample this frame. Wherever the ground was not locally planar, the footprint and the fit chased each other frame to frame.

**Yaw is preserved exactly.** The rotation came from `MakeRotFromXZ` on a forward vector built from the ground normal, which makes yaw a function of the slope. Only pitch and roll are solved from the normal now; yaw is copied through untouched. Iterating the old map on a 30° slope drifted ~8°/frame toward the slope's contour line.

**The slope limit is a cap, not a gate.** Four triplet normals were computed and any steeper than `MaxSlopeAngle` was dropped, discontinuously changing both which corners define the plane and the height evaluated from it. All four corners now fit a single least-squares plane `Z = A*X + B*Y + C`, and `MaxSlopeAngle` caps that plane's tilt while preserving its direction, so crossing the limit is continuous. The fit is ridge-regularized (1e-3 * footprint²) so it degrades toward flat rather than going singular on a footprint with no extent on one axis.

Also:

- **`bCacheOwnerExtents`, new, default on.** `GetActorLocalBounds` builds skeletal bounds from live bone transforms, so an animated owner's footprint changed every frame and moved the trace points for reasons unrelated to the ground. Extents are measured once at `BeginPlay` instead. Only applies when `bOverrideOwnerExtents` is false; editor ticks still measure live, so property edits show up immediately.
- **Dead `EditCondition` fixed.** `MaxSlopeAngle` was conditioned on `bLimitSnapAngle`, which does not exist.

Behavior change worth knowing: a corner hanging over a ledge now drags the fit, bounded by the cap, where before it was dropped. Robust per-corner rejection is not available at this resolution — with four corners the least-squares residual space is spanned by (1, -1, 1, -1), so all four residuals always have equal magnitude and no corner can be identified as the outlier. A denser trace grid would be the way to get it.

Plane fit and tilt cap verified against numpy: fit is exact, cap saturates at the limit with tilt azimuth preserved and no jump at the crossing, and the ridge bias is 0.04° at 20° of tilt.
