### PR TITLE
Track trajectory progress as distance, and allow live speed changes

### DIFF
--- a/TempoMovement/Source/TempoMovement/Private/TempoMovementControlServiceSubsystem.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TempoMovementControlServiceSubsystem.cpp
@@ -546,13 +546,13 @@ void UTempoMovementControlServiceSubsystem::SetTrajectorySpeed(const SetTrajecto
 		return;
 	}
 
-	if (Request.speed() < 0.0f)
+	// Speeds arrive in SI and convert to Unreal-native cm, as in ConfigureTrajectoryFollowing. A
+	// negative speed is a direction, not an error: it drives the pawn back along the spline.
+	if (!FMath::IsFinite(Request.speed()))
 	{
-		ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Trajectory speed may not be negative"));
+		ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Trajectory speed must be finite"));
 		return;
 	}
-
-	// Speeds arrive in SI and convert to Unreal-native cm, as in ConfigureTrajectoryFollowing.
 	constexpr float M2CMScale = 100.0f;
 	if (!FollowingComponent->SetSpeed(Request.speed() * M2CMScale))
 	{

--- a/TempoMovement/Source/TempoMovement/Private/TempoMovementControlServiceSubsystem.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TempoMovementControlServiceSubsystem.cpp
@@ -32,6 +32,7 @@ using PawnMoveToLocationResponse = TempoMovement::PawnMoveToLocationResponse;
 using NavigablePawnsResponse = TempoMovement::NavigablePawnsResponse;
 using SetSplinePointsRequest = TempoMovement::SetSplinePointsRequest;
 using ConfigureTrajectoryFollowingRequest = TempoMovement::ConfigureTrajectoryFollowingRequest;
+using SetTrajectorySpeedRequest = TempoMovement::SetTrajectorySpeedRequest;
 using TempoEmpty = TempoCore::Empty;
 
 namespace
@@ -146,7 +147,8 @@ void UTempoMovementControlServiceSubsystem::RegisterServices(FTempoServer& Serve
 		SimpleRequestHandler(&MovementControlAsyncService::RequestPawnMoveToLocation, &UTempoMovementControlServiceSubsystem::PawnMoveToLocation),
 		SimpleRequestHandler(&MovementControlAsyncService::RequestRebuildNavigation, &UTempoMovementControlServiceSubsystem::RebuildNavigation),
 		SimpleRequestHandler(&MovementControlAsyncService::RequestSetSplinePoints, &UTempoMovementControlServiceSubsystem::SetSplinePoints),
-		SimpleRequestHandler(&MovementControlAsyncService::RequestConfigureTrajectoryFollowing, &UTempoMovementControlServiceSubsystem::ConfigureTrajectoryFollowing)
+		SimpleRequestHandler(&MovementControlAsyncService::RequestConfigureTrajectoryFollowing, &UTempoMovementControlServiceSubsystem::ConfigureTrajectoryFollowing),
+		SimpleRequestHandler(&MovementControlAsyncService::RequestSetTrajectorySpeed, &UTempoMovementControlServiceSubsystem::SetTrajectorySpeed)
 		);
 }
 
@@ -524,6 +526,43 @@ void UTempoMovementControlServiceSubsystem::ConfigureTrajectoryFollowing(const C
 	}
 
 	FollowingComponent->ConfigureAndFollow(SplineActor, Config);
+
+	ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status_OK);
+}
+
+void UTempoMovementControlServiceSubsystem::SetTrajectorySpeed(const SetTrajectorySpeedRequest& Request, const TResponseDelegate<TempoEmpty>& ResponseContinuation) const
+{
+	APawn* Pawn = FindPawn(GetWorld(), UTF8_TO_TCHAR(Request.pawn().c_str()));
+	if (!Pawn)
+	{
+		ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status(grpc::StatusCode::NOT_FOUND, "Did not find a pawn with the specified name"));
+		return;
+	}
+
+	UTrajectoryFollowingComponent* FollowingComponent = Pawn->FindComponentByClass<UTrajectoryFollowingComponent>();
+	if (!FollowingComponent)
+	{
+		ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "Pawn does not have a TrajectoryFollowingComponent"));
+		return;
+	}
+
+	if (Request.speed() < 0.0f)
+	{
+		ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Trajectory speed may not be negative"));
+		return;
+	}
+
+	// Speeds arrive in SI and convert to Unreal-native cm, as in ConfigureTrajectoryFollowing.
+	constexpr float M2CMScale = 100.0f;
+	if (!FollowingComponent->SetSpeed(Request.speed() * M2CMScale))
+	{
+		// Either nothing is being followed yet, or the trajectory is paced by a curve rather than a
+		// constant speed. Both are the caller getting ahead of / disagreeing with its own
+		// ConfigureTrajectoryFollowing, not a transient condition to retry.
+		ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+			"Pawn is not following a constant-speed trajectory"));
+		return;
+	}
 
 	ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status_OK);
 }

--- a/TempoMovement/Source/TempoMovement/Private/Tests/TempoTrajectoryFollowingTest.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/Tests/TempoTrajectoryFollowingTest.cpp
@@ -194,10 +194,68 @@ bool FTempoTrajectoryHoldTest::RunTest(const FString& Parameters)
 	Near(TEXT("Distance after release"), Fixture.Controller->GetDistanceAlongSpline(), 300.0);
 	Near(TEXT("Pawn after release"), Fixture.PawnX(), 300.0);
 
-	// A negative speed is clamped to a hold rather than driving back down the spline.
-	Fixture.Controller->SetSpeed(-100.0);
-	Fixture.Tick(10);
-	Near(TEXT("Distance after a negative speed"), Fixture.Controller->GetDistanceAlongSpline(), 300.0);
+	return true;
+}
+
+//
+// A negative speed is a direction, not an error: the follower drives back along the spline.
+//
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoTrajectoryReverseTest,
+	"Tempo.Movement.TrajectoryFollowing.Reverse", TempoTrajectoryTestFlags)
+bool FTempoTrajectoryReverseTest::RunTest(const FString& Parameters)
+{
+	auto Near = [this](const TCHAR* What, double A, double B, double Tol = DistanceTol)
+	{
+		if (!FMath::IsNearlyEqual(A, B, Tol))
+		{
+			AddError(FString::Printf(TEXT("%s: expected %.4f, got %.4f"), What, B, A));
+		}
+	};
+
+	// One world at a time: TempoCore's service subsystem binds per world and ensures if a second
+	// world is created while the first is still up, so each case gets its own scope.
+	{
+		FTrajectoryTestFixture Fixture;
+		Fixture.Follow(FTrajectoryTestFixture::ConstantSpeedConfig(100.0));
+		Fixture.Tick(50);
+		Near(TEXT("Distance driven out"), Fixture.Controller->GetDistanceAlongSpline(), 500.0);
+
+		// Backing up retraces the road it came in on, at the speed asked for.
+		Fixture.Controller->SetSpeed(-200.0);
+		Fixture.Tick(10);
+		Near(TEXT("Distance after 1 s at -200 cm/s"), Fixture.Controller->GetDistanceAlongSpline(), 300.0);
+		Near(TEXT("Pawn backed up"), Fixture.PawnX(), 300.0);
+
+		// The pawn keeps its heading while reversing — it backs up rather than turning around. (The
+		// target's rotation is the spline tangent, which does not depend on the direction of travel.)
+		Near(TEXT("Heading while reversing"), Fixture.Pawn->GetActorRotation().Yaw, 0.0, 1.0);
+
+		// Reversing does not run off the start of the spline, and does not end the trajectory: it
+		// stops there and drives out again when asked.
+		Fixture.Tick(100);
+		Near(TEXT("Reversing stops at the spline start"), Fixture.Controller->GetDistanceAlongSpline(), 0.0);
+		Fixture.Controller->SetSpeed(100.0);
+		Fixture.Tick(10);
+		Near(TEXT("Driving out again from the start"), Fixture.Controller->GetDistanceAlongSpline(), 100.0);
+	}
+
+	// A Destroy follower backed onto the spline's start is not destroyed by it — only the far end
+	// ends a trajectory.
+	{
+		FTrajectoryTestFixture Destroyer;
+		FTrajectoryFollowingConfig Config = FTrajectoryTestFixture::ConstantSpeedConfig(100.0);
+		Config.EndBehavior = ETrajectoryEndBehavior::Destroy;
+		Destroyer.Follow(Config);
+		Destroyer.Tick(20);
+		Destroyer.Controller->SetSpeed(-100.0);
+		Destroyer.Tick(100);
+		Near(TEXT("Backed onto the start"), Destroyer.Controller->GetDistanceAlongSpline(), 0.0);
+		if (!IsValid(Destroyer.Pawn))
+		{
+			AddError(TEXT("Backing onto the spline's start should not destroy the pawn"));
+		}
+	}
 
 	return true;
 }

