### PR TITLE
Stream trajectory-end events

### DIFF
--- a/TempoMovement/Source/TempoMovement/Private/TempoMovementControlServiceSubsystem.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TempoMovementControlServiceSubsystem.cpp
@@ -17,6 +17,7 @@
 #include "AIController.h"
 #include "Components/SplineComponent.h"
 #include "Curves/CurveFloat.h"
+#include "Engine/World.h"
 #include "GameFramework/Pawn.h"
 #include "Kismet/GameplayStatics.h"
 #include "NavigationSystem.h"
@@ -33,6 +34,8 @@ using NavigablePawnsResponse = TempoMovement::NavigablePawnsResponse;
 using SetSplinePointsRequest = TempoMovement::SetSplinePointsRequest;
 using ConfigureTrajectoryFollowingRequest = TempoMovement::ConfigureTrajectoryFollowingRequest;
 using SetTrajectorySpeedRequest = TempoMovement::SetTrajectorySpeedRequest;
+using TrajectoryEndEventRequest = TempoMovement::TrajectoryEndEventRequest;
+using TrajectoryEndEventResponse = TempoMovement::TrajectoryEndEventResponse;
 using TempoEmpty = TempoCore::Empty;
 
 namespace
@@ -134,6 +137,31 @@ namespace
 		}
 		return Curve;
 	}
+
+	TempoMovement::TrajectoryEndBehavior ToProto(ETrajectoryEndBehavior EndBehavior)
+	{
+		switch (EndBehavior)
+		{
+		case ETrajectoryEndBehavior::Clamp:
+			return TempoMovement::TRAJECTORY_END_BEHAVIOR_CLAMP;
+		case ETrajectoryEndBehavior::Loop:
+			return TempoMovement::TRAJECTORY_END_BEHAVIOR_LOOP;
+		case ETrajectoryEndBehavior::Reset:
+			return TempoMovement::TRAJECTORY_END_BEHAVIOR_RESET;
+		case ETrajectoryEndBehavior::Destroy:
+			return TempoMovement::TRAJECTORY_END_BEHAVIOR_DESTROY;
+		}
+		return TempoMovement::TRAJECTORY_END_BEHAVIOR_UNSPECIFIED;
+	}
+
+	TrajectoryEndEventResponse ToProto(const FTrajectoryEndEvent& Event, const FString& PawnName, const UWorld* World)
+	{
+		TrajectoryEndEventResponse Response;
+		Response.set_pawn(TCHAR_TO_UTF8(*PawnName));
+		Response.set_timestamp_s(World ? World->GetTimeSeconds() : 0.0);
+		Response.set_end_behavior(ToProto(Event.EndBehavior));
+		return Response;
+	}
 }
 
 void UTempoMovementControlServiceSubsystem::RegisterServices(FTempoServer& Server)
@@ -148,7 +176,8 @@ void UTempoMovementControlServiceSubsystem::RegisterServices(FTempoServer& Serve
 		SimpleRequestHandler(&MovementControlAsyncService::RequestRebuildNavigation, &UTempoMovementControlServiceSubsystem::RebuildNavigation),
 		SimpleRequestHandler(&MovementControlAsyncService::RequestSetSplinePoints, &UTempoMovementControlServiceSubsystem::SetSplinePoints),
 		SimpleRequestHandler(&MovementControlAsyncService::RequestConfigureTrajectoryFollowing, &UTempoMovementControlServiceSubsystem::ConfigureTrajectoryFollowing),
-		SimpleRequestHandler(&MovementControlAsyncService::RequestSetTrajectorySpeed, &UTempoMovementControlServiceSubsystem::SetTrajectorySpeed)
+		SimpleRequestHandler(&MovementControlAsyncService::RequestSetTrajectorySpeed, &UTempoMovementControlServiceSubsystem::SetTrajectorySpeed),
+		StreamingRequestHandler(&MovementControlAsyncService::RequestStreamTrajectoryEndEvents, &UTempoMovementControlServiceSubsystem::StreamTrajectoryEndEvents)
 		);
 }
 
@@ -565,4 +594,69 @@ void UTempoMovementControlServiceSubsystem::SetTrajectorySpeed(const SetTrajecto
 	}
 
 	ResponseContinuation.ExecuteIfBound(TempoEmpty(), grpc::Status_OK);
