### PR TITLE
Add RotationCenter to Kinematic Movement Components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ gRPC. Functional/rendering/agents/ROS layers are still not built.
 |---|---|---|
 | Unit/handedness conversion | `TempoCore/.../Tests/TempoConversionTest.cpp` | `QuantityConverter` factors, vector/rotator/quat handedness, round trips |
 | Camera/lidar lens math | `TempoSensors/.../Tests/TempoLensModelsTest.cpp` | factory, Brown-Conrady/Rational/Kannala-Brandt/Equidistant/Double-Sphere distort↔undistort round trips, focal-length math |
-| Kinematic motion models | `TempoMovement/.../Tests/TempoKinematicsTest.cpp` | bicycle & unicycle forward (`SimulateMotion`) + inverse (`ComputeNormalizedSteeringForYawRate`) models, saturation, forward/inverse round trip |
+| Kinematic motion models | `TempoMovement/.../Tests/TempoKinematicsTest.cpp` | bicycle & unicycle forward (`SimulateMotion`) + inverse (`ComputeNormalizedSteeringForYawRate`) models, saturation, forward/inverse round trip, off-origin `RotationCenter` pivoting |
 
 **Convention for testing UObject components** (see `TempoKinematicsTest.cpp`): a const method
 that only reads the component's own properties (e.g. the inverse motion model) can be tested by

--- a/TempoMovement/README.md
+++ b/TempoMovement/README.md
@@ -2,13 +2,20 @@
 TempoMovement includes controllers and dynamics models for simulating the movement of Actors.
 
 ## Vehicle Control
-TempoMovement includes movement models for vehicles (currently only a simple kinematic bicycle model) and a controller for vehicles. You can control a simulated vehicle with the `command_vehicle` RPC. For example:
+TempoMovement includes movement models for vehicles (a kinematic bicycle model, a kinematic unicycle model, and a Chaos wheeled vehicle) and a controller for vehicles. You can control a simulated vehicle with the `command_vehicle` RPC. For example:
 ```
 import tempo_sim.tempo_movement as tm
 
 commandable_vehicles_response = tm.get_commandable_vehicles()
 tm.command_vehicle(vehicle="MyVehicle", acceleration=0.5, steering=0.0) # Acceleration and steering are normalized from -1.0 to 1.0.
 ```
+
+### Rotation center
+The kinematic models (`KinematicBicycleModelMovementComponent`, `KinematicUnicycleModelMovementComponent`) turn about `RotationCenter`, an owner-local XY point on the movement component. It defaults to zero, which turns about the owner's origin. Set it when the owner's origin is not where the vehicle should pivot — for instance a mesh whose origin sits at the rear bumper. `RotationCenter` is also the point whose velocity the motion model describes, so it is the point that tracks a commanded speed exactly. It is an unscaled owner-local offset (the owner's scale applies on top of it), and can be set at runtime with `set_vector2d_property`.
+
+For the bicycle model this is independent of `AxleRatio`. `AxleRatio` places the model's reference point along the wheelbase (`0` = rear axle, `1` = front axle), which sets the slip angle; `RotationCenter` says where that same point sits on the owner. A vehicle with a 300 cm wheelbase whose rear axle is 50 cm ahead of its origin uses `AxleRatio = 0`, `RotationCenter = (50, 0)` to turn about its rear axle, or `AxleRatio = 0.5`, `RotationCenter = (200, 0)` to turn about the middle of its wheelbase.
+
+Because yaw is about the world Z axis, only the horizontal offset matters, which is why `RotationCenter` is 2D. `GroundSnapComponent` takes the same kind of offset as `ExtentsCenter`, so an off-center origin usually wants both set consistently.
 
 ## Pawn Movement
 TempoMovement also supports controlling pawns, using Unreal's navigation system. You can control a simulated Pawn (like a humanoid Character). For example:

--- a/TempoMovement/Source/TempoMovement/Private/KinematicVehicleMovementComponent.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/KinematicVehicleMovementComponent.cpp
@@ -7,6 +7,28 @@ FVector UKinematicVehicleMovementComponent::GetActorFeetLocation() const
 	return GetActorLocation();
 }
 