--- a/TempoMovement/Source/TempoMovement/Private/Tests/TempoTrajectoryFollowingTest.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/Tests/TempoTrajectoryFollowingTest.cpp
@@ -1,0 +1,393 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#include "SplineActor.h"
+#include "TrajectoryFollowingController.h"
+
+#include "Components/SplineComponent.h"
+#include "Engine/Engine.h"
+#include "Engine/World.h"
+#include "GameFramework/Pawn.h"
+#include "Misc/AutomationTest.h"
+
+// Unit tests for ATrajectoryFollowingController: how progress along a trajectory is advanced, when a
+// trajectory ends, and what each end behavior does about it.
+//
+// The controller is driven directly — spawn it, call FollowTrajectory, then call Tick with the deltas
+// we want — rather than through a UTrajectoryFollowingComponent and the engine's tick, so a test can
+// step the trajectory by an exact amount. Every test follows a straight spline in Teleport mode, so
+// the pawn's location *is* the sampled target and arc length along the spline is just distance in x;
+// nothing here depends on a movement component, physics, or the RHI.
+//
+// Runs headlessly via:
+//   Scripts/Test.sh Tempo.Movement
+//   Automation RunTests Tempo.Movement.TrajectoryFollowing   (from the editor console)
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+namespace
+{
+	constexpr EAutomationTestFlags TempoTrajectoryTestFlags =
+		EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter;
+
+	// Spline length used by most tests, in cm.
+	constexpr double TestSplineLength = 1000.0;
+
+	// Tolerance for a distance the controller integrated over several ticks (cm). Generous relative to
+	// the quantities under test (hundreds of cm), because a spline's arc length is measured from its
+	// polyline approximation and need not agree with the straight-line distance to the last decimal.
+	constexpr double DistanceTol = 1.0;
+
+	// RAII fixture: a transient Game world holding a straight spline along +x from the origin and a
+	// bare pawn for the controller to possess and teleport along it.
+	struct FTrajectoryTestFixture
+	{
+		UWorld* World = nullptr;
+		ASplineActor* SplineActor = nullptr;
+		APawn* Pawn = nullptr;
+		ATrajectoryFollowingController* Controller = nullptr;
+
+		explicit FTrajectoryTestFixture(double Length = TestSplineLength)
+		{
+			World = UWorld::CreateWorld(EWorldType::Game, /*bInformEngineOfWorld=*/false);
+			FWorldContext& WorldContext = GEngine->CreateNewWorldContext(EWorldType::Game);
+			WorldContext.SetCurrentWorld(World);
+
+			SplineActor = World->SpawnActor<ASplineActor>();
+			USplineComponent* Spline = SplineActor->GetSpline();
+			Spline->ClearSplinePoints(false);
+			Spline->AddSplinePoint(FVector::ZeroVector, ESplineCoordinateSpace::World, false);
+			Spline->AddSplinePoint(FVector(Length, 0.0, 0.0), ESplineCoordinateSpace::World, false);
+			// A straight line: pin both tangents along +x so the curve doesn't bow between the points
+			// and its arc length is the distance between them.
+			Spline->SetTangentAtSplinePoint(0, FVector(Length, 0.0, 0.0), ESplineCoordinateSpace::World, false);
+			Spline->SetTangentAtSplinePoint(1, FVector(Length, 0.0, 0.0), ESplineCoordinateSpace::World, false);
+			Spline->UpdateSpline();
+
+			Pawn = World->SpawnActor<APawn>();
+			USceneComponent* Root = NewObject<USceneComponent>(Pawn);
+			Pawn->SetRootComponent(Root);
+			Root->RegisterComponent();
+
+			Controller = World->SpawnActor<ATrajectoryFollowingController>();
+		}
+
+		// Config shared by the tests: teleport (so the pawn lands exactly on the target) and hold at
+		// the end unless the test says otherwise.
+		static FTrajectoryFollowingConfig ConstantSpeedConfig(double SpeedCmS)
+		{
+			FTrajectoryFollowingConfig Config;
+			Config.SpeedMode = ETrajectorySpeedMode::ConstantSpeed;
+			Config.Speed = SpeedCmS;
+			Config.bTeleport = true;
+			Config.EndBehavior = ETrajectoryEndBehavior::Clamp;
+			return Config;
+		}
+
+		void Follow(const FTrajectoryFollowingConfig& Config) const
+		{
+			Controller->FollowTrajectory(SplineActor, Pawn, Config);
+		}
+
+		// Tick the controller Count times with a fixed delta.
+		void Tick(int32 Count, float DeltaSeconds = 0.1f) const
+		{
+			for (int32 TickIndex = 0; TickIndex < Count; ++TickIndex)
+			{
+				Controller->Tick(DeltaSeconds);
+			}
+		}
+
+		double PawnX() const { return Pawn->GetActorLocation().X; }
+
+		~FTrajectoryTestFixture()
+		{
+			if (World)
+			{
+				GEngine->DestroyWorldContext(World);
+				World->DestroyWorld(/*bInformEngineOfWorld=*/false);
+			}
+		}
+
+		FTrajectoryTestFixture(const FTrajectoryTestFixture&) = delete;
+		FTrajectoryTestFixture& operator=(const FTrajectoryTestFixture&) = delete;
+	};
+}
+
+//
+// Constant speed: distance is integrated per tick, so speed is a live input.
+//
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoTrajectoryConstantSpeedTest,
+	"Tempo.Movement.TrajectoryFollowing.ConstantSpeed", TempoTrajectoryTestFlags)
+bool FTempoTrajectoryConstantSpeedTest::RunTest(const FString& Parameters)
+{
+	auto Near = [this](const TCHAR* What, double A, double B, double Tol = DistanceTol)
+	{
+		if (!FMath::IsNearlyEqual(A, B, Tol))
+		{
+			AddError(FString::Printf(TEXT("%s: expected %.4f, got %.4f"), What, B, A));
+		}
+	};
+
+	FTrajectoryTestFixture Fixture;
+	Fixture.Follow(FTrajectoryTestFixture::ConstantSpeedConfig(100.0));
+
+	// 10 ticks of 0.1 s at 100 cm/s = 100 cm, and the pawn is teleported onto it.
+	Fixture.Tick(10);
+	Near(TEXT("Distance after 1 s at 100 cm/s"), Fixture.Controller->GetDistanceAlongSpline(), 100.0);
+	Near(TEXT("Pawn x after 1 s at 100 cm/s"), Fixture.PawnX(), 100.0);
+
+	// Doubling the speed neither moves the pawn nor rewinds its progress: the change applies to the
+	// *next* increment only. (Deriving distance from the clock instead would put the target at
+	// 200 cm/s * 1 s = 200 cm here, teleporting the pawn a metre down the spline.)
+	Fixture.Controller->SetSpeed(200.0);
+	Near(TEXT("Distance is unchanged by SetSpeed"), Fixture.Controller->GetDistanceAlongSpline(), 100.0);
+	Near(TEXT("Pawn does not move on SetSpeed"), Fixture.PawnX(), 100.0);
+
+	// ... and from there it advances at the new speed.
+	Fixture.Tick(10);
+	Near(TEXT("Distance after a further 1 s at 200 cm/s"), Fixture.Controller->GetDistanceAlongSpline(), 300.0);
+	Near(TEXT("Pawn x after a further 1 s at 200 cm/s"), Fixture.PawnX(), 300.0);
+
+	// Halving it again is equally continuous, including part way through the spline.
+	Fixture.Controller->SetSpeed(50.0);
+	Fixture.Tick(10);
+	Near(TEXT("Distance after 1 s at 50 cm/s"), Fixture.Controller->GetDistanceAlongSpline(), 350.0);
+
+	return true;
+}
+
+//
+// Zero speed: an ordinary value, not a degenerate one. The follower holds its place indefinitely
+// without ending the trajectory or losing its progress, and resumes from where it stopped.
+//
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoTrajectoryHoldTest,
+	"Tempo.Movement.TrajectoryFollowing.Hold", TempoTrajectoryTestFlags)
+bool FTempoTrajectoryHoldTest::RunTest(const FString& Parameters)
+{
+	auto Near = [this](const TCHAR* What, double A, double B, double Tol = DistanceTol)
+	{
+		if (!FMath::IsNearlyEqual(A, B, Tol))
+		{
+			AddError(FString::Printf(TEXT("%s: expected %.4f, got %.4f"), What, B, A));
+		}
+	};
+
+	FTrajectoryTestFixture Fixture;
+	Fixture.Follow(FTrajectoryTestFixture::ConstantSpeedConfig(100.0));
+	Fixture.Tick(20);
+	Near(TEXT("Distance before the hold"), Fixture.Controller->GetDistanceAlongSpline(), 200.0);
+
+	// Held: 10 s of ticks move the pawn not at all, and leave it where it was — not back at the
+	// spline's start, which is where a duration-based follower lands when its duration collapses to
+	// zero (length / 0 speed).
+	Fixture.Controller->SetSpeed(0.0);
+	Fixture.Tick(100);
+	Near(TEXT("Distance is held"), Fixture.Controller->GetDistanceAlongSpline(), 200.0);
+	Near(TEXT("Pawn is held"), Fixture.PawnX(), 200.0);
+
+	// The trajectory did not end while held: released, it carries on from the same point rather than
+	// restarting or jumping to the end.
+	Fixture.Controller->SetSpeed(100.0);
+	Fixture.Tick(10);
+	Near(TEXT("Distance after release"), Fixture.Controller->GetDistanceAlongSpline(), 300.0);
+	Near(TEXT("Pawn after release"), Fixture.PawnX(), 300.0);
+
+	// A negative speed is clamped to a hold rather than driving back down the spline.
+	Fixture.Controller->SetSpeed(-100.0);
+	Fixture.Tick(10);
+	Near(TEXT("Distance after a negative speed"), Fixture.Controller->GetDistanceAlongSpline(), 300.0);
+
+	return true;
+}
+
+//
+// End of trajectory. The arc-length modes end where the spline does, whatever speeds they were driven
+// at along the way.
+//
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoTrajectoryEndBehaviorTest,
+	"Tempo.Movement.TrajectoryFollowing.EndBehavior", TempoTrajectoryTestFlags)
+bool FTempoTrajectoryEndBehaviorTest::RunTest(const FString& Parameters)
+{
+	auto Near = [this](const TCHAR* What, double A, double B, double Tol = DistanceTol)
+	{
+		if (!FMath::IsNearlyEqual(A, B, Tol))
+		{
+			AddError(FString::Printf(TEXT("%s: expected %.4f, got %.4f"), What, B, A));
+		}
+	};
+
+	// Clamp: hold the final pose, and keep holding it.
+	{
+		FTrajectoryTestFixture Fixture;
+		Fixture.Follow(FTrajectoryTestFixture::ConstantSpeedConfig(1000.0));
+		Fixture.Tick(20);
+		Near(TEXT("Clamp stops at the end of the spline"), Fixture.Controller->GetDistanceAlongSpline(), TestSplineLength);
+		Near(TEXT("Clamp leaves the pawn at the last point"), Fixture.PawnX(), TestSplineLength);
+		Fixture.Tick(20);
+		Near(TEXT("Clamp holds the final pose"), Fixture.PawnX(), TestSplineLength);
+	}
+
+	// Loop: wrap back to the start, carrying the overshoot so the pace is unbroken across the wrap.
+	{
+		FTrajectoryTestFixture Fixture;
+		FTrajectoryFollowingConfig Config = FTrajectoryTestFixture::ConstantSpeedConfig(1000.0);
+		Config.EndBehavior = ETrajectoryEndBehavior::Loop;
+		Fixture.Follow(Config);
+		// 1.5 s at 1000 cm/s = 1500 cm over a 1000 cm spline.
+		Fixture.Tick(15);
+		Near(TEXT("Loop carries the overshoot"), Fixture.Controller->GetDistanceAlongSpline(), 500.0);
+		Near(TEXT("Loop puts the pawn back near the start"), Fixture.PawnX(), 500.0);
+	}
+
+	// Reset: teleport back to the start of the spline and go again.
+	{
+		FTrajectoryTestFixture Fixture;
+		FTrajectoryFollowingConfig Config = FTrajectoryTestFixture::ConstantSpeedConfig(1000.0);
+		Config.EndBehavior = ETrajectoryEndBehavior::Reset;
+		Fixture.Follow(Config);
+		// 1.2 s at 1000 cm/s = 1200 cm over a 1000 cm spline: the reset tick teleports the pawn back
+		// to the wrapped point, 200 cm in, rather than leaving it clamped at the end.
+		Fixture.Tick(12);
+		Near(TEXT("Reset wraps to the carried overshoot"), Fixture.Controller->GetDistanceAlongSpline(), 200.0);
+		Near(TEXT("Reset teleports the pawn back toward the start"), Fixture.PawnX(), 200.0);
+	}
+
+	// Destroy: the pawn is destroyed when it reaches the end.
+	{
+		FTrajectoryTestFixture Fixture;
+		FTrajectoryFollowingConfig Config = FTrajectoryTestFixture::ConstantSpeedConfig(1000.0);
+		Config.EndBehavior = ETrajectoryEndBehavior::Destroy;
+		Fixture.Follow(Config);
+		Fixture.Tick(5);
+		if (!IsValid(Fixture.Pawn))
+		{
+			AddError(TEXT("Destroy should not fire before the end of the spline"));
+		}
+		Fixture.Tick(15);
+		if (IsValid(Fixture.Pawn))
+		{
+			AddError(TEXT("Destroy should destroy the pawn at the end of the spline"));
+		}
+	}
+
+	// A trajectory held at 0 speed never reaches its end, however long it is ticked — the end is a
+	// place on the spline now, not a moment on a clock.
+	{
+		FTrajectoryTestFixture Fixture;
+		FTrajectoryFollowingConfig Config = FTrajectoryTestFixture::ConstantSpeedConfig(1000.0);
+		Config.EndBehavior = ETrajectoryEndBehavior::Destroy;
+		Fixture.Follow(Config);
+		Fixture.Tick(5);
+		Fixture.Controller->SetSpeed(0.0);
+		Fixture.Tick(200);
+		if (!IsValid(Fixture.Pawn))
+		{
+			AddError(TEXT("A held trajectory should not reach its end and destroy the pawn"));
+		}
+	}
+
+	return true;
+}
+
+//
+// SpeedVsTime: the speed curve is integrated tick by tick, and the trajectory ends on whichever comes
+// first — the end of the spline or the end of the curve.
+//
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoTrajectorySpeedVsTimeTest,
+	"Tempo.Movement.TrajectoryFollowing.SpeedVsTime", TempoTrajectoryTestFlags)
+bool FTempoTrajectorySpeedVsTimeTest::RunTest(const FString& Parameters)
+{
+	auto Near = [this](const TCHAR* What, double A, double B, double Tol)
+	{
+		if (!FMath::IsNearlyEqual(A, B, Tol))
+		{
+			AddError(FString::Printf(TEXT("%s: expected %.4f, got %.4f"), What, B, A));
+		}
+	};
+
+	auto MakeConfig = [](TFunctionRef<void(FRichCurve&)> BuildCurve)
+	{
+		FTrajectoryFollowingConfig Config;
+		Config.SpeedMode = ETrajectorySpeedMode::SpeedVsTime;
+		Config.bTeleport = true;
+		Config.EndBehavior = ETrajectoryEndBehavior::Clamp;
+		BuildCurve(*Config.TimeToSpeed.GetRichCurve());
+		return Config;
+	};
+
+	// A flat curve is just a constant speed: 100 cm/s for 4 s.
+	{
+		FTrajectoryTestFixture Fixture(/*Length=*/5000.0);
+		Fixture.Follow(MakeConfig([](FRichCurve& Curve)
+		{
+			Curve.AddKey(0.0f, 100.0f);
+			Curve.AddKey(4.0f, 100.0f);
+		}));
+		Fixture.Tick(10);
+		Near(TEXT("Flat speed curve after 1 s"), Fixture.Controller->GetDistanceAlongSpline(), 100.0, DistanceTol);
+		Near(TEXT("Pawn under a flat speed curve"), Fixture.PawnX(), 100.0, DistanceTol);
+	}
+
+	// A ramp from 0 to 200 cm/s over 2 s covers its integral, 200 cm. The controller integrates with
+	// the speed at the start of each tick, so a fine delta is worth a couple of cm of tolerance.
+	{
+		FTrajectoryTestFixture Fixture(/*Length=*/5000.0);
+		Fixture.Follow(MakeConfig([](FRichCurve& Curve)
+		{
+			Curve.AddKey(0.0f, 0.0f);
+			Curve.AddKey(2.0f, 200.0f);
+		}));
+		Fixture.Tick(200, /*DeltaSeconds=*/0.01f);
+		Near(TEXT("Ramped speed curve integral"), Fixture.Controller->GetDistanceAlongSpline(), 200.0, 5.0);
+	}
+
+	// The curve's own duration ends the trajectory when the spline outlives it: 100 cm/s for 2 s over
+	// a 5000 cm spline stops at 200 cm, and stays there under Clamp.
+	{
+		FTrajectoryTestFixture Fixture(/*Length=*/5000.0);
+		Fixture.Follow(MakeConfig([](FRichCurve& Curve)
+		{
+			Curve.AddKey(0.0f, 100.0f);
+			Curve.AddKey(2.0f, 100.0f);
+		}));
+		Fixture.Tick(100);
+		Near(TEXT("An exhausted speed curve ends the trajectory"), Fixture.Controller->GetDistanceAlongSpline(), 200.0, DistanceTol);
+	}
+
+	// ... and the end of the spline ends it when the curve outlives *that*: 1000 cm/s for 10 s over a
+	// 1000 cm spline stops at the spline's end after 1 s.
+	{
+		FTrajectoryTestFixture Fixture;
+		Fixture.Follow(MakeConfig([](FRichCurve& Curve)
+		{
+			Curve.AddKey(0.0f, 1000.0f);
+			Curve.AddKey(10.0f, 1000.0f);
+		}));
+		Fixture.Tick(50);
+		Near(TEXT("A short spline ends a long speed curve"), Fixture.Controller->GetDistanceAlongSpline(), TestSplineLength, DistanceTol);
+		Near(TEXT("Pawn clamped at the end of the spline"), Fixture.PawnX(), TestSplineLength, DistanceTol);
+	}
+
+	// SetSpeed is a ConstantSpeed control and declines to act on a curve-paced trajectory, rather than
+	// silently having no effect.
+	{
+		FTrajectoryTestFixture Fixture(/*Length=*/5000.0);
+		Fixture.Follow(MakeConfig([](FRichCurve& Curve)
+		{
+			Curve.AddKey(0.0f, 100.0f);
+			Curve.AddKey(4.0f, 100.0f);
+		}));
+		if (Fixture.Controller->SetSpeed(0.0))
+		{
+			AddError(TEXT("SetSpeed should refuse a trajectory that is not in ConstantSpeed mode"));
+		}
+	}
+
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingComponent.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingComponent.cpp
@@ -28,6 +28,22 @@ void UTrajectoryFollowingComponent::ConfigureAndFollow(ASplineActor* InSpline, c
 	StartFollowing();
 }
 
+bool UTrajectoryFollowingComponent::SetSpeed(double SpeedCmS)
+{
+	if (!Controller)
+	{
+		return false;
+	}
+	// Keep the component's own Config in step with the controller's, so a later StartFollowing
+	// (a reconfigure that leaves the speed model alone) does not resurrect the superseded speed.
+	if (!Controller->SetSpeed(SpeedCmS))
+	{
+		return false;
+	}
+	Config.Speed = FMath::Max(SpeedCmS, 0.0);
+	return true;
+}
+
 void UTrajectoryFollowingComponent::StartFollowing()
 {
 	if (!Spline)

--- a/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingComponent.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingComponent.cpp
@@ -40,7 +40,7 @@ bool UTrajectoryFollowingComponent::SetSpeed(double SpeedCmS)
 	{
 		return false;
 	}
-	Config.Speed = FMath::Max(SpeedCmS, 0.0);
+	Config.Speed = SpeedCmS;
 	return true;
 }
 

--- a/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingController.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingController.cpp
@@ -38,7 +38,8 @@ void ATrajectoryFollowingController::FollowTrajectory(ASplineActor* InSpline, AP
 	Spline = InSpline;
 	Config = InConfig;
 	ElapsedSeconds = 0.0;
-	RebuildSpeedDistanceCache();
+	DistanceAlongSpline = 0.0;
+	bReachedTrajectoryEnd = false;
 	VehicleVelocityController.Reset();
 	if (InPawn)
 	{
@@ -46,9 +47,47 @@ void ATrajectoryFollowingController::FollowTrajectory(ASplineActor* InSpline, AP
 	}
 }
 
-float ATrajectoryFollowingController::GetDuration() const
+bool ATrajectoryFollowingController::SetSpeed(double SpeedCmS)
 {
-	const USplineComponent* SplineComponent = Spline ? Spline->GetSpline() : nullptr;
+	if (Config.SpeedMode != ETrajectorySpeedMode::ConstantSpeed)
+	{
+		return false;
+	}
+	// Nothing to re-anchor: the target pose is sampled at DistanceAlongSpline, which this does not
+	// touch, so the new speed only changes how fast that distance grows from here on.
+	Config.Speed = FMath::Max(SpeedCmS, 0.0);
+	return true;
+}
+
+bool ATrajectoryFollowingController::IsArcLengthMode() const
+{
+	return Config.SpeedMode == ETrajectorySpeedMode::ConstantSpeed || Config.SpeedMode == ETrajectorySpeedMode::SpeedVsTime;
+}
+
+double ATrajectoryFollowingController::CurrentSpeed() const
+{
+	switch (Config.SpeedMode)
+	{
+	case ETrajectorySpeedMode::ConstantSpeed:
+		return FMath::Max(Config.Speed, 0.0);
+	case ETrajectorySpeedMode::SpeedVsTime:
+	{
+		// Signed on purpose: a negative key is how a speed curve drives back along the spline.
+		const FRichCurve* Curve = Config.TimeToSpeed.GetRichCurveConst();
+		return (Curve && Curve->GetNumKeys() > 0) ? Curve->Eval(ElapsedSeconds) : 0.0;
+	}
+	default:
+		return 0.0;
+	}
+}
+
+double ATrajectoryFollowingController::GetDistanceAlongSpline() const
+{
+	return IsArcLengthMode() ? DistanceAlongSpline : DistanceAtTime(ElapsedSeconds);
+}
+
+float ATrajectoryFollowingController::ClockDuration() const
+{
 	switch (Config.SpeedMode)
 	{
 	case ETrajectorySpeedMode::SplinePointVsTime:
@@ -59,8 +98,35 @@ float ATrajectoryFollowingController::GetDuration() const
 		return CurveMaxTime(Config.TimeToSpeed);
 	case ETrajectorySpeedMode::ConstantSpeed:
 	default:
-		return (!SplineComponent || Config.Speed <= 0.0) ? 0.0f : SplineComponent->GetSplineLength() / Config.Speed;
+		// No authored clock: a constant-speed trajectory ends where the spline does, however long
+		// that takes at whatever speeds it was driven at.
+		return 0.0f;
 	}
+}
+
+float ATrajectoryFollowingController::GetDuration() const
+{
+	if (Config.SpeedMode != ETrajectorySpeedMode::ConstantSpeed)
+	{
+		return ClockDuration();
+	}
+	const USplineComponent* SplineComponent = Spline ? Spline->GetSpline() : nullptr;
+	return (!SplineComponent || Config.Speed <= 0.0) ? 0.0f : SplineComponent->GetSplineLength() / Config.Speed;
+}
+
+void ATrajectoryFollowingController::RestartTrajectory(double SplineLength, float ClockEnd)
+{
+	// A constant-speed loop can carry its overshoot exactly, since distance is its only state, which
+	// keeps the follower's pace unbroken across the wrap. Anything driven by a curve restarts the
+	// curve instead: its speed (or geometry) is authored from t = 0, so resuming it part-way through
+	// would not be a loop.
+	if (Config.SpeedMode == ETrajectorySpeedMode::ConstantSpeed)
+	{
+		DistanceAlongSpline = SplineLength > 0.0 ? FMath::Fmod(DistanceAlongSpline, SplineLength) : 0.0;
+		return;
+	}
+	DistanceAlongSpline = 0.0;
+	ElapsedSeconds = ClockEnd > 0.0f ? FMath::Fmod(ElapsedSeconds, static_cast<double>(ClockEnd)) : 0.0;
 }
 
 FTransform ATrajectoryFollowingController::GetTransformAtTime(float Time) const
@@ -68,6 +134,17 @@ FTransform ATrajectoryFollowingController::GetTransformAtTime(float Time) const
 	const float Duration = GetDuration();
 	const float ClampedTime = FMath::Clamp(Time, 0.0f, FMath::Max(Duration, 0.0f));
 	return SampleAtTime(ClampedTime);
+}
+
+FTransform ATrajectoryFollowingController::GetTransformAtDistance(double Distance) const
+{
+	const USplineComponent* SplineComponent = Spline ? Spline->GetSpline() : nullptr;
+	if (!SplineComponent)
+	{
+		return FTransform::Identity;
+	}
+	const double ClampedDistance = FMath::Clamp(Distance, 0.0, SplineComponent->GetSplineLength());
+	return SplineComponent->GetTransformAtDistanceAlongSpline(ClampedDistance, ESplineCoordinateSpace::World);
 }
 
 FTransform ATrajectoryFollowingController::SampleAtTime(float Time) const
@@ -85,8 +162,7 @@ FTransform ATrajectoryFollowingController::SampleAtTime(float Time) const
 		return SplineComponent->GetTransformAtSplineInputKey(InputKey, ESplineCoordinateSpace::World);
 	}
 