+}
+
+void UTempoMovementControlServiceSubsystem::StreamTrajectoryEndEvents(const TrajectoryEndEventRequest& Request, const TResponseDelegate<TrajectoryEndEventResponse>& ResponseContinuation)
+{
+	APawn* Pawn = FindPawn(GetWorld(), UTF8_TO_TCHAR(Request.pawn().c_str()));
+	if (!Pawn)
+	{
+		ResponseContinuation.ExecuteIfBound(TrajectoryEndEventResponse(), grpc::Status(grpc::StatusCode::NOT_FOUND, "Did not find a pawn with the specified name"));
+		return;
+	}
+
+	UTrajectoryFollowingComponent* FollowingComponent = Pawn->FindComponentByClass<UTrajectoryFollowingComponent>();
+	if (!FollowingComponent)
+	{
+		ResponseContinuation.ExecuteIfBound(TrajectoryEndEventResponse(), grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "Pawn does not have a TrajectoryFollowingComponent"));
+		return;
+	}
+
+	PendingTrajectoryEndRequests.FindOrAdd(UTempoCoreUtils::GetActorIdentifier(Pawn)).Add(ResponseContinuation);
+	// Both bindings are for the pawn's lifetime, not this one request: the component outlives any
+	// single trajectory, so repeat subscriptions must not stack duplicate handlers.
+	if (!FollowingComponent->OnTrajectoryEnd.IsBoundToObject(this))
+	{
+		FollowingComponent->OnTrajectoryEnd.AddUObject(this, &UTempoMovementControlServiceSubsystem::OnTrajectoryEnd);
+	}
+	Pawn->OnDestroyed.AddUniqueDynamic(this, &UTempoMovementControlServiceSubsystem::OnWatchedPawnDestroyed);
+}
+
+void UTempoMovementControlServiceSubsystem::OnTrajectoryEnd(const FTrajectoryEndEvent& Event)
+{
+	if (!Event.Pawn)
+	{
+		return;
+	}
+	const FString PawnName = UTempoCoreUtils::GetActorIdentifier(Event.Pawn);
+	TArray<TResponseDelegate<TrajectoryEndEventResponse>> ResponseContinuations;
+	if (!PendingTrajectoryEndRequests.RemoveAndCopyValue(PawnName, ResponseContinuations))
+	{
+		// Nobody waiting. The component's delegate stays bound for the pawn's life, so this is the
+		// ordinary case between one client request and the next.
+		return;
+	}
+
+	const TrajectoryEndEventResponse Response = ToProto(Event, PawnName, GetWorld());
+	for (const auto& ResponseContinuation : ResponseContinuations)
+	{
+		ResponseContinuation.ExecuteIfBound(Response, grpc::Status_OK);
+	}
+}
+
+void UTempoMovementControlServiceSubsystem::OnWatchedPawnDestroyed(AActor* DestroyedActor)
+{
+	TArray<TResponseDelegate<TrajectoryEndEventResponse>> ResponseContinuations;
+	if (!PendingTrajectoryEndRequests.RemoveAndCopyValue(UTempoCoreUtils::GetActorIdentifier(DestroyedActor), ResponseContinuations))
+	{
+		return;
+	}
+
+	// Reached only when the pawn goes away without its trajectory ending -- destroyed by a client, or
+	// with the world. The Destroy end behavior raises its own event first, which consumes the entry
+	// above, so it does not come through here.
+	for (const auto& ResponseContinuation : ResponseContinuations)
+	{
+		ResponseContinuation.ExecuteIfBound(TrajectoryEndEventResponse(), grpc::Status(grpc::StatusCode::ABORTED, "Pawn was destroyed before its trajectory ended"));
+	}
 }

--- a/TempoMovement/Source/TempoMovement/Private/Tests/TempoTrajectoryFollowingTest.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/Tests/TempoTrajectoryFollowingTest.cpp
@@ -471,16 +471,12 @@ bool FTempoTrajectoryEndEventTest::RunTest(const FString& Parameters)
 	struct FRecorder
 	{
 		TArray<FTrajectoryEndEvent> Events;
-		// Sampled at the event rather than read back later: the Destroy end behavior destroys the
-		// pawn immediately afterwards, so by the time a test looks, it never is valid.
-		TArray<bool> PawnValidWhenRaised;
 
 		void Watch(UTrajectoryFollowingComponent* Component)
 		{
 			Component->OnTrajectoryEnd.AddLambda([this](const FTrajectoryEndEvent& Event)
 			{
 				Events.Add(Event);
-				PawnValidWhenRaised.Add(IsValid(Event.Pawn));
 			});
 		}
 	};
@@ -547,9 +543,17 @@ bool FTempoTrajectoryEndEventTest::RunTest(const FString& Parameters)
 	// Destroy: the event goes out before the pawn does, so a subscriber can still identify it.
 	{
 		FRecorder Recorder;
+		// Whether the pawn was alive is sampled at the event, not read back afterwards: Destroy
+		// destroys it on the very next line, so by the time the assertions run it never is.
+		bool bPawnAliveAtEvent = false;
 		FTrajectoryTestFixture Fixture;
 		Recorder.Watch(Fixture.Component);
 		APawn* const WatchedPawn = Fixture.Pawn;
+		Fixture.Component->OnTrajectoryEnd.AddLambda(
+			[&bPawnAliveAtEvent, WatchedPawn](const FTrajectoryEndEvent& Event)
+			{
+				bPawnAliveAtEvent = Event.Pawn == WatchedPawn && IsValid(Event.Pawn);
+			});
 		FTrajectoryFollowingConfig Config = FTrajectoryTestFixture::ConstantSpeedConfig(1000.0);
 		Config.EndBehavior = ETrajectoryEndBehavior::Destroy;
 		Fixture.Follow(Config);
@@ -558,7 +562,7 @@ bool FTempoTrajectoryEndEventTest::RunTest(const FString& Parameters)
 		{
 			AddError(FString::Printf(TEXT("Destroy should raise exactly one end event, got %d"), Recorder.Events.Num()));
 		}
-		else if (Recorder.Events[0].Pawn != WatchedPawn || !Recorder.PawnValidWhenRaised[0])
+		if (!bPawnAliveAtEvent)
 		{
 			AddError(TEXT("Destroy's end event should name the pawn, and be raised while it is still valid"));
 		}
@@ -583,7 +587,7 @@ bool FTempoTrajectoryEndEventTest::RunTest(const FString& Parameters)
 		}
 	}
 