+FVector UKinematicVehicleMovementComponent::GetRotationCenterWorldLocation() const
+{
+	return GetOwner()->GetActorTransform().TransformPosition(FVector(RotationCenter, 0.0));
+}
+
+FVector UKinematicVehicleMovementComponent::ComputePivotCorrection(float DeltaYawDegrees) const
+{
+	if (RotationCenter.IsNearlyZero())
+	{
+		return FVector::ZeroVector;
+	}
+
+	// Where the rotation center sits relative to the owner's origin, in world space. TransformVector
+	// applies the owner's scale, so RotationCenter stays an unscaled owner-local offset.
+	const FVector CenterOffset = GetOwner()->GetActorTransform().TransformVector(FVector(RotationCenter, 0.0));
+
+	// A world rotation pivots about the owner's origin, which swings the rotation center along an arc.
+	// Translating by the negative of that arc puts the center back where it started, so the two
+	// together read as a rotation about the center.
+	return CenterOffset - FRotator(0.0, DeltaYawDegrees, 0.0).RotateVector(CenterOffset);
+}
+
 void UKinematicVehicleMovementComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
 {
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
@@ -52,12 +74,20 @@ void UKinematicVehicleMovementComponent::TickComponent(float DeltaTime, ELevelTi
 
 	const FTempoTwist Motion = SimulateMotion(DeltaTime, SteeringAngle, NewLinearVelocity);
 
+	// Motion.Linear is the velocity of the rotation center, not of the owner's origin. Offsetting the
+	// origin by the same amount and folding in the pivot correction leaves the center translating by
+	// exactly Motion.Linear while the owner yaws about it.
+	const FRotator DeltaRotation(0.0, DeltaTime * Motion.Angular.Z, 0.0);
+	const FVector PivotCorrection = ComputePivotCorrection(DeltaRotation.Yaw);
+
 	FHitResult MoveHitResult;
-	GetOwner()->AddActorWorldOffset(DeltaTime * Motion.Linear, true, &MoveHitResult);
+	GetOwner()->AddActorWorldOffset(DeltaTime * Motion.Linear + PivotCorrection, true, &MoveHitResult);
 	LinearVelocity = NewLinearVelocity;
-	Velocity = Motion.Linear;
+	// AActor::GetVelocity() reports this alongside the actor's location, so it has to describe the
+	// origin: the center's velocity plus the rate at which the origin swings about the center.
+	Velocity = DeltaTime > 0.0f ? Motion.Linear + PivotCorrection / DeltaTime : Motion.Linear;
 
 	FHitResult RotateHitResult;
-	GetOwner()->AddActorWorldRotation(FRotator(0.0, DeltaTime * Motion.Angular.Z, 0.0), true, &RotateHitResult);
+	GetOwner()->AddActorWorldRotation(DeltaRotation, true, &RotateHitResult);
 	AngularVelocity = Motion.Angular.Z;
 }

--- a/TempoMovement/Source/TempoMovement/Private/KinematicVehicleMovementComponent.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/KinematicVehicleMovementComponent.cpp
@@ -88,6 +88,11 @@ void UKinematicVehicleMovementComponent::TickComponent(float DeltaTime, ELevelTi
 	Velocity = DeltaTime > 0.0f ? Motion.Linear + PivotCorrection / DeltaTime : Motion.Linear;
 
 	FHitResult RotateHitResult;
+	// Yaw is about the world Z axis, not the owner's own up axis. These models are horizontal-plane
+	// simulations — Motion.Linear has no Z component, and SimulateMotion takes its heading from
+	// GetActorRotation().Yaw — and GroundSnapComponent copies yaw through untouched while solving pitch
+	// and roll from the terrain. Rotating about the owner's up axis instead would inject roll that
+	// GroundSnapComponent discards, and would make the heading a function of the ground we drive over.
 	GetOwner()->AddActorWorldRotation(DeltaRotation, true, &RotateHitResult);
 	AngularVelocity = Motion.Angular.Z;
 }

--- a/TempoMovement/Source/TempoMovement/Private/Tests/TempoKinematicsTest.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/Tests/TempoKinematicsTest.cpp
@@ -285,6 +285,112 @@ bool FTempoKinematicsUnicycleForwardTest::RunTest(const FString& Parameters)
 }
 
 //