-	const double Distance = DistanceAtTime(Time);
-	return SplineComponent->GetTransformAtDistanceAlongSpline(Distance, ESplineCoordinateSpace::World);
+	return GetTransformAtDistance(DistanceAtTime(Time));
 }
 
 double ATrajectoryFollowingController::DistanceAtTime(float Time) const
@@ -99,47 +175,13 @@ double ATrajectoryFollowingController::DistanceAtTime(float Time) const
 		return Curve ? Curve->Eval(Time) : 0.0;
 	}
 	case ETrajectorySpeedMode::SpeedVsTime:
-		return SpeedDistanceCache.GetNumKeys() > 0 ? SpeedDistanceCache.Eval(Time) : 0.0;
+		// Only an estimate: the follower integrates this curve tick by tick (see Tick), so the true
+		// distance depends on the deltas it was integrated over, not on Time alone. Reported as if
+		// the current speed had held throughout, for the benefit of GetTransformAtTime's callers.
+		return CurrentSpeed() * Time;
 	case ETrajectorySpeedMode::ConstantSpeed:
 	default:
 		return Config.Speed * Time;
-	}
-}
-
-void ATrajectoryFollowingController::RebuildSpeedDistanceCache()
-{
-	SpeedDistanceCache.Reset();
-
-	const FRichCurve* SpeedCurve = Config.TimeToSpeed.GetRichCurveConst();
-	if (!SpeedCurve || SpeedCurve->GetNumKeys() == 0)
-	{
-		return;
-	}
-
-	float MinTime = 0.0f;
-	float MaxTime = 0.0f;
-	SpeedCurve->GetTimeRange(MinTime, MaxTime);
-	MinTime = FMath::Max(MinTime, 0.0f);
-
-	SpeedDistanceCache.AddKey(MinTime, 0.0f);
-	if (MaxTime <= MinTime)
-	{
-		return;
-	}
-
-	// Trapezoidal integration of speed -> cumulative distance, sampled finely so any curve
-	// interpolation mode is captured well enough for runtime lookup.
-	constexpr int32 NumSamples = 256;
-	const float DeltaTime = (MaxTime - MinTime) / NumSamples;
-	double CumulativeDistance = 0.0;
-	float PrevSpeed = SpeedCurve->Eval(MinTime);
-	for (int32 SampleIndex = 1; SampleIndex <= NumSamples; ++SampleIndex)
-	{
-		const float SampleTime = MinTime + SampleIndex * DeltaTime;
-		const float SampleSpeed = SpeedCurve->Eval(SampleTime);
-		CumulativeDistance += 0.5 * (PrevSpeed + SampleSpeed) * DeltaTime;
-		SpeedDistanceCache.AddKey(SampleTime, static_cast<float>(CumulativeDistance));
-		PrevSpeed = SampleSpeed;
 	}
 }
 