-	// Re-following raises a fresh event for the new trajectory, not a repeat of the old one.
+	// Each trajectory raises its own end event, and reconfiguring does not raise one of its own.
 	{
 		FRecorder Recorder;
 		FTrajectoryTestFixture Fixture;

--- a/TempoMovement/Source/TempoMovement/Private/Tests/TempoTrajectoryFollowingTest.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/Tests/TempoTrajectoryFollowingTest.cpp
@@ -1,6 +1,7 @@
 // Copyright Tempo Simulation, LLC. All Rights Reserved
 
 #include "SplineActor.h"
+#include "TrajectoryFollowingComponent.h"
 #include "TrajectoryFollowingController.h"
 
 #include "Components/SplineComponent.h"
@@ -45,6 +46,10 @@ namespace
 		ASplineActor* SplineActor = nullptr;
 		APawn* Pawn = nullptr;
 		ATrajectoryFollowingController* Controller = nullptr;
+		// Present so the pawn has somewhere for its end events to be raised: the controller hands each
+		// one to its pawn's UTrajectoryFollowingComponent. Not otherwise used — the tests drive the
+		// controller directly, so this component never spawns a controller of its own.
+		UTrajectoryFollowingComponent* Component = nullptr;
 
 		explicit FTrajectoryTestFixture(double Length = TestSplineLength)
 		{
@@ -67,6 +72,10 @@ namespace
 			USceneComponent* Root = NewObject<USceneComponent>(Pawn);
 			Pawn->SetRootComponent(Root);
 			Root->RegisterComponent();
+
+			Component = NewObject<UTrajectoryFollowingComponent>(Pawn, TEXT("TrajectoryFollowing"));
+			Pawn->AddInstanceComponent(Component);
+			Component->RegisterComponent();
 
 			Controller = World->SpawnActor<ATrajectoryFollowingController>();
 		}
@@ -442,6 +451,156 @@ bool FTempoTrajectorySpeedVsTimeTest::RunTest(const FString& Parameters)
 		if (Fixture.Controller->SetSpeed(0.0))
 		{
 			AddError(TEXT("SetSpeed should refuse a trajectory that is not in ConstantSpeed mode"));
+		}
+	}
+
+	return true;
+}
+
+//
+// End events. One per trajectory end, for every end behavior, raised while the pawn is still alive.
+//
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoTrajectoryEndEventTest,
+	"Tempo.Movement.TrajectoryFollowing.EndEvent", TempoTrajectoryTestFlags)
+bool FTempoTrajectoryEndEventTest::RunTest(const FString& Parameters)
+{
+	// Records every end event raised on the pawn's component, which is where the controller sends
+	// them. Declared before the fixture in each case below, so it outlives the component holding the
+	// lambda that writes to it.
+	struct FRecorder
+	{
+		TArray<FTrajectoryEndEvent> Events;
+		// Sampled at the event rather than read back later: the Destroy end behavior destroys the
+		// pawn immediately afterwards, so by the time a test looks, it never is valid.
+		TArray<bool> PawnValidWhenRaised;
+
+		void Watch(UTrajectoryFollowingComponent* Component)
+		{
+			Component->OnTrajectoryEnd.AddLambda([this](const FTrajectoryEndEvent& Event)
+			{
+				Events.Add(Event);
+				PawnValidWhenRaised.Add(IsValid(Event.Pawn));
+			});
+		}
+	};
+
+	// Clamp: exactly one event, at the end of the spline — and it keeps holding without raising
+	// another.
+	{
+		FRecorder Recorder;
+		FTrajectoryTestFixture Fixture;
+		Recorder.Watch(Fixture.Component);
+		Fixture.Follow(FTrajectoryTestFixture::ConstantSpeedConfig(1000.0));
+		Fixture.Tick(5);
+		if (Recorder.Events.Num() != 0)
+		{
+			AddError(TEXT("No end event should be raised before the end of the spline"));
+		}
+		Fixture.Tick(20);
+		if (Recorder.Events.Num() != 1)
+		{
+			AddError(FString::Printf(TEXT("Clamp should raise exactly one end event, got %d"), Recorder.Events.Num()));
+		}
+		else
+		{
+			const FTrajectoryEndEvent& Event = Recorder.Events[0];
+			if (Event.Pawn != Fixture.Pawn)
+			{
+				AddError(TEXT("The end event should name the followed pawn"));
+			}
+			if (Event.EndBehavior != ETrajectoryEndBehavior::Clamp)
+			{
+				AddError(TEXT("Clamp's end event should report Clamp"));
+			}
+		}
+		Fixture.Tick(20);
+		if (Recorder.Events.Num() > 1)
+		{
+			AddError(TEXT("A clamped trajectory should not keep raising end events while it holds"));
+		}
+	}
+
+	// Loop: an event per lap, each reporting Loop — the trajectory ends and carries on.
+	{
+		FRecorder Recorder;
+		FTrajectoryTestFixture Fixture;
+		Recorder.Watch(Fixture.Component);
+		FTrajectoryFollowingConfig Config = FTrajectoryTestFixture::ConstantSpeedConfig(1000.0);
+		Config.EndBehavior = ETrajectoryEndBehavior::Loop;
+		Fixture.Follow(Config);
+		// 2.5 s at 1000 cm/s over a 1000 cm spline: two laps completed.
+		Fixture.Tick(25);
+		if (Recorder.Events.Num() != 2)
+		{
+			AddError(FString::Printf(TEXT("Loop should raise one end event per lap (expected 2), got %d"), Recorder.Events.Num()));
+		}
+		for (const FTrajectoryEndEvent& Event : Recorder.Events)
+		{
+			if (Event.EndBehavior != ETrajectoryEndBehavior::Loop)
+			{
+				AddError(TEXT("A lap's end event should report Loop"));
+			}
+		}
+	}
+
+	// Destroy: the event goes out before the pawn does, so a subscriber can still identify it.
+	{
+		FRecorder Recorder;
+		FTrajectoryTestFixture Fixture;
+		Recorder.Watch(Fixture.Component);
+		APawn* const WatchedPawn = Fixture.Pawn;
+		FTrajectoryFollowingConfig Config = FTrajectoryTestFixture::ConstantSpeedConfig(1000.0);
+		Config.EndBehavior = ETrajectoryEndBehavior::Destroy;
+		Fixture.Follow(Config);
+		Fixture.Tick(20);
+		if (Recorder.Events.Num() != 1)
+		{
+			AddError(FString::Printf(TEXT("Destroy should raise exactly one end event, got %d"), Recorder.Events.Num()));
+		}
+		else if (Recorder.Events[0].Pawn != WatchedPawn || !Recorder.PawnValidWhenRaised[0])
+		{
+			AddError(TEXT("Destroy's end event should name the pawn, and be raised while it is still valid"));
+		}
+		if (IsValid(Fixture.Pawn))
+		{
+			AddError(TEXT("Destroy should still destroy the pawn"));
+		}
+	}
+
+	// A held trajectory never ends, so it never raises the event.
+	{
+		FRecorder Recorder;
+		FTrajectoryTestFixture Fixture;
+		Recorder.Watch(Fixture.Component);
+		Fixture.Follow(FTrajectoryTestFixture::ConstantSpeedConfig(1000.0));
+		Fixture.Tick(5);
+		Fixture.Controller->SetSpeed(0.0);
+		Fixture.Tick(200);
+		if (Recorder.Events.Num() != 0)
+		{
+			AddError(FString::Printf(TEXT("A held trajectory should raise no end event, got %d"), Recorder.Events.Num()));
+		}
+	}
+
+	// Re-following raises a fresh event for the new trajectory, not a repeat of the old one.
+	{
+		FRecorder Recorder;
+		FTrajectoryTestFixture Fixture;
+		Recorder.Watch(Fixture.Component);
+		Fixture.Follow(FTrajectoryTestFixture::ConstantSpeedConfig(1000.0));
+		Fixture.Tick(20);
+		Fixture.Follow(FTrajectoryTestFixture::ConstantSpeedConfig(1000.0));
+		if (Recorder.Events.Num() != 1)
+		{
+			AddError(TEXT("Re-following should not raise an end event of its own"));
+		}
+		Fixture.Tick(20);
+		if (Recorder.Events.Num() != 2)
+		{
+			AddError(FString::Printf(
+				TEXT("The second trajectory should raise its own end event (expected 2 total), got %d"),
+				Recorder.Events.Num()));
 		}
 	}
 

--- a/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingComponent.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingComponent.cpp
@@ -44,6 +44,11 @@ bool UTrajectoryFollowingComponent::SetSpeed(double SpeedCmS)
 	return true;
 }
 