+// Rotation center: where on the owner the model is referenced.
+//
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoKinematicsRotationCenterTest,
+	"Tempo.Movement.Kinematics.RotationCenter", TempoKinematicsTestFlags)
+bool FTempoKinematicsRotationCenterTest::RunTest(const FString& Parameters)
+{
+	auto NearVector = [this](const TCHAR* What, const FVector& A, const FVector& B, double Tol = KinematicsTol)
+	{
+		if (!A.Equals(B, Tol))
+		{
+			AddError(FString::Printf(TEXT("%s: expected %s, got %s"), What, *B.ToString(), *A.ToString()));
+		}
+	};
+
+	// One integration step the way TickComponent applies it: the origin offset (with the pivot
+	// correction folded in) first, then the world yaw. Returns where the rotation center ended up.
+	auto StepAndGetCenter = [](UKinematicVehicleMovementComponent* Component, const FVector& CenterOffset, double DeltaYawDeg)
+	{
+		Component->GetOwner()->AddActorWorldOffset(CenterOffset + Component->ComputePivotCorrection(DeltaYawDeg));
+		Component->GetOwner()->AddActorWorldRotation(FRotator(0.0, DeltaYawDeg, 0.0));
+		return Component->GetRotationCenterWorldLocation();
+	};
+
+	// The default rotation center is the owner's origin, and needs no correction at all: the motion is
+	// exactly what it was before the parameter existed.
+	{
+		const FKinematicTestFixture Fixture(30.0);
+		UKinematicUnicycleModelMovementComponent* Unicycle = Fixture.MakeComponent<UKinematicUnicycleModelMovementComponent>();
+		NearVector(TEXT("Default rotation center is the owner's origin"),
+			Unicycle->GetRotationCenterWorldLocation(), Fixture.Actor->GetActorLocation());
+		NearVector(TEXT("Default rotation center needs no correction"),
+			Unicycle->ComputePivotCorrection(45.0f), FVector::ZeroVector);
+	}
+
+	// With the center 200 cm ahead of the origin, a pure yaw pivots about that point: the center holds
+	// still while the origin swings around it.
+	{
+		const FKinematicTestFixture Fixture(0.0);
+		UKinematicUnicycleModelMovementComponent* Unicycle = Fixture.MakeComponent<UKinematicUnicycleModelMovementComponent>();
+		Unicycle->SetRotationCenter(FVector2D(200.0, 0.0));
+
+		const FVector CenterBefore = Unicycle->GetRotationCenterWorldLocation();
+		NearVector(TEXT("Rotation center 200 cm ahead of the origin"), CenterBefore, FVector(200.0, 0.0, 0.0));
+
+		NearVector(TEXT("Pure yaw holds the rotation center"),
+			StepAndGetCenter(Unicycle, FVector::ZeroVector, 90.0), CenterBefore);
+		// A quarter turn takes the origin from 200 cm behind the center to 200 cm to its world -Y side.
+		NearVector(TEXT("Origin swings about the rotation center"),
+			Fixture.Actor->GetActorLocation(), FVector(200.0, -200.0, 0.0));
+	}
+
+	// The center is the point whose velocity the model describes, so it translates by exactly the
+	// commanded offset even while the body yaws.
+	{
+		const FKinematicTestFixture Fixture(0.0);
+		UKinematicBicycleModelMovementComponent* Bike = Fixture.MakeComponent<UKinematicBicycleModelMovementComponent>();
+		Bike->SetRotationCenter(FVector2D(150.0, -25.0));
+
+		const FVector CenterBefore = Bike->GetRotationCenterWorldLocation();
+		const FVector CenterOffset(50.0, 10.0, 0.0);
+		NearVector(TEXT("Rotation center translates by the commanded offset"),
+			StepAndGetCenter(Bike, CenterOffset, 20.0), CenterBefore + CenterOffset);
+	}
+
+	// The center is owner-local: at yaw 90 an offset along the owner's +X points along world +Y.
+	{
+		const FKinematicTestFixture Fixture(90.0);
+		UKinematicUnicycleModelMovementComponent* Unicycle = Fixture.MakeComponent<UKinematicUnicycleModelMovementComponent>();
+		Unicycle->SetRotationCenter(FVector2D(100.0, 0.0));
+		NearVector(TEXT("Rotation center follows the owner's heading"),
+			Unicycle->GetRotationCenterWorldLocation(), FVector(0.0, 100.0, 0.0));
+	}
+
+	// RotationCenter is unscaled owner-local, so the owner's scale applies on top of it — and the
+	// pivot correction has to use the same scaled offset for the center to stay put.
+	{
+		const FKinematicTestFixture Fixture(0.0);
+		Fixture.Actor->SetActorScale3D(FVector(2.0, 2.0, 2.0));
+		UKinematicUnicycleModelMovementComponent* Unicycle = Fixture.MakeComponent<UKinematicUnicycleModelMovementComponent>();
+		Unicycle->SetRotationCenter(FVector2D(100.0, 0.0));
+
+		const FVector CenterBefore = Unicycle->GetRotationCenterWorldLocation();
+		NearVector(TEXT("Owner scale applies to the rotation center"), CenterBefore, FVector(200.0, 0.0, 0.0));
+		NearVector(TEXT("Scaled rotation center still holds under yaw"),
+			StepAndGetCenter(Unicycle, FVector::ZeroVector, 45.0), CenterBefore);
+	}
+
+	// A pitched owner (as GroundSnapComponent leaves one on a slope) still yaws about the world Z axis
+	// through the center, which now sits above or below the owner's origin height.
+	{
+		const FKinematicTestFixture Fixture(0.0);
+		Fixture.Actor->SetActorRotation(FRotator(/*Pitch=*/15.0, /*Yaw=*/0.0, /*Roll=*/0.0));
+		UKinematicUnicycleModelMovementComponent* Unicycle = Fixture.MakeComponent<UKinematicUnicycleModelMovementComponent>();
+		Unicycle->SetRotationCenter(FVector2D(200.0, 0.0));
+
+		const FVector CenterBefore = Unicycle->GetRotationCenterWorldLocation();
+		TestTrue(TEXT("Pitched owner lifts the rotation center off the origin height"), CenterBefore.Z > 0.0);
+		NearVector(TEXT("Pitched owner still yaws about the rotation center"),
+			StepAndGetCenter(Unicycle, FVector::ZeroVector, 30.0), CenterBefore);
+	}
+
+	return true;
+}
+
+//
 // Forward/inverse consistency: the inverse model recovers the steering that produced a yaw rate.
 //
 