@@ -153,35 +195,75 @@ void ATrajectoryFollowingController::Tick(float DeltaSeconds)
 		return;
 	}
 
-	ElapsedSeconds += DeltaSeconds;
-
-	// Apply end-of-trajectory behavior once the duration is reached.
-	bool bResetThisTick = false;
-	const float Duration = GetDuration();
-	if (Duration > 0.0f && ElapsedSeconds >= Duration)
+	const USplineComponent* SplineComponent = Spline->GetSpline();
+	if (!SplineComponent)
 	{
-		switch (Config.EndBehavior)
+		return;
+	}
+
+	// Advance the trajectory. The clock runs for every mode (the curves are functions of it); the
+	// arc-length modes additionally integrate the distance their speed carries the pawn over this
+	// tick, and it is that distance — not the clock — their target is sampled at. Integrating rather
+	// than recomputing distance from the clock is what lets the speed change mid-trajectory without
+	// the target jumping, and what makes speed 0 an ordinary value (the distance simply stops
+	// growing) rather than a division by zero.
+	//
+	// Nothing advances once the trajectory has ended and been clamped: both parameters stay at the
+	// end, so every subsequent tick re-targets the final pose. The clock in particular must stop,
+	// since a SpeedVsTime curve evaluated past its last key returns that key's speed and would
+	// otherwise keep driving the pawn down the spline forever.
+	const bool bArcLength = IsArcLengthMode();
+	const double SpeedThisTick = bReachedTrajectoryEnd ? 0.0 : CurrentSpeed();
+	const double SplineLength = SplineComponent->GetSplineLength();
+	bool bResetThisTick = false;
+	if (!bReachedTrajectoryEnd)
+	{
+		ElapsedSeconds += DeltaSeconds;
+		if (bArcLength)
 		{
-		case ETrajectoryEndBehavior::Clamp:
-			ElapsedSeconds = Duration;
-			break;
-		case ETrajectoryEndBehavior::Loop:
-			ElapsedSeconds = FMath::Fmod(ElapsedSeconds, Duration);
-			break;
-		case ETrajectoryEndBehavior::Reset:
-			ElapsedSeconds = FMath::Fmod(ElapsedSeconds, Duration);
-			bResetThisTick = true;
-			break;
-		case ETrajectoryEndBehavior::Destroy:
-			// Destroy the followed pawn once it reaches the end. Destroying the pawn tears down its
-			// UTrajectoryFollowingComponent, whose EndPlay unpossesses and destroys this controller,
-			// so return immediately without touching any more state.
-			ControlledPawn->Destroy();
-			return;
+			DistanceAlongSpline = FMath::Max(DistanceAlongSpline + SpeedThisTick * DeltaSeconds, 0.0);
+		}
+
+		// Apply end-of-trajectory behavior once the trajectory runs out, in whichever domain governs
+		// this mode: the arc-length modes end at the end of the spline, the time-domain modes when
+		// their curve runs out. Only one of the two can fire for most modes (ClockDuration is 0 for
+		// ConstantSpeed, and the time-domain modes never advance a distance), but SpeedVsTime ends on
+		// either, since its speed curve has an authored duration of its own and need not cover the
+		// whole spline.
+		const float ClockEnd = ClockDuration();
+		const bool bReachedSplineEnd = bArcLength && SplineLength > 0.0 && DistanceAlongSpline >= SplineLength;
+		const bool bReachedClockEnd = ClockEnd > 0.0f && ElapsedSeconds >= ClockEnd;
+		if (bReachedSplineEnd || bReachedClockEnd)
+		{
+			switch (Config.EndBehavior)
+			{
+			case ETrajectoryEndBehavior::Clamp:
+				// Give back the part of this tick that ran past the end, so the pawn holds the pose
+				// the trajectory actually ends at rather than one partial tick beyond it, then stop.
+				if (bReachedClockEnd)
+				{
+					DistanceAlongSpline -= SpeedThisTick * (ElapsedSeconds - ClockEnd);
+					ElapsedSeconds = ClockEnd;
+				}
+				DistanceAlongSpline = FMath::Clamp(DistanceAlongSpline, 0.0, SplineLength);
+				bReachedTrajectoryEnd = true;
+				break;
+			case ETrajectoryEndBehavior::Loop:
+			case ETrajectoryEndBehavior::Reset:
+				RestartTrajectory(SplineLength, ClockEnd);
+				bResetThisTick = Config.EndBehavior == ETrajectoryEndBehavior::Reset;
+				break;
+			case ETrajectoryEndBehavior::Destroy:
+				// Destroy the followed pawn once it reaches the end. Destroying the pawn tears down
+				// its UTrajectoryFollowingComponent, whose EndPlay unpossesses and destroys this
+				// controller, so return immediately without touching any more state.
+				ControlledPawn->Destroy();
+				return;
+			}
 		}
 	}
 