+void UTrajectoryFollowingComponent::NotifyTrajectoryEnd(const FTrajectoryEndEvent& Event)
+{
+	OnTrajectoryEnd.Broadcast(Event);
+}
+
 void UTrajectoryFollowingComponent::StartFollowing()
 {
 	if (!Spline)

--- a/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingController.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingController.cpp
@@ -61,20 +61,17 @@ bool ATrajectoryFollowingController::SetSpeed(double SpeedCmS)
 	return true;
 }
 
-void ATrajectoryFollowingController::NotifyTrajectoryEnd(APawn* EndedPawn)
+void ATrajectoryFollowingController::NotifyTrajectoryEnd()
 {
+	APawn* EndedPawn = GetPawn();
 	FTrajectoryEndEvent Event;
 	Event.Pawn = EndedPawn;
-	// EndBehavior is also what tells a subscriber whether to expect another event: Loop and Reset
-	// carry on and end again, Clamp and Destroy do not.
 	Event.EndBehavior = Config.EndBehavior;
 
-	// The component owns the event, because it is what a subscriber can find and bind to on a pawn
-	// whose trajectory has not been configured yet — this controller may not have existed then.
 	// Located the same way the movement service locates it, so both agree which component speaks for
 	// a pawn.
 	if (UTrajectoryFollowingComponent* Component =
-			EndedPawn ? EndedPawn->FindComponentByClass<UTrajectoryFollowingComponent>() : nullptr)
+			EndedPawn->FindComponentByClass<UTrajectoryFollowingComponent>())
 	{
 		Component->NotifyTrajectoryEnd(Event);
 	}