--- a/TempoMovement/Source/TempoMovement/Private/Tests/TempoKinematicsTest.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/Tests/TempoKinematicsTest.cpp
@@ -373,8 +373,10 @@ bool FTempoKinematicsRotationCenterTest::RunTest(const FString& Parameters)
 			StepAndGetCenter(Unicycle, FVector::ZeroVector, 45.0), CenterBefore);
 	}
 
-	// A pitched owner (as GroundSnapComponent leaves one on a slope) still yaws about the world Z axis
-	// through the center, which now sits above or below the owner's origin height.
+	// A pitched owner (as GroundSnapComponent leaves one on a slope) yaws about the world Z axis, which
+	// fixes the whole vertical line through the center. So the center's height does not matter, which is
+	// what makes an XY RotationCenter sufficient, but its horizontal lever arm is foreshortened by the
+	// pitch and the correction has to use that foreshortened offset.
 	{
 		const FKinematicTestFixture Fixture(0.0);
 		Fixture.Actor->SetActorRotation(FRotator(/*Pitch=*/15.0, /*Yaw=*/0.0, /*Roll=*/0.0));

--- a/TempoMovement/Source/TempoMovement/Public/KinematicBicycleModelMovementComponent.h
+++ b/TempoMovement/Source/TempoMovement/Public/KinematicBicycleModelMovementComponent.h
@@ -22,7 +22,10 @@ protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	float Wheelbase = 100.0; // CM
 
-	// The normalized distance (as a fraction of the wheelbase) from the rear axle to the origin.
+	// The normalized distance (as a fraction of the wheelbase) from the rear axle to the rotation
+	// center: 0 puts the rotation center on the rear axle, 1 on the front axle. This is where the
+	// model is referenced between the axles, which sets the slip angle; RotationCenter separately says
+	// where that same point sits on the owner.
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	float AxleRatio = 0.5;
 };

--- a/TempoMovement/Source/TempoMovement/Public/KinematicVehicleMovementComponent.h
+++ b/TempoMovement/Source/TempoMovement/Public/KinematicVehicleMovementComponent.h
@@ -26,6 +26,20 @@ public:
 	// Signed forward speed in cm/s (Unreal native).
 	float GetLinearVelocity() const { return LinearVelocity; }
 