-	const FTransform Target = GetTransformAtTime(ElapsedSeconds);
+	const FTransform Target = bArcLength ? GetTransformAtDistance(DistanceAlongSpline) : GetTransformAtTime(ElapsedSeconds);
 	const FVector CurrentLocation = ControlledPawn->GetActorLocation();
 
 #if ENABLE_DRAW_DEBUG
@@ -210,9 +292,13 @@ void ATrajectoryFollowingController::Tick(float DeltaSeconds)
 		return;
 	}
 
-	// Feedforward: the trajectory's own velocity, from a forward finite difference.
+	// Feedforward: the trajectory's own velocity, from a forward finite difference. For the
+	// arc-length modes that difference is taken along the spline at the speed actually being
+	// integrated, so a held follower feeds forward exactly zero.
 	const float Lookahead = FMath::Max(DeltaSeconds, KINDA_SMALL_NUMBER);
-	const FVector AheadLocation = GetTransformAtTime(ElapsedSeconds + Lookahead).GetLocation();
+	const FVector AheadLocation = bArcLength
+		? GetTransformAtDistance(DistanceAlongSpline + SpeedThisTick * Lookahead).GetLocation()
+		: GetTransformAtTime(ElapsedSeconds + Lookahead).GetLocation();
 	const FVector FeedforwardVelocity = (AheadLocation - Target.GetLocation()) / Lookahead;
 
 	// Deadband: errors smaller than the band produce no corrective input, so the pawn coasts on the
@@ -234,8 +320,13 @@ void ATrajectoryFollowingController::Tick(float DeltaSeconds)
 		const FVector ToTargetLocal = ControlledPawn->GetActorTransform().InverseTransformVectorNoScale(Target.GetLocation() - CurrentLocation);
 
 		// Trajectory pace plus an along-track correction to catch up to / hang back from the target.
+		// Floored at zero: a follower that has overshot its target — which is the steady state of a
+		// held (0 speed) trajectory, and of one clamped at its end — should brake and stay put, not
+		// reverse back down the spline. ApplyChaosAccelInput already brakes rather than reverses
+		// while the vehicle is rolling forward, but a standing vehicle under a sustained negative
+		// command would shift into reverse.
 		const double AlongTrackError = ApplyDeadband(ToTargetLocal.X, Config.PositionDeadband);
-		const double TargetLinVelCmS = FeedforwardVelocity.Size() + Config.PositionGain * AlongTrackError;
+		const double TargetLinVelCmS = FMath::Max(FeedforwardVelocity.Size() + Config.PositionGain * AlongTrackError, 0.0);
 		// Steer toward the target point: heading error in the pawn's frame.
 		const double HeadingErrorDeg = ApplyDeadband(FMath::RadiansToDegrees(FMath::Atan2(ToTargetLocal.Y, ToTargetLocal.X)), Config.HeadingDeadband);
 		const double TargetYawRateDegS = Config.YawRateGain * HeadingErrorDeg;

--- a/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingController.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingController.cpp
@@ -54,8 +54,9 @@ bool ATrajectoryFollowingController::SetSpeed(double SpeedCmS)
 		return false;
 	}
 	// Nothing to re-anchor: the target pose is sampled at DistanceAlongSpline, which this does not
-	// touch, so the new speed only changes how fast that distance grows from here on.
-	Config.Speed = FMath::Max(SpeedCmS, 0.0);
+	// touch, so the new speed only changes how fast — and, if it is negative, which way — that
+	// distance moves from here on.
+	Config.Speed = SpeedCmS;
 	return true;
 }
 