@@ -279,14 +276,14 @@ void ATrajectoryFollowingController::Tick(float DeltaSeconds)
 			case ETrajectoryEndBehavior::Destroy:
 				// Destroy the followed pawn once it reaches the end. Destroying the pawn tears down
 				// its UTrajectoryFollowingComponent, whose EndPlay unpossesses and destroys this
-				// controller, so notify first — while there is still a pawn to name and a delegate to
-				// raise it on — and return immediately without touching any more state.
-				NotifyTrajectoryEnd(ControlledPawn);
+				// controller, so notify before any of that goes away, and return immediately without
+				// touching any more state.
+				NotifyTrajectoryEnd();
 				ControlledPawn->Destroy();
 				return;
 			}
 
-			NotifyTrajectoryEnd(ControlledPawn);
+			NotifyTrajectoryEnd();
 		}
 	}
 

--- a/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingController.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingController.cpp
@@ -4,6 +4,7 @@
 
 #include "KinematicVehicleMovementComponent.h"
 #include "SplineActor.h"
+#include "TrajectoryFollowingComponent.h"
 
 #include "ChaosVehicleMovementComponent.h"
 #include "Components/SplineComponent.h"
@@ -58,6 +59,25 @@ bool ATrajectoryFollowingController::SetSpeed(double SpeedCmS)
 	// distance moves from here on.
 	Config.Speed = SpeedCmS;
 	return true;
+}
+
+void ATrajectoryFollowingController::NotifyTrajectoryEnd(APawn* EndedPawn)
+{
+	FTrajectoryEndEvent Event;
+	Event.Pawn = EndedPawn;
+	// EndBehavior is also what tells a subscriber whether to expect another event: Loop and Reset
+	// carry on and end again, Clamp and Destroy do not.
+	Event.EndBehavior = Config.EndBehavior;
+
+	// The component owns the event, because it is what a subscriber can find and bind to on a pawn
+	// whose trajectory has not been configured yet — this controller may not have existed then.
+	// Located the same way the movement service locates it, so both agree which component speaks for
+	// a pawn.
+	if (UTrajectoryFollowingComponent* Component =
+			EndedPawn ? EndedPawn->FindComponentByClass<UTrajectoryFollowingComponent>() : nullptr)
+	{
+		Component->NotifyTrajectoryEnd(Event);
+	}
 }
 
 bool ATrajectoryFollowingController::IsArcLengthMode() const
@@ -259,10 +279,14 @@ void ATrajectoryFollowingController::Tick(float DeltaSeconds)
 			case ETrajectoryEndBehavior::Destroy:
 				// Destroy the followed pawn once it reaches the end. Destroying the pawn tears down
 				// its UTrajectoryFollowingComponent, whose EndPlay unpossesses and destroys this
-				// controller, so return immediately without touching any more state.
+				// controller, so notify first — while there is still a pawn to name and a delegate to
+				// raise it on — and return immediately without touching any more state.
+				NotifyTrajectoryEnd(ControlledPawn);
 				ControlledPawn->Destroy();
 				return;
 			}
+
+			NotifyTrajectoryEnd(ControlledPawn);
 		}
 	}
 

--- a/TempoMovement/Source/TempoMovement/Public/MovementControlService.proto
+++ b/TempoMovement/Source/TempoMovement/Public/MovementControlService.proto
@@ -157,6 +157,28 @@ message SetTrajectorySpeedRequest {
   float speed = 2;
 }
 