+	FVector2D GetRotationCenter() const { return RotationCenter; }
+
+	void SetRotationCenter(const FVector2D& InRotationCenter) { RotationCenter = InRotationCenter; }
+
+	// The rotation center in world space at the owner's current pose. Useful to check where a
+	// RotationCenter actually lands, and for control laws that should reference the point the vehicle
+	// turns about rather than the owner's origin.
+	UFUNCTION(BlueprintPure, Category="Movement")
+	FVector GetRotationCenterWorldLocation() const;
+
+	// The extra world-space translation the owner's origin needs so that yawing it by DeltaYawDegrees
+	// pivots about RotationCenter instead of about the origin. Zero when RotationCenter is zero.
+	FVector ComputePivotCorrection(float DeltaYawDegrees) const;
+
 	// Inverse motion model: returns the normalized steering input in [-1, 1] that would
 	// produce the desired yaw rate at the given linear velocity. Inputs are Unreal-native
 	// (deg/s left-handed yaw, cm/s forward speed). Implementations should clamp to [-1, 1]
@@ -35,8 +49,18 @@ public:
 
 protected:
 	// Forward motion model. Returns the resulting world-frame motion as a Twist: Linear is the
-	// world-frame velocity (cm/s), Angular.Z is the yaw rate (deg/s, left-handed).
+	// world-frame velocity of the rotation center (cm/s), Angular.Z is the yaw rate (deg/s,
+	// left-handed).
 	virtual FTempoTwist SimulateMotion(float DeltaTime, float Steering, float NewLinearVelocity) PURE_VIRTUAL(UKinematicVehicleMovementComponent::SimulateMotion, return FTempoTwist(););
+
+	// The owner-local XY point this vehicle turns about, which is also the point whose velocity the
+	// motion model describes. Zero (the default) turns about the owner's origin. Set it when the
+	// owner's origin is not where the vehicle should pivot, e.g. a mesh whose origin sits at the rear
+	// bumper of a vehicle that should turn about the middle of its wheelbase. This is an unscaled
+	// owner-local offset, like the owner's own bounds, so the owner's scale is applied on top of it.
+	// XY only: these models yaw about the world Z axis, so the center's height has nothing to act on.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FVector2D RotationCenter = FVector2D::ZeroVector;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	bool bReverseEnabled = false;


### PR DESCRIPTION
`UKinematicVehicleMovementComponent` gains `RotationCenter`, an owner-local XY point the vehicle turns about. It defaults to zero, which turns about the owner's origin, so existing setups are unchanged. It lives on the shared base, so the bicycle and unicycle models both get it — the unicycle had no equivalent knob before.

`AddActorWorldRotation` always pivots about the origin, which swings the rotation center along an arc. Adding the negative of that arc to the same tick's translation puts the center back where it started, so the pair reads as a rotation about the center:

```cpp
return CenterOffset - FRotator(0.0, DeltaYawDegrees, 0.0).RotateVector(CenterOffset);
```

Exact rather than small-angle: the center translates by exactly `DeltaTime * Motion.Linear` and the body yaws by exactly `DeltaTime * Motion.Angular.Z`, for any yaw step and any owner pitch/roll. It collapses to zero when `RotationCenter` is zero.

Two consequences:

- **`Motion.Linear` is the rotation center's velocity**, which it always was — the center was just implicitly the origin. So `RotationCenter` is also the point that tracks a commanded speed exactly.
- **`Velocity` now describes the origin**, not the center. `AActor::GetVelocity()` reports it alongside the actor's location, so it has to include the origin's swing about the center.

**`AxleRatio` and `RotationCenter` are independent**, and the docs now say so. `AxleRatio` places the model's reference point between the axles, which is what sets the slip angle; `RotationCenter` says where that same point sits on the owner. A vehicle with a 300 cm wheelbase whose rear axle is 50 cm ahead of its origin uses `AxleRatio = 0`, `RotationCenter = (50, 0)` to turn about its rear axle, or `AxleRatio = 0.5`, `RotationCenter = (200, 0)` to turn about the middle of its wheelbase.

`FVector2D` because yaw is about world Z, so only the horizontal offset is a meaningful degree of freedom — matching `GroundSnapComponent::ExtentsCenter`, which takes the same kind of offset for the same reason. An off-center origin usually wants both set consistently. Settable at runtime with `set_vector2d_property`.

New `Tempo.Movement.Kinematics.RotationCenter` test: default-is-origin, pure yaw holds the center while the origin swings, the center translates by exactly the commanded offset under simultaneous yaw, owner-local orientation, owner scale, and a pitched owner (the `GroundSnapComponent`-on-a-slope case).

Not changed: `TrajectoryFollowingController` still measures from `GetActorLocation()`, and its teleport mode puts the origin on the spline. That is a separate "which point follows the path" decision, and it would affect pawns with no kinematic movement component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
