### PR TITLE
Drive a trajectory that runs against the pawn's heading in reverse

### DIFF
--- a/TempoMovement/Source/TempoMovement/Private/Tests/TempoTrajectoryFollowingTest.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/Tests/TempoTrajectoryFollowingTest.cpp
@@ -611,4 +611,54 @@ bool FTempoTrajectoryEndEventTest::RunTest(const FString& Parameters)
 	return true;
 }
 
+//
+// The wheeled-vehicle command law. Steering a real vehicle needs a movement component and physics,
+// so what is pinned here is the law itself: how the trajectory's pace and the along-track error
+// combine into a body-frame forward speed, and which way that speed points.
+//
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoTrajectoryBodySpeedTest,
+	"Tempo.Movement.TrajectoryFollowing.BodySpeed", TempoTrajectoryTestFlags)
+bool FTempoTrajectoryBodySpeedTest::RunTest(const FString& Parameters)
+{
+	constexpr double Gain = 1.0;
+	auto Speed = [](double FeedforwardBodyCmS, double AlongTrackErrorCm, bool bReversing)
+	{
+		return ATrajectoryFollowingController::ComputeBodyForwardSpeed(
+			FeedforwardBodyCmS, AlongTrackErrorCm, Gain, bReversing);
+	};
+	auto Near = [this](const TCHAR* What, double A, double B)
+	{
+		if (!FMath::IsNearlyEqual(A, B, KINDA_SMALL_NUMBER))
+		{
+			AddError(FString::Printf(TEXT("%s: expected %.4f, got %.4f"), What, B, A));
+		}
+	};
+
+	// Driving forwards: the pace, plus catch-up when the target is ahead of the nose.
+	Near(TEXT("Forwards, on pace"), Speed(100.0, 0.0, /*bReversing=*/false), 100.0);
+	Near(TEXT("Forwards, lagging"), Speed(100.0, 50.0, /*bReversing=*/false), 150.0);
+
+	// Overshot while driving forwards: brake to a stop, but never back up to fix it.
+	Near(TEXT("Forwards, overshot"), Speed(100.0, -200.0, /*bReversing=*/false), 0.0);
+	Near(TEXT("Held, overshot"), Speed(0.0, -200.0, /*bReversing=*/false), 0.0);
+
+	// A leg whose path runs against the pawn's heading feeds forward a *negative* body speed, and the
+	// error to a target behind the nose is negative too: the two now agree, where projecting the
+	// feedforward onto the path instead would have them cancel. The pawn backs up at its own pace
+	// plus catch-up, rather than stalling once the target is gain * feedforward behind it.
+	Near(TEXT("Reversing, on pace"), Speed(-100.0, 0.0, /*bReversing=*/true), -100.0);
+	Near(TEXT("Reversing, lagging"), Speed(-100.0, -300.0, /*bReversing=*/true), -400.0);
+
+	// Reversing and overshot: the mirror image — brake, do not pull forwards again.
+	Near(TEXT("Reversing, overshot"), Speed(-100.0, 200.0, /*bReversing=*/true), 0.0);
+
+	// Held at the end of a reverse leg (feedforward gone) but still short of the target: the latched
+	// direction is what keeps it closing. Re-deriving the direction from this zero feedforward would
+	// read "forwards" and clamp the pawn where it stands, stranding it short of the target.
+	Near(TEXT("Reversing, held, still short"), Speed(0.0, -50.0, /*bReversing=*/true), -50.0);
+
+	return true;
+}
+
 #endif // WITH_DEV_AUTOMATION_TESTS

--- a/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingController.cpp
+++ b/TempoMovement/Source/TempoMovement/Private/TrajectoryFollowingController.cpp
@@ -27,6 +27,11 @@ namespace
 		RichCurve->GetTimeRange(MinTime, MaxTime);
 		return MaxTime;
 	}