+// Request the stream of trajectory-end events for one pawn.
+message TrajectoryEndEventRequest {
+  // Identifier of the pawn to watch. The pawn must carry a TrajectoryFollowingComponent, but need
+  // not be following anything yet — subscribing before ConfigureTrajectoryFollowing is the way to
+  // be sure of catching the end of a short trajectory.
+  string pawn = 1;
+}
+
+// Emitted each time a follower's trajectory reaches its end, whatever end behavior is configured.
+// This is the *trajectory* ending — the progress of the point the pawn is being driven toward — not
+// the pawn arriving anywhere: a steering follower lags its target, so it is still short of the final
+// point when this fires.
+message TrajectoryEndEventResponse {
+  // Identifier of the pawn whose trajectory ended (matches the request's `pawn`).
+  string pawn = 1;
+  // Sim time at which it ended, in seconds.
+  double timestamp_s = 2;
+  // The end behavior that was applied, which is also what says whether to expect another event:
+  // CLAMP and DESTROY end the following, LOOP and RESET carry on and end again next lap.
+  TrajectoryEndBehavior end_behavior = 3;
+}
+
 service MovementControlService {
   rpc GetCommandablePawns(TempoCore.Empty) returns (CommandablePawnsResponse);
 
@@ -177,4 +199,12 @@ service MovementControlService {
   rpc ConfigureTrajectoryFollowing(ConfigureTrajectoryFollowingRequest) returns (TempoCore.Empty);
 
   rpc SetTrajectorySpeed(SetTrajectorySpeedRequest) returns (TempoCore.Empty);
+
+  // Stream the pawn's trajectory-end events. The stream carries one message per end, so a CLAMP or
+  // DESTROY follower produces exactly one and a LOOP or RESET follower one per lap; it stays open
+  // across reconfiguration, reporting the end of each trajectory the pawn is given in turn. It
+  // carries the ends that happen while it is open and keeps no history, so subscribe before
+  // configuring the trajectory whose end you care about. A destroyed pawn ends the stream with
+  // ABORTED — including under the DESTROY end behavior, whose own event is sent first.
+  rpc StreamTrajectoryEndEvents(TrajectoryEndEventRequest) returns (stream TrajectoryEndEventResponse);
 }

--- a/TempoMovement/Source/TempoMovement/Public/TempoMovementControlServiceSubsystem.h
+++ b/TempoMovement/Source/TempoMovement/Public/TempoMovementControlServiceSubsystem.h
@@ -5,6 +5,9 @@
 #include "TempoServiceProvider.h"
 #include "TempoServer.h"
 #include "TempoSubsystems.h"
+// For FTrajectoryEndEvent, which OnTrajectoryEnd takes by value through a UFUNCTION and so needs
+// complete rather than forward-declared.
+#include "TrajectoryFollowingController.h"
 
 #include "CoreMinimal.h"
 #include "Navigation/PathFollowingComponent.h"
@@ -28,6 +31,8 @@ namespace TempoMovement
 	class SetSplinePointsRequest;
 	class ConfigureTrajectoryFollowingRequest;
 	class SetTrajectorySpeedRequest;
+	class TrajectoryEndEventRequest;
+	class TrajectoryEndEventResponse;
 }
 
 FORCEINLINE uint32 GetTypeHash(const FAIRequestID& AIRequestID)
@@ -73,9 +78,24 @@ public:
 
 	void SetTrajectorySpeed(const TempoMovement::SetTrajectorySpeedRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation) const;
 
+	void StreamTrajectoryEndEvents(const TempoMovement::TrajectoryEndEventRequest& Request, const TResponseDelegate<TempoMovement::TrajectoryEndEventResponse>& ResponseContinuation);
+
 protected:
 	TMap<FAIRequestID, FPendingPawnMoveInfo> PendingPawnMoves;
 
 	UFUNCTION()
 	void OnPawnMoveCompleted(FAIRequestID RequestID, EPathFollowingResult::Type Result);
+
+	// Bound to UTrajectoryFollowingComponent::OnTrajectoryEnd, a plain C++ delegate, so this needs no
+	// UFUNCTION (unlike OnWatchedPawnDestroyed, which hangs off a dynamic one).
+	void OnTrajectoryEnd(const FTrajectoryEndEvent& Event);
+
+	// Finishes any stream still waiting on a pawn that has gone away, rather than leaving its client
+	// waiting for an event that can no longer happen.
+	UFUNCTION()
+	void OnWatchedPawnDestroyed(AActor* DestroyedActor);
+
+	// Streams awaiting a trajectory-end event, keyed by pawn identifier. Each entry is consumed when
+	// the event fires (or the pawn is destroyed); the client's next request re-adds one.
+	TMap<FString, TArray<TResponseDelegate<TempoMovement::TrajectoryEndEventResponse>>> PendingTrajectoryEndRequests;
 };

--- a/TempoMovement/Source/TempoMovement/Public/TempoMovementControlServiceSubsystem.h
+++ b/TempoMovement/Source/TempoMovement/Public/TempoMovementControlServiceSubsystem.h
@@ -5,9 +5,6 @@
 #include "TempoServiceProvider.h"
 #include "TempoServer.h"
 #include "TempoSubsystems.h"