@@ -69,10 +70,9 @@ double ATrajectoryFollowingController::CurrentSpeed() const
 	switch (Config.SpeedMode)
 	{
 	case ETrajectorySpeedMode::ConstantSpeed:
-		return FMath::Max(Config.Speed, 0.0);
+		return Config.Speed;
 	case ETrajectorySpeedMode::SpeedVsTime:
 	{
-		// Signed on purpose: a negative key is how a speed curve drives back along the spline.
 		const FRichCurve* Curve = Config.TimeToSpeed.GetRichCurveConst();
 		return (Curve && Curve->GetNumKeys() > 0) ? Curve->Eval(ElapsedSeconds) : 0.0;
 	}
@@ -221,6 +221,9 @@ void ATrajectoryFollowingController::Tick(float DeltaSeconds)
 		ElapsedSeconds += DeltaSeconds;
 		if (bArcLength)
 		{
+			// Floored at the spline's start: a follower driven backwards stops there and holds. That
+			// is deliberately not an end — only reaching the far end is, so a Destroy follower backed
+			// onto its start is not destroyed by it.
 			DistanceAlongSpline = FMath::Max(DistanceAlongSpline + SpeedThisTick * DeltaSeconds, 0.0);
 		}
 
@@ -300,6 +303,11 @@ void ATrajectoryFollowingController::Tick(float DeltaSeconds)
 		? GetTransformAtDistance(DistanceAlongSpline + SpeedThisTick * Lookahead).GetLocation()
 		: GetTransformAtTime(ElapsedSeconds + Lookahead).GetLocation();
 	const FVector FeedforwardVelocity = (AheadLocation - Target.GetLocation()) / Lookahead;
+	// The same feedforward as a signed speed *along the path*, by projecting it onto the path
+	// direction at the target (the target's rotation is the spline tangent). A magnitude would lose
+	// the one thing a reversing trajectory needs: which way along the spline the target is moving.
+	const double FeedforwardAlongPathCmS =
+		FVector::DotProduct(FeedforwardVelocity, Target.GetRotation().GetForwardVector());
 
 	// Deadband: errors smaller than the band produce no corrective input, so the pawn coasts on the
 	// feedforward instead of chasing tiny tracking errors. Zeros the error when within the band.
@@ -318,17 +326,24 @@ void ATrajectoryFollowingController::Tick(float DeltaSeconds)
 	if (bIsWheeledVehicle)
 	{
 		const FVector ToTargetLocal = ControlledPawn->GetActorTransform().InverseTransformVectorNoScale(Target.GetLocation() - CurrentLocation);
+		// Which way along the path the trajectory is taking the pawn. A reversing follower keeps its
+		// heading and backs up, so this is the trajectory's direction, not the pawn's.
+		const bool bReversing = FeedforwardAlongPathCmS < 0.0;
 
 		// Trajectory pace plus an along-track correction to catch up to / hang back from the target.
-		// Floored at zero: a follower that has overshot its target — which is the steady state of a
-		// held (0 speed) trajectory, and of one clamped at its end — should brake and stay put, not
-		// reverse back down the spline. ApplyChaosAccelInput already brakes rather than reverses
-		// while the vehicle is rolling forward, but a standing vehicle under a sustained negative
-		// command would shift into reverse.
+		// The correction may brake the pawn to a stop but not reverse its direction of travel: only a
+		// negative commanded speed does that. Without this a follower that has overshot its target —
+		// the steady state of a held (0 speed) trajectory, and of one clamped at its end — would sit
+		// there commanding reverse, and eventually get it.
 		const double AlongTrackError = ApplyDeadband(ToTargetLocal.X, Config.PositionDeadband);
-		const double TargetLinVelCmS = FMath::Max(FeedforwardVelocity.Size() + Config.PositionGain * AlongTrackError, 0.0);
-		// Steer toward the target point: heading error in the pawn's frame.
-		const double HeadingErrorDeg = ApplyDeadband(FMath::RadiansToDegrees(FMath::Atan2(ToTargetLocal.Y, ToTargetLocal.X)), Config.HeadingDeadband);
+		const double Corrected = FeedforwardAlongPathCmS + Config.PositionGain * AlongTrackError;
+		const double TargetLinVelCmS = bReversing ? FMath::Min(Corrected, 0.0) : FMath::Max(Corrected, 0.0);
+
+		// Steer toward the target point: heading error in the pawn's frame, measured against whichever
+		// end of the pawn leads. Backing up, the target is *behind*, so measuring it off the nose
+		// would read as a ~180 degree error and command a hard turn instead of a steering correction.
+		const FVector ToTargetAhead = bReversing ? -ToTargetLocal : ToTargetLocal;
+		const double HeadingErrorDeg = ApplyDeadband(FMath::RadiansToDegrees(FMath::Atan2(ToTargetAhead.Y, ToTargetAhead.X)), Config.HeadingDeadband);
 		const double TargetYawRateDegS = Config.YawRateGain * HeadingErrorDeg;
 
 		VehicleVelocityController.TrackBodyVelocity(ControlledPawn, TargetLinVelCmS, TargetYawRateDegS, DeltaSeconds);

--- a/TempoMovement/Source/TempoMovement/Private/WheeledVehicleVelocityController.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/WheeledVehicleVelocityController.cpp
@@ -38,9 +38,14 @@ bool FWheeledVehicleVelocityController::TrackBodyVelocity(APawn* Pawn, float Tar
 		{
 			CurrentYawRateDegS = AngVel->GetAngularVelocity().Z;
 		}
-		// Positive Chaos steering input = right turn = +yaw (Unreal left-handed). Same sign as the LH yaw error.
+		// Positive Chaos steering input = right turn = +yaw (Unreal left-handed). Same sign as the LH yaw
+		// error — but only going forwards: the steered axle trails when reversing, so a given steering
+		// input yields the opposite yaw rate and the loop has to change sign with it or it diverges,
+		// steering harder the further off it gets. Keyed off the *commanded* direction rather than the
+		// measured one, so it does not chatter around a standstill.
 		const float YawErrorDegS = TargetYawRateDegS - CurrentYawRateDegS;
-		const float NormSteer = FMath::Clamp(YawRateKp * YawErrorDegS, -1.0f, 1.0f);
+		const float SteeringSign = TargetLinVelCmS < 0.0f ? -1.0f : 1.0f;
+		const float NormSteer = FMath::Clamp(SteeringSign * YawRateKp * YawErrorDegS, -1.0f, 1.0f);
 
 		ChaosMovement->SetSteeringInput(NormSteer);
 		ApplyChaosAccelInput(ChaosMovement, NormAccel);

--- a/TempoMovement/Source/TempoMovement/Public/MovementControlService.proto
+++ b/TempoMovement/Source/TempoMovement/Public/MovementControlService.proto
@@ -149,8 +149,9 @@ message SetTrajectorySpeedRequest {
   // TrajectoryFollowingComponent that has been configured with ConfigureTrajectoryFollowing.
   string pawn = 1;
   // Speed along the spline, in meters/second. 0 holds the pawn where it is, indefinitely and
-  // without ending the trajectory; following resumes from the same point when a positive speed is
-  // set again. Negative speeds are clamped to 0.
+  // without ending the trajectory; following resumes from the same point when a speed is set again.
+  // Negative drives back along the spline — a steering follower reverses, keeping its heading rather
+  // than turning around — and stops at the spline's start without ending the trajectory.
   float speed = 2;
 }
 

--- a/TempoMovement/Source/TempoMovement/Public/MovementControlService.proto
+++ b/TempoMovement/Source/TempoMovement/Public/MovementControlService.proto
@@ -115,7 +115,9 @@ enum TrajectoryEndBehavior {
   TRAJECTORY_END_BEHAVIOR_LOOP = 2;
   // Teleport back to the start (even for a steering follower) and repeat.
   TRAJECTORY_END_BEHAVIOR_RESET = 3;
-  // Destroy the pawn when it reaches the end of the trajectory.
+  // Destroy the pawn when it reaches the end of the trajectory. As with every end behavior, that is
+  // when the *trajectory* reaches its end, not the pawn: a steering follower lags its target, so it
+  // is destroyed while still short of the spline's final point.
   TRAJECTORY_END_BEHAVIOR_DESTROY = 4;
 }
 

--- a/TempoMovement/Source/TempoMovement/Public/MovementControlService.proto
+++ b/TempoMovement/Source/TempoMovement/Public/MovementControlService.proto
@@ -127,7 +127,8 @@ message ConfigureTrajectoryFollowingRequest {
   string spline = 2;
   // How trajectory time maps onto the spline geometry. Exactly one must be set.
   oneof speed {
-    // Traverse the spline at a fixed speed, in meters/second.
+    // Traverse the spline at a fixed speed, in meters/second. Can be changed while following with
+    // SetTrajectorySpeed, which (unlike reconfiguring) does not restart the trajectory.
     float constant_speed = 3;
     // Map time to a spline input key (point index); value is the input key.
     TrajectoryCurve spline_point_vs_time = 4;
@@ -140,6 +141,17 @@ message ConfigureTrajectoryFollowingRequest {
   TrajectoryFollowMode follow_mode = 7;
   // Optional: behavior at the end of the trajectory. UNSPECIFIED keeps the follower's current behavior.
   TrajectoryEndBehavior end_behavior = 8;
+}
+
+// Change the speed of a trajectory already being followed, without restarting it.
+message SetTrajectorySpeedRequest {
+  // Identifier of the pawn whose trajectory to re-pace. The pawn must carry a
+  // TrajectoryFollowingComponent that has been configured with ConfigureTrajectoryFollowing.
+  string pawn = 1;
+  // Speed along the spline, in meters/second. 0 holds the pawn where it is, indefinitely and
+  // without ending the trajectory; following resumes from the same point when a positive speed is
+  // set again. Negative speeds are clamped to 0.
+  float speed = 2;
 }
 
 service MovementControlService {
@@ -160,4 +172,6 @@ service MovementControlService {
   rpc SetSplinePoints(SetSplinePointsRequest) returns (TempoCore.Empty);
 
   rpc ConfigureTrajectoryFollowing(ConfigureTrajectoryFollowingRequest) returns (TempoCore.Empty);
+
+  rpc SetTrajectorySpeed(SetTrajectorySpeedRequest) returns (TempoCore.Empty);
 }

--- a/TempoMovement/Source/TempoMovement/Public/TempoMovementControlServiceSubsystem.h
+++ b/TempoMovement/Source/TempoMovement/Public/TempoMovementControlServiceSubsystem.h
@@ -27,6 +27,7 @@ namespace TempoMovement
 	class PawnMoveToLocationResponse;
 	class SetSplinePointsRequest;
 	class ConfigureTrajectoryFollowingRequest;
+	class SetTrajectorySpeedRequest;
 }
 
 FORCEINLINE uint32 GetTypeHash(const FAIRequestID& AIRequestID)
@@ -69,6 +70,8 @@ public:
 	void SetSplinePoints(const TempoMovement::SetSplinePointsRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation) const;
 
 	void ConfigureTrajectoryFollowing(const TempoMovement::ConfigureTrajectoryFollowingRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation) const;
+
+	void SetTrajectorySpeed(const TempoMovement::SetTrajectorySpeedRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation) const;
 
 protected:
 	TMap<FAIRequestID, FPendingPawnMoveInfo> PendingPawnMoves;

--- a/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingComponent.h
+++ b/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingComponent.h
@@ -35,7 +35,8 @@ public:
 	void ConfigureAndFollow(ASplineActor* InSpline, const FTrajectoryFollowingConfig& InConfig);
 
 	// Change the ConstantSpeed speed (cm/s) of the trajectory already being followed, without
-	// restarting it or moving the pawn; 0 holds the pawn where it is. Used by the SetTrajectorySpeed
+	// restarting it or moving the pawn; 0 holds the pawn where it is, and a negative value drives it
+	// back along the spline (reversing, for a steering follower). Used by the SetTrajectorySpeed
 	// RPC to pace a follower against something outside the trajectory (an obstacle, a signal, a
 	// hand-off), which ConfigureAndFollow cannot do — it restarts following from the spline's start.
 	// Returns false if there is no controller yet or the trajectory is not in ConstantSpeed mode.

--- a/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingComponent.h
+++ b/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingComponent.h
@@ -34,6 +34,14 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Trajectory")
 	void ConfigureAndFollow(ASplineActor* InSpline, const FTrajectoryFollowingConfig& InConfig);
 
+	// Change the ConstantSpeed speed (cm/s) of the trajectory already being followed, without
+	// restarting it or moving the pawn; 0 holds the pawn where it is. Used by the SetTrajectorySpeed
+	// RPC to pace a follower against something outside the trajectory (an obstacle, a signal, a
+	// hand-off), which ConfigureAndFollow cannot do — it restarts following from the spline's start.
+	// Returns false if there is no controller yet or the trajectory is not in ConstantSpeed mode.
+	UFUNCTION(BlueprintCallable, Category = "Trajectory")
+	bool SetSpeed(double SpeedCmS);
+
 	const FTrajectoryFollowingConfig& GetConfig() const { return Config; }
 
 protected:

--- a/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
+++ b/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
@@ -126,7 +126,9 @@ struct FTrajectoryFollowingConfig
 //     (distance += speed * dt). Speed is therefore a live input: changing it takes effect on the next
 //     tick without moving the pawn, 0 holds it where it is, and a negative value drives back along
 //     the spline (a steering follower reverses, keeping its heading, rather than turning around).
-//     These modes end when the pawn reaches the end of the spline; backing up to the spline's start
+//     These modes end when that integrated distance reaches the end of the spline — the progress of
+//     the *target*, not the pawn's own position, so a steering follower that lags behind it (or has
+//     been shoved off the spline) neither delays nor skips the end. Backing up to the spline's start
 //     stops there but does not end the trajectory.
 //   * The time-domain modes (SplinePointVsTime, DistanceVsTime) are authored as functions of
 //     trajectory time, so they advance a clock (ElapsedSeconds) and end when their curve runs out.

--- a/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
+++ b/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
@@ -62,9 +62,11 @@ struct FTrajectoryFollowingConfig
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Trajectory")
 	ETrajectorySpeedMode SpeedMode = ETrajectorySpeedMode::ConstantSpeed;
 
-	// ConstantSpeed mode: speed along the spline, in cm/s. Settable while following via
-	// ATrajectoryFollowingController::SetSpeed (or the SetTrajectorySpeed RPC).
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Trajectory", meta = (EditCondition = "SpeedMode == ETrajectorySpeedMode::ConstantSpeed", EditConditionHides, ClampMin = 0.0))
+	// ConstantSpeed mode: speed along the spline, in cm/s. Negative drives back along the spline
+	// (a steering follower reverses; it keeps its heading and backs up rather than turning around).
+	// Settable while following via ATrajectoryFollowingController::SetSpeed (or the
+	// SetTrajectorySpeed RPC).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Trajectory", meta = (EditCondition = "SpeedMode == ETrajectorySpeedMode::ConstantSpeed", EditConditionHides))
 	double Speed = 100.0;
 
 	// SplinePointVsTime mode: maps time in seconds (X) to spline input key / point index (Y).
@@ -122,8 +124,10 @@ struct FTrajectoryFollowingConfig
 // differently:
 //   * The arc-length modes (ConstantSpeed, SpeedVsTime) integrate distance along the spline directly
 //     (distance += speed * dt). Speed is therefore a live input: changing it takes effect on the next
-//     tick without moving the pawn, and 0 holds it where it is. These modes end when the pawn reaches
-//     the end of the spline.
+//     tick without moving the pawn, 0 holds it where it is, and a negative value drives back along
+//     the spline (a steering follower reverses, keeping its heading, rather than turning around).
+//     These modes end when the pawn reaches the end of the spline; backing up to the spline's start
+//     stops there but does not end the trajectory.
 //   * The time-domain modes (SplinePointVsTime, DistanceVsTime) are authored as functions of
 //     trajectory time, so they advance a clock (ElapsedSeconds) and end when their curve runs out.
 // SpeedVsTime needs both: the clock to evaluate its speed curve, and the integrated distance to know
@@ -156,7 +160,8 @@ public:
 	// Set the ConstantSpeed speed (cm/s) while following, without moving the pawn or restarting the
 	// trajectory: the new speed takes effect on the next tick's integration step. 0 holds the pawn
 	// where it is on the spline, indefinitely and without ending the trajectory; following resumes
-	// from the same point when a positive speed is set again. Negative speeds are clamped to 0.
+	// from the same point when a speed is set again. Negative drives back along the spline, and stops
+	// at its start (which is a hold, not the end of the trajectory — only the far end is that).
 	// Only meaningful in ConstantSpeed mode; returns false (and changes nothing) in any other.
 	UFUNCTION(BlueprintCallable, Category = "Trajectory")
 	bool SetSpeed(double SpeedCmS);
@@ -225,8 +230,7 @@ protected:
 
 	// Speed along the spline (cm/s) the arc-length modes advance at right now: Config.Speed, or the
 	// speed curve evaluated at the current clock. 0 for the time-domain modes, which have no
-	// independent speed. May be negative in SpeedVsTime, which is how a curve drives back along the
-	// spline.
+	// independent speed. Signed: negative drives back along the spline.
 	double CurrentSpeed() const;
 
 private:

--- a/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
+++ b/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
@@ -19,14 +19,17 @@ class USplineComponent;
 UENUM(BlueprintType)
 enum class ETrajectorySpeedMode : uint8
 {
-	// Traverse the spline at a fixed speed: distance along the spline = Speed * time.
+	// Traverse the spline at a fixed speed, integrated per tick: distance += Speed * dt. Speed may be
+	// changed while following (see SetSpeed) and takes effect on the next tick, without moving the
+	// pawn or restarting the trajectory; 0 holds it in place.
 	ConstantSpeed,
 	// Map time to a spline input key (point index) via a curve, letting the path dwell,
 	// accelerate, decelerate, or reverse independently of arc length.
 	SplinePointVsTime,
 	// Map time directly to distance along the spline (cm) via a curve.
 	DistanceVsTime,
-	// Map time to speed along the spline (cm/s) via a curve; distance is its time integral.
+	// Map time to speed along the spline (cm/s) via a curve, integrated per tick:
+	// distance += TimeToSpeed(time) * dt. A negative value drives back along the spline.
 	SpeedVsTime,
 };
 
@@ -34,9 +37,9 @@ enum class ETrajectorySpeedMode : uint8
 UENUM(BlueprintType)
 enum class ETrajectoryEndBehavior : uint8
 {
-	// Hold the final pose (clamp time to the trajectory's duration).
+	// Hold the final pose (freeze progress at the end of the trajectory).
 	Clamp,
-	// Wrap back to the start (time modulo duration); a steering follower drives back to the start.
+	// Wrap back to the start of the spline; a steering follower drives back to the start.
 	Loop,
 	// Teleport the pawn (even a non-teleport/steering follower) back to the start and restart,
 	// repeating indefinitely.
@@ -59,7 +62,8 @@ struct FTrajectoryFollowingConfig
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Trajectory")
 	ETrajectorySpeedMode SpeedMode = ETrajectorySpeedMode::ConstantSpeed;
 
-	// ConstantSpeed mode: speed along the spline, in cm/s.
+	// ConstantSpeed mode: speed along the spline, in cm/s. Settable while following via
+	// ATrajectoryFollowingController::SetSpeed (or the SetTrajectorySpeed RPC).
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Trajectory", meta = (EditCondition = "SpeedMode == ETrajectorySpeedMode::ConstantSpeed", EditConditionHides, ClampMin = 0.0))
 	double Speed = 100.0;
 
@@ -110,10 +114,22 @@ struct FTrajectoryFollowingConfig
 	ETrajectoryEndBehavior EndBehavior = ETrajectoryEndBehavior::Clamp;
 };
 
-// Drives a possessed pawn along an ASplineActor. Each tick it samples the spline at the time since
-// following began (mapping time onto the spline via the config's speed model) and either teleports
-// the pawn to the target pose, or steers toward it (letting the pawn and its movement component
-// respond). In the non-teleport path the steering law adapts to the pawn:
+// Drives a possessed pawn along an ASplineActor. Each tick it advances its progress along the
+// trajectory, samples the spline there, and either teleports the pawn to the target pose or steers
+// toward it (letting the pawn and its movement component respond).
+//
+// How progress is tracked depends on the speed mode, because the two families are parameterized
+// differently:
+//   * The arc-length modes (ConstantSpeed, SpeedVsTime) integrate distance along the spline directly
+//     (distance += speed * dt). Speed is therefore a live input: changing it takes effect on the next
+//     tick without moving the pawn, and 0 holds it where it is. These modes end when the pawn reaches
+//     the end of the spline.
+//   * The time-domain modes (SplinePointVsTime, DistanceVsTime) are authored as functions of
+//     trajectory time, so they advance a clock (ElapsedSeconds) and end when their curve runs out.
+// SpeedVsTime needs both: the clock to evaluate its speed curve, and the integrated distance to know
+// where on the spline that puts the pawn.
+//
+// In the non-teleport path the steering law adapts to the pawn:
 //   * Wheeled vehicles (Chaos or kinematic) can't strafe, so the target is converted into a
 //     body-frame velocity (trajectory pace + along-track catch-up, plus a yaw rate that turns
 //     the vehicle toward the target) and tracked via VehicleVelocityController.
@@ -137,13 +153,37 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Trajectory")
 	void FollowTrajectory(ASplineActor* InSpline, APawn* InPawn, const FTrajectoryFollowingConfig& InConfig);
 
-	// World-space transform (location + tangent-aligned rotation) at the given time, in seconds,
-	// mapping time onto the spline geometry via the config's speed model. Time is clamped to
-	// [0, GetDuration()]; end-of-trajectory behavior (clamp/loop/reset) is applied in Tick.
+	// Set the ConstantSpeed speed (cm/s) while following, without moving the pawn or restarting the
+	// trajectory: the new speed takes effect on the next tick's integration step. 0 holds the pawn
+	// where it is on the spline, indefinitely and without ending the trajectory; following resumes
+	// from the same point when a positive speed is set again. Negative speeds are clamped to 0.
+	// Only meaningful in ConstantSpeed mode; returns false (and changes nothing) in any other.
+	UFUNCTION(BlueprintCallable, Category = "Trajectory")
+	bool SetSpeed(double SpeedCmS);
+
+	// World-space transform (location + tangent-aligned rotation) at the given trajectory time, in
+	// seconds. Only meaningful for the time-domain modes (SplinePointVsTime, DistanceVsTime), whose
+	// geometry is a function of time; for the arc-length modes (ConstantSpeed, SpeedVsTime) the pose
+	// depends on the integrated distance and the speeds it was integrated at, not on time alone, so
+	// this reports the pose the trajectory *would* reach at that time had it run at the current speed
+	// throughout. Prefer GetTransformAtDistance for those. Time is clamped to [0, GetDuration()];
+	// end-of-trajectory behavior (clamp/loop/reset) is applied in Tick.
 	UFUNCTION(BlueprintCallable, Category = "Trajectory")
 	FTransform GetTransformAtTime(float Time) const;
 
+	// World-space transform at a distance (cm) along the spline, clamped to the spline's length.
+	UFUNCTION(BlueprintCallable, Category = "Trajectory")
+	FTransform GetTransformAtDistance(double Distance) const;
+
+	// How far along the spline the pawn's target currently is, in cm. Only advances for the
+	// arc-length modes; for the time-domain modes it reports the distance implied by the clock.
+	UFUNCTION(BlueprintCallable, Category = "Trajectory")
+	double GetDistanceAlongSpline() const;
+
 	// Time to traverse the whole trajectory, in seconds. 0 if there is no spline or speed model.
+	// For ConstantSpeed this is an estimate at the *current* speed, not a commitment: it changes
+	// whenever the speed does, and no longer governs when the trajectory ends (reaching the end of
+	// the spline does). It is 0 while held at 0 speed, where the true duration is unbounded.
 	UFUNCTION(BlueprintCallable, Category = "Trajectory")
 	float GetDuration() const;
 
@@ -169,20 +209,42 @@ protected:
 	// Sample the trajectory at a time already normalized to [0, GetDuration()].
 	FTransform SampleAtTime(float Time) const;
 
-	// Distance along the spline (cm) at the given time, for the arc-length speed modes.
+	// Distance along the spline (cm) the time-domain modes' clock implies at the given time.
 	double DistanceAtTime(float Time) const;
 
-	// Integrate Config.TimeToSpeed into the cumulative SpeedDistanceCache (used by SpeedVsTime).
-	// Rebuilt whenever FollowTrajectory adopts a new config.
-	void RebuildSpeedDistanceCache();
+	// Whether this mode tracks progress as a distance along the spline (ConstantSpeed, SpeedVsTime)
+	// rather than as a position on a time-parameterized curve.
+	bool IsArcLengthMode() const;
+
+	// The time (seconds) at which this mode's authored curve runs out, and with it the trajectory.
+	// 0 for ConstantSpeed, which has no clock-driven end — it ends where the spline does.
+	float ClockDuration() const;
+
+	// Wrap progress back to the start for the Loop and Reset end behaviors.
+	void RestartTrajectory(double SplineLength, float ClockEnd);
+
+	// Speed along the spline (cm/s) the arc-length modes advance at right now: Config.Speed, or the
+	// speed curve evaluated at the current clock. 0 for the time-domain modes, which have no
+	// independent speed. May be negative in SpeedVsTime, which is how a curve drives back along the
+	// spline.
+	double CurrentSpeed() const;
 
 private:
 	// Time (seconds) elapsed along the trajectory, accumulated from the per-tick sim delta rather
 	// than absolute world time, so it holds steady whenever the simulation is paused or stepped.
-	// Reset to 0 when FollowTrajectory (re)starts following.
+	// The trajectory parameter for the time-domain modes; for SpeedVsTime it is only the argument
+	// its speed curve is evaluated at. Unused by ConstantSpeed. Reset to 0 when FollowTrajectory
+	// (re)starts following.
 	double ElapsedSeconds = 0.0;
 
-	// Cumulative distance (cm) vs. time, integrated from Config.TimeToSpeed for the SpeedVsTime mode.
-	// Runtime state, rebuilt in FollowTrajectory; not serialized.
-	FRichCurve SpeedDistanceCache;
+	// Set once the trajectory has run out under the Clamp end behavior, after which progress stops
+	// advancing entirely and the pawn holds the final pose. Cleared when FollowTrajectory (re)starts
+	// following, which is the only way to drive a clamped trajectory again.
+	bool bReachedTrajectoryEnd = false;
+
+	// Distance (cm) travelled along the spline, integrated per tick from CurrentSpeed() for the
+	// arc-length modes. This — not the clock — is what those modes' target pose is sampled at, which
+	// is why their speed can be changed mid-trajectory without the pose jumping. Reset to 0 when
+	// FollowTrajectory (re)starts following.
+	double DistanceAlongSpline = 0.0;
 };


### PR DESCRIPTION
  ## Live trajectory re-pacing: `SetTrajectorySpeed`

  A follower couldn't be re-paced once started. `ConfigureTrajectoryFollowing` restarts
  from the spline's start (it resets `ElapsedSeconds` to 0), so slowing, holding, or
  releasing a pawn part-way along its trajectory meant re-splining it from wherever it
  stood — which restarts the speed profile, and can't express a hold at all.

  The blocker was that `ConstantSpeed` derived position from the clock
  (`distance = Speed * ElapsedSeconds`), which makes speed retroactive: writing it
  mid-trajectory moves the target, and 0 isn't slow but degenerate — duration is
  `length / speed`, so `GetDuration()` collapsed to 0, `GetTransformAtTime` clamped into
  `[0, 0]`, and the pawn was sent back to the start of the spline.

  ### What changed

  - The arc-length modes (`ConstantSpeed`, `SpeedVsTime`) integrate distance per tick —
    `distance += speed * dt` — and sample the target there. Speed becomes an ordinary
    live input: it affects only the next increment, so the pose is continuous by
    construction with nothing to re-anchor, and 0 just stops the distance growing.
    `SpeedVsTime` integrates its curve the same way, retiring the 256-sample
    pre-integration cache. The time-domain modes (`SplinePointVsTime`, `DistanceVsTime`)
    are authored against time and keep the clock, unchanged.
  - End-of-trajectory splits the same way: the arc-length modes end when their integrated distance reaches the end of the spline — speed-independent, and measured on the trajectory's own progress rather than the pawn's position, so a steering follower that lags its target neither delays nor skips it — and no longer consult GetDuration()
  - `SetTrajectorySpeed(pawn, speed)` exposes this over gRPC in m/s, same units and
    meaning as `constant_speed`, with 0 as an indefinite hold that doesn't end the
    trajectory.
  - Speed is signed: negative drives back along the spline, floored at its start (backing
    onto the start holds there rather than ending, so a `Destroy` follower survives it).
    Reverse needed three fixes in the steering path, which had only ever been asked to go
    forwards: the feedforward was a magnitude, so a target moving backwards still
    commanded forward speed (it's now projected onto the path direction at the target);
    heading error is measured off the tail rather than the nose, so a target behind the
    pawn no longer reads as a ~180° error; and the Chaos yaw-rate loop's sign follows the
    commanded direction, since the steered axle trails in reverse and the loop otherwise
    diverged. The along-track correction is floored per-direction — it may brake to a
    stop, but only a negative commanded speed reverses the direction of travel.

  ### Testing

  `TempoTrajectoryFollowingTest` covers the follower for the first time: constant-speed
  integration, that `SetSpeed` neither moves nor rewinds the pawn, hold and release at 0,
  reverse, the speed-curve integral, both ways a `SpeedVsTime` trajectory can end, and
  each of the four end behaviors (which had no coverage before this moved them into
  distance space).

  Teleport-mode reverse is covered there. The three steering-path fixes are reasoned but
  unexercised — there's no vehicle in the automation-test world — so they want a look in
  sim before anything leans on them.