+
+	// Feedforward speeds (cm/s) below this are treated as carrying no direction of travel: a held or
+	// clamped trajectory feeds forward zero, and its sign is then only floating-point noise. Matches
+	// the standstill threshold the vehicle velocity controller uses.
+	constexpr double DirectionOfTravelThresholdCmS = 1.0;
 }
 
 ATrajectoryFollowingController::ATrajectoryFollowingController()
@@ -41,6 +46,7 @@ void ATrajectoryFollowingController::FollowTrajectory(ASplineActor* InSpline, AP
 	ElapsedSeconds = 0.0;
 	DistanceAlongSpline = 0.0;
 	bReachedTrajectoryEnd = false;
+	bReversingLeg = false;
 	VehicleVelocityController.Reset();
 	if (InPawn)
 	{
@@ -202,6 +208,13 @@ double ATrajectoryFollowingController::DistanceAtTime(float Time) const
 	}
 }
 
+double ATrajectoryFollowingController::ComputeBodyForwardSpeed(
+	double FeedforwardBodyCmS, double AlongTrackErrorCm, double PositionGain, bool bReversing)
+{
+	const double Corrected = FeedforwardBodyCmS + PositionGain * AlongTrackErrorCm;
+	return bReversing ? FMath::Min(Corrected, 0.0) : FMath::Max(Corrected, 0.0);
+}
+
 void ATrajectoryFollowingController::Tick(float DeltaSeconds)
 {
 	Super::Tick(DeltaSeconds);
@@ -324,11 +337,6 @@ void ATrajectoryFollowingController::Tick(float DeltaSeconds)
 		? GetTransformAtDistance(DistanceAlongSpline + SpeedThisTick * Lookahead).GetLocation()
 		: GetTransformAtTime(ElapsedSeconds + Lookahead).GetLocation();
 	const FVector FeedforwardVelocity = (AheadLocation - Target.GetLocation()) / Lookahead;
-	// The same feedforward as a signed speed *along the path*, by projecting it onto the path
-	// direction at the target (the target's rotation is the spline tangent). A magnitude would lose
-	// the one thing a reversing trajectory needs: which way along the spline the target is moving.
-	const double FeedforwardAlongPathCmS =
-		FVector::DotProduct(FeedforwardVelocity, Target.GetRotation().GetForwardVector());
 
 	// Deadband: errors smaller than the band produce no corrective input, so the pawn coasts on the
 	// feedforward instead of chasing tiny tracking errors. Zeros the error when within the band.
@@ -346,24 +354,41 @@ void ATrajectoryFollowingController::Tick(float DeltaSeconds)
 
 	if (bIsWheeledVehicle)
 	{
-		const FVector ToTargetLocal = ControlledPawn->GetActorTransform().InverseTransformVectorNoScale(Target.GetLocation() - CurrentLocation);
-		// Which way along the path the trajectory is taking the pawn. A reversing follower keeps its
-		// heading and backs up, so this is the trajectory's direction, not the pawn's.
-		const bool bReversing = FeedforwardAlongPathCmS < 0.0;
+		const FTransform PawnTransform = ControlledPawn->GetActorTransform();
+		const FVector ToTargetLocal = PawnTransform.InverseTransformVectorNoScale(Target.GetLocation() - CurrentLocation);
+		// The trajectory's own velocity as a signed speed along the pawn's *nose*, which is the frame
+		// the along-track error below is measured in and the frame the vehicle is commanded in.
+		// Projecting it onto the path instead mixes frames: where the path runs against the pawn's
+		// heading the two disagree about which way is forward, and the feedforward then subtracts from
+		// the very correction that is trying to follow it (settling |error| = feedforward / gain short).
+		const double FeedforwardBodyCmS = PawnTransform.InverseTransformVectorNoScale(FeedforwardVelocity).X;
+		// Which way the pawn has to travel to follow this leg: backwards whenever the trajectory
+		// carries its target towards the pawn's tail — because the commanded speed is negative, or
+		// because the path itself runs against the pawn's heading. A reversing follower keeps its
+		// heading and backs up rather than turning around.
+		//
+		// Latched, and only updated while the trajectory is actually moving: the feedforward vanishes
+		// wherever a trajectory is held (0 speed) or clamped at its end, and a vanished feedforward
+		// carries no direction. The direction of travel is a property of the leg, not of the instant,
+		// and reading it off a zero would silently reset it to "forwards" exactly where the pawn is
+		// still creeping the last of a reverse leg in.
+		if (FMath::Abs(FeedforwardBodyCmS) > DirectionOfTravelThresholdCmS)
+		{
+			bReversingLeg = FeedforwardBodyCmS < 0.0;
+		}
 
 		// Trajectory pace plus an along-track correction to catch up to / hang back from the target.
-		// The correction may brake the pawn to a stop but not reverse its direction of travel: only a
-		// negative commanded speed does that. Without this a follower that has overshot its target —
-		// the steady state of a held (0 speed) trajectory, and of one clamped at its end — would sit
-		// there commanding reverse, and eventually get it.
+		// The correction may brake the pawn to a stop but not reverse its direction of travel, so a
+		// follower that has *overshot* its target holds where it is rather than backing up to fix it —
+		// which is also what keeps a follower held at 0 speed, or clamped at its end, from creeping.
 		const double AlongTrackError = ApplyDeadband(ToTargetLocal.X, Config.PositionDeadband);
-		const double Corrected = FeedforwardAlongPathCmS + Config.PositionGain * AlongTrackError;
-		const double TargetLinVelCmS = bReversing ? FMath::Min(Corrected, 0.0) : FMath::Max(Corrected, 0.0);
+		const double TargetLinVelCmS = ComputeBodyForwardSpeed(
+			FeedforwardBodyCmS, AlongTrackError, Config.PositionGain, bReversingLeg);
 
 		// Steer toward the target point: heading error in the pawn's frame, measured against whichever
 		// end of the pawn leads. Backing up, the target is *behind*, so measuring it off the nose
 		// would read as a ~180 degree error and command a hard turn instead of a steering correction.
-		const FVector ToTargetAhead = bReversing ? -ToTargetLocal : ToTargetLocal;
+		const FVector ToTargetAhead = bReversingLeg ? -ToTargetLocal : ToTargetLocal;
 		const double HeadingErrorDeg = ApplyDeadband(FMath::RadiansToDegrees(FMath::Atan2(ToTargetAhead.Y, ToTargetAhead.X)), Config.HeadingDeadband);
 		const double TargetYawRateDegS = Config.YawRateGain * HeadingErrorDeg;
 

--- a/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
+++ b/TempoMovement/Source/TempoMovement/Public/TrajectoryFollowingController.h
@@ -138,7 +138,11 @@ struct FTrajectoryFollowingConfig
 // In the non-teleport path the steering law adapts to the pawn:
 //   * Wheeled vehicles (Chaos or kinematic) can't strafe, so the target is converted into a
 //     body-frame velocity (trajectory pace + along-track catch-up, plus a yaw rate that turns
-//     the vehicle toward the target) and tracked via VehicleVelocityController.
+//     the vehicle toward the target) and tracked via VehicleVelocityController. Every quantity in
+//     that law lives in the pawn's own frame, including the feedforward, so a leg whose path runs
+//     against the pawn's heading is driven in reverse — heading held, tail leading — rather than
+//     turned around. Which way the pawn travels is latched per leg (see bReversingLeg), because a
+//     trajectory that is held or clamped feeds forward nothing to read a direction from.
 //   * Other pawns use AddMovementInput, which drives translation only, so their heading is
 //     governed by their movement component, not the trajectory's orientation.
 // Only bTeleport reproduces the target rotation exactly.
@@ -186,6 +190,14 @@ public:
 	// arc-length modes; for the time-domain modes it reports the distance implied by the clock.
 	UFUNCTION(BlueprintCallable, Category = "Trajectory")
 	double GetDistanceAlongSpline() const;
+
+	// Body-frame forward speed (cm/s) to command so the pawn tracks its target: the trajectory's own
+	// pace plus a proportional along-track correction, both measured along the pawn's nose (+x), where
+	// bReversing says which end of the pawn leads. The correction may brake the pawn to a stop but
+	// never reverse its direction of travel, so a follower that has overshot holds rather than backing
+	// up, while one that is still short of its target keeps closing. Pure; exposed for testing.
+	static double ComputeBodyForwardSpeed(
+		double FeedforwardBodyCmS, double AlongTrackErrorCm, double PositionGain, bool bReversing);
 
 	// Time to traverse the whole trajectory, in seconds. 0 if there is no spline or speed model.
 	// For ConstantSpeed this is an estimate at the *current* speed, not a commitment: it changes
@@ -252,6 +264,15 @@ private:
 	// advancing entirely and the pawn holds the final pose. Cleared when FollowTrajectory (re)starts
 	// following, which is the only way to drive a clamped trajectory again.
 	bool bReachedTrajectoryEnd = false;
+
+	// Which way the pawn is travelling along the current leg: true once the trajectory is carrying its
+	// target towards the pawn's tail, so following means reversing (heading held) rather than turning
+	// around. Latched rather than recomputed every tick, because the feedforward it is read from
+	// vanishes wherever a trajectory is held at 0 speed or clamped at its end — precisely where a
+	// reverse leg is still creeping its last few cm in, and where re-deriving it would flip the pawn
+	// to "forwards" and strand it short. Reset to forwards when FollowTrajectory (re)starts following;
+	// flips as soon as the trajectory moves the other way (e.g. after SetSpeed changes sign).
+	bool bReversingLeg = false;
 
 	// Distance (cm) travelled along the spline, integrated per tick from CurrentSpeed() for the
 	// arc-length modes. This — not the clock — is what those modes' target pose is sampled at, which


### PR DESCRIPTION
A wheeled follower whose path runs against its own heading stalls instead of backing up: it creeps forward a few tenths of a metre, then holds until the leg times out. Both causes are in the body-frame command law added by #550.

  1. Mixed frames. Corrected = FeedforwardAlongPathCmS + PositionGain * AlongTrackError adds a speed measured along the path to an error measured along the pawn's nose. Where the two disagree about which way is forward, the feedforward subtracts from the correction that is trying to follow it, leaving the pawn stalled feedforward / gain short.
  2. Direction of travel read from an instant. bReversing = FeedforwardAlongPathCmS < 0 is the sign of the commanded speed, so it only ever describes a negative-speed leg — never a positive-speed leg on a path that runs backwards relative to the pawn. It also vanishes wherever a trajectory is held or clamped, which is exactly where a reverse leg is still creeping its last few cm in.

  Changes

  - Project the feedforward onto the pawn's nose rather than the path tangent, so it composes with the along-track error and the vehicle command in one frame.
  - Replace bReversing with bReversingLeg: latched state meaning "this leg is driven tail-first", updated only while |feedforward| > 1 cm/s so a held or clamped trajectory cannot reset it. Reset in FollowTrajectory; flips as soon as the trajectory moves
    the other way, so SetSpeed sign changes still work as documented.
  - Extract the law as a pure ATrajectoryFollowingController::ComputeBodyForwardSpeed and pin it with a new automation test.

  The clamp rule is unchanged in intent — the correction may brake the pawn but never reverse its direction of travel — but it is now applied against the leg's actual direction instead of an instantaneous feedforward.

  Behavior changes

  - Legs clamped short now close. A reverse leg held at its end keeps closing on its target instead of freezing, so resting poses land up to PositionDeadband (10 cm) nearer the endpoint. Lets a reposition finish by arrival rather than on its caller's timeout.
  - A pawn yawed >90° off its path now backs along it instead of stalling. The latch keys on the path direction vs the nose, not on where the target sits, so a vehicle tracking an ordinary curve never flips — a momentary along-track overshoot mid-curve
    still just brakes. Only a path tighter than the vehicle can steer reverses, where it previously deadlocked.
  - Unchanged: a path perpendicular to the heading feeds forward ≈0 along the nose, so the latch does not update and the pawn holds. A bicycle model cannot make that move; noting it as a known no-op rather than a regression.