-// For FTrajectoryEndEvent, which OnTrajectoryEnd takes by value through a UFUNCTION and so needs
-// complete rather than forward-declared.
-#include "TrajectoryFollowingController.h"
 
 #include "CoreMinimal.h"
 #include "Navigation/PathFollowingComponent.h"
@@ -18,6 +15,8 @@ namespace TempoCore
 {
 	class Empty;
 }
+
+struct FTrajectoryEndEvent;
 
 namespace TempoMovement
 {
@@ -86,8 +85,8 @@ protected:
 	UFUNCTION()
 	void OnPawnMoveCompleted(FAIRequestID RequestID, EPathFollowingResult::Type Result);
 
-	// Bound to UTrajectoryFollowingComponent::OnTrajectoryEnd, a plain C++ delegate, so this needs no
-	// UFUNCTION (unlike OnWatchedPawnDestroyed, which hangs off a dynamic one).
+	// Bound to UTrajectoryFollowingComponent::OnTrajectoryEnd for every watched pawn; the event's
+	// Pawn is what says which one an end belongs to.
 	void OnTrajectoryEnd(const FTrajectoryEndEvent& Event);
 
 	// Finishes any stream still waiting on a pawn that has gone away, rather than leaving its client

--- a/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingComponent.h
+++ b/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingComponent.h
@@ -12,6 +12,24 @@
 
 class ASplineActor;
 
+// One trajectory-end occurrence: a follower's progress reached the end of its trajectory, and its
+// end behavior was applied. Reported for every end behavior, so a caller can react to the end itself
+// rather than inferring it from a duration or polling the pawn's position.
+//
+// The end is the *trajectory's*, not the pawn's: it is the integrated progress of the point the pawn
+// is driven toward that has reached the end of the spline, and a steering follower lags that point,
+// so it is still short of the final pose when this fires.
+struct FTrajectoryEndEvent
+{
+	// The pawn whose trajectory ended. Still valid when the event fires, including under Destroy,
+	// which destroys it immediately afterwards.
+	APawn* Pawn = nullptr;
+
+	// The end behavior that was applied. Also says whether to expect another event: Loop and Reset
+	// carry on and end again next lap, Clamp and Destroy do not.
+	ETrajectoryEndBehavior EndBehavior = ETrajectoryEndBehavior::Clamp;
+};
+
 // Raised on each trajectory end (see FTrajectoryEndEvent). Declared here rather than on the
 // controller because this component is what a subscriber can find on a pawn: it is present from the
 // moment it is added, whereas the controller is not spawned until a spline has been configured, and

--- a/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingComponent.h
+++ b/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingComponent.h
@@ -12,6 +12,12 @@
 
 class ASplineActor;
 
+// Raised on each trajectory end (see FTrajectoryEndEvent). Declared here rather than on the
+// controller because this component is what a subscriber can find on a pawn: it is present from the
+// moment it is added, whereas the controller is not spawned until a spline has been configured, and
+// one binding here covers every trajectory the pawn is subsequently given.
+DECLARE_MULTICAST_DELEGATE_OneParam(FTrajectoryEndSignature, const FTrajectoryEndEvent&);
+
 // Add to a pawn to have it follow an ASplineActor. On BeginPlay (and whenever reconfigured) it spawns
 // a ATrajectoryFollowingController, hands it the spline, this pawn, and Config, and lets the
 // controller possess and drive the pawn. Because the spline is referenced (not owned), several pawns
@@ -42,6 +48,15 @@ public:
 	// Returns false if there is no controller yet or the trajectory is not in ConstantSpeed mode.
 	UFUNCTION(BlueprintCallable, Category = "Trajectory")
 	bool SetSpeed(double SpeedCmS);
+
+	// Raised each time this pawn's trajectory reaches its end, whatever end behavior is configured,
+	// and before that behavior's own effects — so a Destroy subscriber is notified while the pawn is
+	// still alive.
+	FTrajectoryEndSignature OnTrajectoryEnd;
+
+	// Raise OnTrajectoryEnd. Called by the controller driving this pawn, which is where the end is
+	// detected; not meant for anyone else.
+	void NotifyTrajectoryEnd(const FTrajectoryEndEvent& Event);
 
 	const FTrajectoryFollowingConfig& GetConfig() const { return Config; }
 

--- a/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
+++ b/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
@@ -48,6 +48,30 @@ enum class ETrajectoryEndBehavior : uint8
 	Destroy,
 };
 
+// One trajectory-end occurrence: a follower's progress reached the end of its trajectory, and its
+// end behavior was applied. Reported for every end behavior, so a caller can react to the end itself
+// rather than inferring it from a duration or polling the pawn's position.
+//
+// The end is the *trajectory's*, not the pawn's: it is the integrated progress of the point the pawn
+// is driven toward that has reached the end of the spline, and a steering follower lags that point,
+// so it is still short of the final pose when this fires.
+USTRUCT(BlueprintType)
+struct FTrajectoryEndEvent
+{
+	GENERATED_BODY()
+
+	// The pawn whose trajectory ended. Still valid when the event fires, including under Destroy,
+	// which destroys it immediately afterwards.
+	UPROPERTY(BlueprintReadOnly, Category = "Trajectory")
+	APawn* Pawn = nullptr;
+
+	// The end behavior that was applied.
+	UPROPERTY(BlueprintReadOnly, Category = "Trajectory")
+	ETrajectoryEndBehavior EndBehavior = ETrajectoryEndBehavior::Clamp;
+
+};
+
+
 // Per-follower settings governing how a pawn follows a spline: the speed model that turns trajectory
 // time into a point on the spline, plus how the pawn is driven to that point. Authored on a
 // UTrajectoryFollowingComponent (or set over the ConfigureTrajectoryFollowing RPC) and copied onto
@@ -234,6 +258,11 @@ protected:
 	// speed curve evaluated at the current clock. 0 for the time-domain modes, which have no
 	// independent speed. Signed: negative drives back along the spline.
 	double CurrentSpeed() const;
+
+	// Assemble the end event for a trajectory that has just run out and hand it to the pawn's
+	// UTrajectoryFollowingComponent to raise, if it has one. A manually-wired controller (see
+	// FollowTrajectory) need not have one, in which case the end goes unannounced.
+	void NotifyTrajectoryEnd(APawn* EndedPawn);
 
 private:
 	// Time (seconds) elapsed along the trajectory, accumulated from the per-tick sim delta rather

--- a/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
+++ b/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
@@ -48,30 +48,6 @@ enum class ETrajectoryEndBehavior : uint8
 	Destroy,
 };
 
-// One trajectory-end occurrence: a follower's progress reached the end of its trajectory, and its
-// end behavior was applied. Reported for every end behavior, so a caller can react to the end itself
-// rather than inferring it from a duration or polling the pawn's position.
-//
-// The end is the *trajectory's*, not the pawn's: it is the integrated progress of the point the pawn
-// is driven toward that has reached the end of the spline, and a steering follower lags that point,
-// so it is still short of the final pose when this fires.
-USTRUCT(BlueprintType)
-struct FTrajectoryEndEvent
-{
-	GENERATED_BODY()
-
-	// The pawn whose trajectory ended. Still valid when the event fires, including under Destroy,
-	// which destroys it immediately afterwards.
-	UPROPERTY(BlueprintReadOnly, Category = "Trajectory")
-	APawn* Pawn = nullptr;
-
-	// The end behavior that was applied.
-	UPROPERTY(BlueprintReadOnly, Category = "Trajectory")
-	ETrajectoryEndBehavior EndBehavior = ETrajectoryEndBehavior::Clamp;
-
-};
-
-
 // Per-follower settings governing how a pawn follows a spline: the speed model that turns trajectory
 // time into a point on the spline, plus how the pawn is driven to that point. Authored on a
 // UTrajectoryFollowingComponent (or set over the ConfigureTrajectoryFollowing RPC) and copied onto
@@ -259,10 +235,10 @@ protected:
 	// independent speed. Signed: negative drives back along the spline.
 	double CurrentSpeed() const;
 
-	// Assemble the end event for a trajectory that has just run out and hand it to the pawn's
-	// UTrajectoryFollowingComponent to raise, if it has one. A manually-wired controller (see
+	// Assemble the end event for a trajectory that has just run out and hand it to the possessed
+	// pawn's UTrajectoryFollowingComponent to raise, if it has one. A manually-wired controller (see
 	// FollowTrajectory) need not have one, in which case the end goes unannounced.
-	void NotifyTrajectoryEnd(APawn* EndedPawn);
+	void NotifyTrajectoryEnd();
 
 private:
 	// Time (seconds) elapsed along the trajectory, accumulated from the per-tick sim delta rather


### PR DESCRIPTION
A client had no way to learn that a follower had finished its trajectory. The only signals were the pawn's pose, which lags the trajectory and never quite reaches its last point under Drive mode, and the trajectory's nominal duration, which is now a poor proxy for anything: it is an estimate at the current speed, and a follower re-paced with SetTrajectorySpeed (held at 0, or reversed) can take arbitrarily longer than it, or never arrive.

So the controller now raises FOnTrajectoryEnd as it applies its end behavior, for every behavior. Destroy notifies before it destroys the pawn, while there is still a pawn to name.

The event is raised on the controller, which is where the end is detected, and re-broadcast by UTrajectoryFollowingComponent, which is what subscribers should use: the component is on the pawn from the moment it is added, whereas the controller is not spawned until a spline has been configured, and one binding to the component covers every trajectory the pawn is subsequently given.

StreamTrajectoryEndEvents exposes it over gRPC, with one thing a plain event-to-stream bridge would get wrong: a pawn destroyed while a client waits ends the stream with ABORTED, rather than leaving it waiting for an event that can no longer happen. This is for the pawn a *client* destroys; the Destroy end behavior's own event goes out first and consumes the request before its teardown reaches here.