### PR TITLE
Expose TempoSensors Configuration API

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoActorLabeler.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoActorLabeler.cpp
@@ -15,6 +15,7 @@
 #include "DefaultActorClassifier.h"
 
 #include "EngineUtils.h"
+#include "Misc/FileHelper.h"
 #include "Components/InstancedStaticMeshComponent.h"
 #include "NiagaraComponent.h"
 #include "NiagaraEmitter.h"
@@ -112,7 +113,11 @@ void UTempoActorLabeler::RegisterServices(FTempoServer& Server)
 		SimpleRequestHandler(&LabelAsyncService::RequestGetSemanticClasses, &UTempoActorLabeler::HandleGetSemanticClasses),
 		SimpleRequestHandler(&LabelAsyncService::RequestSetActorTypeSemanticId, &UTempoActorLabeler::HandleSetActorTypeSemanticId),
 		SimpleRequestHandler(&LabelAsyncService::RequestGetAllStaticMeshTypes, &UTempoActorLabeler::HandleGetAllStaticMeshTypes),
-		SimpleRequestHandler(&LabelAsyncService::RequestSetStaticMeshTypeSemanticId, &UTempoActorLabeler::HandleSetStaticMeshTypeSemanticId)
+		SimpleRequestHandler(&LabelAsyncService::RequestSetStaticMeshTypeSemanticId, &UTempoActorLabeler::HandleSetStaticMeshTypeSemanticId),
+		SimpleRequestHandler(&LabelAsyncService::RequestSetLabelType, &UTempoActorLabeler::HandleSetLabelType),
+		SimpleRequestHandler(&LabelAsyncService::RequestLoadLabelTable, &UTempoActorLabeler::HandleLoadLabelTable),
+		SimpleRequestHandler(&LabelAsyncService::RequestSetInstanceLabelUniqueness, &UTempoActorLabeler::HandleSetInstanceLabelUniqueness),
+		SimpleRequestHandler(&LabelAsyncService::RequestSetLabelRowOverrides, &UTempoActorLabeler::HandleSetLabelRowOverrides)
 	);
 }
 
@@ -401,6 +406,135 @@ void UTempoActorLabeler::HandleSetStaticMeshTypeSemanticId(const TempoSensors::S
 	ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
 }
 
+void UTempoActorLabeler::HandleSetLabelType(const TempoSensors::SetLabelTypeRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation)
+{
+	ELabelType LabelType;
+	switch (Request.label_type())
+	{
+	case TempoSensors::LT_SEMANTIC:
+		{
+			LabelType = ELabelType::Semantic;
+			break;
+		}
+	case TempoSensors::LT_INSTANCE:
+		{
+			LabelType = ELabelType::Instance;
+			break;
+		}
+	default:
+		{
+			ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+				grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "label_type must be LT_SEMANTIC or LT_INSTANCE"));
+			return;
+		}
+	}
+
+	// Broadcasts back to OnLabelSettingsChanged, which re-labels the world in the new mode.
+	GetMutableDefault<UTempoSensorsSettings>()->SetLabelType(LabelType);
+
+	ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
+}
+
+void UTempoActorLabeler::HandleLoadLabelTable(const TempoSensors::LoadLabelTableRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation)
+{
+	FString Json = UTF8_TO_TCHAR(Request.json().c_str());
+	FString JsonFile = UTF8_TO_TCHAR(Request.json_file().c_str());
+
+	if (Json.IsEmpty() == JsonFile.IsEmpty())
+	{
+		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Exactly one of json and json_file must be set"));
+		return;
+	}
+
+	if (!JsonFile.IsEmpty())
+	{
+		if (FPaths::IsRelative(JsonFile))
+		{
+			JsonFile = FPaths::Combine(FPaths::ProjectDir(), JsonFile);
+		}
+		if (!FFileHelper::LoadFileToString(Json, *JsonFile))
+		{
+			const FString ErrorMsg = FString::Printf(TEXT("Could not read label table file '%s'"), *JsonFile);
+			ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+				grpc::Status(grpc::StatusCode::NOT_FOUND, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
+			return;
+		}
+	}
+
+	// Import into a fresh table so a table that fails to parse never reaches the world. Only a
+	// clean import is installed; on any problem the previously active table stays in place.
+	UDataTable* NewSemanticLabelTable = NewObject<UDataTable>(GetTransientPackage(), NAME_None, RF_Transient);
+	NewSemanticLabelTable->RowStruct = FSemanticLabel::StaticStruct();
+	// A row that assigns only actor types shouldn't have to spell out empty StaticMeshTypes and
+	// ComponentTags, so let an omitted column keep the row struct's default. Unrecognized columns
+	// stay an error: those are typos, and silently dropping one would silently drop its labels.
+	NewSemanticLabelTable->bIgnoreMissingFields = true;
+	const TArray<FString> Problems = NewSemanticLabelTable->CreateTableFromJSONString(Json);
+	if (!Problems.IsEmpty())
+	{
+		const FString ErrorMsg = FString::Printf(TEXT("Could not import label table: %s"), *FString::Join(Problems, TEXT(" ")));
+		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
+		return;
+	}
+
+	// Broadcasts back to OnLabelSettingsChanged, which rebuilds the label maps and re-labels the
+	// world, and to the sensors, which re-resolve the overridable/overriding label pair.
+	GetMutableDefault<UTempoSensorsSettings>()->SetRuntimeSemanticLabelTable(NewSemanticLabelTable);
+
+	ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
+}
+
+void UTempoActorLabeler::HandleSetInstanceLabelUniqueness(const TempoSensors::SetInstanceLabelUniquenessRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation)
+{
+	// Governs future instance ID allocations only. Objects already labeled keep the IDs they have.
+	UTempoSensorsSettings* TempoSensorsSettings = GetMutableDefault<UTempoSensorsSettings>();
+	TempoSensorsSettings->SetGloballyUniqueInstanceLabels(Request.globally_unique());
+	TempoSensorsSettings->SetInstantaneouslyUniqueInstanceLabels(Request.instantaneously_unique());
+
+	ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
+}
+
+void UTempoActorLabeler::HandleSetLabelRowOverrides(const TempoSensors::SetLabelRowOverridesRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation)
+{
+	const FString OverridableRowName = UTF8_TO_TCHAR(Request.overridable_row_name().c_str());
+	const FString OverridingRowName = UTF8_TO_TCHAR(Request.overriding_row_name().c_str());
+
+	// The substitution only happens when both rows resolve, so a request naming just one of them
+	// would silently do nothing.
+	if (OverridableRowName.IsEmpty() != OverridingRowName.IsEmpty())
+	{
+		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+			"overridable_row_name and overriding_row_name must both be set, or both be empty to disable overriding"));
+		return;
+	}
+
+	// Reject a row name the active table doesn't have, rather than accepting a setting that can
+	// only ever resolve to "no override".
+	if (SemanticLabelTable && !OverridableRowName.IsEmpty())
+	{
+		for (const FString& RowName : { OverridableRowName, OverridingRowName })
+		{
+			if (!SemanticLabelTable->GetRowNames().Contains(FName(*RowName)))
+			{
+				const FString ErrorMsg = FString::Printf(TEXT("Semantic label table has no row named '%s'"), *RowName);
+				ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+					grpc::Status(grpc::StatusCode::NOT_FOUND, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
+				return;
+			}
+		}
+	}
+
+	// Broadcasts to the sensors, which re-push the resolved pair onto their post-process materials.
+	GetMutableDefault<UTempoSensorsSettings>()->SetLabelRowNameOverrides(
+		OverridableRowName.IsEmpty() ? NAME_None : FName(*OverridableRowName),
+		OverridingRowName.IsEmpty() ? NAME_None : FName(*OverridingRowName));
+
+	ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
+}
+
 void UTempoActorLabeler::HandleGetAllActorLabels(const TempoCore::Empty& Request, const TResponseDelegate<TempoSensors::GetAllActorLabelsResponse>& ResponseContinuation)
 {
 	TempoSensors::GetAllActorLabelsResponse Response;
@@ -506,7 +640,7 @@ void UTempoActorLabeler::OnWorldBeginPlay(UWorld& InWorld)
 		UnLabelComponent(Component);
 	});
 
-	GetMutableDefault<UTempoSensorsSettings>()->TempoSensorsLabelSettingsChangedEvent.AddUObject(this, &UTempoActorLabeler::ReLabelAllActors);
+	GetMutableDefault<UTempoSensorsSettings>()->TempoSensorsLabelSettingsChangedEvent.AddUObject(this, &UTempoActorLabeler::OnLabelSettingsChanged);
 }
 
 void UTempoActorLabeler::Initialize(FSubsystemCollectionBase& Collection)
@@ -525,6 +659,14 @@ void UTempoActorLabeler::Deinitialize()
 
 void UTempoActorLabeler::BuildLabelMaps()
 {
+	// Everything below is derived wholly from SemanticLabelTable, and this runs again whenever that
+	// table is replaced, so start from empty rather than accumulating the previous table's entries.
+	ActorSemanticLabels.Reset();
+	StaticMeshLabels.Reset();
+	ComponentTagLabels.Reset();
+	SemanticIds.Reset();
+	NoLabelId = 0;
+
 	if (!SemanticLabelTable)
 	{
 		UE_LOG(LogTempoSensors, Error, TEXT("Semantic Label table was not set"));
@@ -932,9 +1074,16 @@ void UTempoActorLabeler::UnLabelComponent(UPrimitiveComponent* Component)
 	LabeledObjects.Remove(Component);
 }
 
-void UTempoActorLabeler::ReLabelAllActors()
+void UTempoActorLabeler::OnLabelSettingsChanged()
 {
+	// Unlabel first, while the maps still describe the labels the world is currently wearing —
+	// UnLabelActor reads NoLabelId to decide which instance IDs to reclaim, and BuildLabelMaps
+	// re-derives NoLabelId from the new table.
 	UnLabelAllActors();
+
+	SemanticLabelTable = GetDefault<UTempoSensorsSettings>()->GetSemanticLabelTable();
+	BuildLabelMaps();
+
 	LabelAllActors();
 }
 

--- a/TempoSensors/Source/TempoSensors/Private/TempoActorLabeler.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoActorLabeler.cpp
@@ -296,11 +296,11 @@ void UTempoActorLabeler::HandleSetActorTypeSemanticId(const TempoSensors::SetAct
 	const int32 SemanticId = Request.semantic_id();
 
 	// Validate range
-	if (SemanticId < -1 || SemanticId > 255)
+	if (SemanticId < -1 || SemanticId > GTempoCamera_Max_Label)
 	{
+		const FString ErrorMsg = FString::Printf(TEXT("semantic_id must be -1 (revert) or 0-%d"), GTempoCamera_Max_Label);
 		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
-			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-			"semantic_id must be -1 (revert) or 0-255"));
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
 		return;
 	}
 
@@ -420,11 +420,11 @@ void UTempoActorLabeler::HandleSetStaticMeshTypeSemanticId(const TempoSensors::S
 	const int32 SemanticId = Request.semantic_id();
 
 	// Validate range
-	if (SemanticId < -1 || SemanticId > 255)
+	if (SemanticId < -1 || SemanticId > GTempoCamera_Max_Label)
 	{
+		const FString ErrorMsg = FString::Printf(TEXT("semantic_id must be -1 (revert) or 0-%d"), GTempoCamera_Max_Label);
 		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
-			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-			"semantic_id must be -1 (revert) or 0-255"));
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
 		return;
 	}
 
@@ -594,11 +594,11 @@ void UTempoActorLabeler::HandleSetActorTagSemanticId(const TempoSensors::SetActo
 	const int32 SemanticId = Request.semantic_id();
 
 	// Validate range
-	if (SemanticId < -1 || SemanticId > 255)
+	if (SemanticId < -1 || SemanticId > GTempoCamera_Max_Label)
 	{
+		const FString ErrorMsg = FString::Printf(TEXT("semantic_id must be -1 (revert) or 0-%d"), GTempoCamera_Max_Label);
 		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
-			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-			"semantic_id must be -1 (revert) or 0-255"));
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
 		return;
 	}
 

--- a/TempoSensors/Source/TempoSensors/Private/TempoActorLabeler.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoActorLabeler.cpp
@@ -9,6 +9,7 @@
 
 #include "TempoSensorsConstants.h"
 #include "TempoSensorsSettings.h"
+#include "TempoSensorsUtils.h"
 
 #include "TempoClassUtils.h"
 #include "TempoCoreUtils.h"
@@ -17,6 +18,9 @@
 #include "EngineUtils.h"
 #include "Misc/FileHelper.h"
 #include "Components/InstancedStaticMeshComponent.h"
+#include "Components/SkinnedMeshComponent.h"
+#include "Engine/SkeletalMesh.h"
+#include "Engine/SkinnedAsset.h"
 #include "NiagaraComponent.h"
 #include "NiagaraEmitter.h"
 #include "NiagaraEmitterHandle.h"
@@ -114,6 +118,8 @@ void UTempoActorLabeler::RegisterServices(FTempoServer& Server)
 		SimpleRequestHandler(&LabelAsyncService::RequestSetActorTypeSemanticId, &UTempoActorLabeler::HandleSetActorTypeSemanticId),
 		SimpleRequestHandler(&LabelAsyncService::RequestGetAllStaticMeshTypes, &UTempoActorLabeler::HandleGetAllStaticMeshTypes),
 		SimpleRequestHandler(&LabelAsyncService::RequestSetStaticMeshTypeSemanticId, &UTempoActorLabeler::HandleSetStaticMeshTypeSemanticId),
+		SimpleRequestHandler(&LabelAsyncService::RequestSetActorTagSemanticId, &UTempoActorLabeler::HandleSetActorTagSemanticId),
+		SimpleRequestHandler(&LabelAsyncService::RequestGetLabelTableAsJson, &UTempoActorLabeler::HandleGetLabelTableAsJson),
 		SimpleRequestHandler(&LabelAsyncService::RequestSetLabelType, &UTempoActorLabeler::HandleSetLabelType),
 		SimpleRequestHandler(&LabelAsyncService::RequestLoadLabelTable, &UTempoActorLabeler::HandleLoadLabelTable),
 		SimpleRequestHandler(&LabelAsyncService::RequestSetInstanceLabelUniqueness, &UTempoActorLabeler::HandleSetInstanceLabelUniqueness),
@@ -191,6 +197,17 @@ void UTempoActorLabeler::HandleGetSemanticClasses(const TempoCore::Empty& Reques
 		SemanticIdToMeshPaths.FindOrAdd(OverrideSemanticId).Add(MeshPath);
 	}
 
+	// Build reverse mapping: semantic_id -> skeletal mesh paths
+	TMap<int32, TArray<FString>> SemanticIdToSkeletalMeshPaths;
+
+	for (const auto& [MeshPath, LabelName] : SkeletalMeshLabels)
+	{
+		if (const int32* SemanticId = SemanticIds.Find(LabelName))
+		{
+			SemanticIdToSkeletalMeshPaths.FindOrAdd(*SemanticId).Add(MeshPath);
+		}
+	}
+
 	// Build reverse mapping: semantic_id -> component tags
 	TMap<int32, TArray<FName>> SemanticIdToComponentTags;
 
@@ -200,6 +217,27 @@ void UTempoActorLabeler::HandleGetSemanticClasses(const TempoCore::Empty& Reques
 		{
 			SemanticIdToComponentTags.FindOrAdd(*SemanticId).Add(ComponentTag);
 		}
+	}
+
+	// Build reverse mapping: semantic_id -> actor tags
+	TMap<int32, TArray<FName>> SemanticIdToActorTags;
+
+	for (const auto& [ActorTag, LabelName] : ActorTagLabels)
+	{
+		if (const int32* SemanticId = SemanticIds.Find(LabelName))
+		{
+			SemanticIdToActorTags.FindOrAdd(*SemanticId).Add(ActorTag);
+		}
+	}
+
+	// Include runtime actor tag overrides (they take precedence)
+	for (const auto& [ActorTag, OverrideSemanticId] : ActorTagSemanticIdOverrides)
+	{
+		for (auto& [Id, Tags] : SemanticIdToActorTags)
+		{
+			Tags.Remove(ActorTag);
+		}
+		SemanticIdToActorTags.FindOrAdd(OverrideSemanticId).Add(ActorTag);
 	}
 
 	// Iterate DataTable to get all class definitions
@@ -225,11 +263,27 @@ void UTempoActorLabeler::HandleGetSemanticClasses(const TempoCore::Empty& Reques
 			}
 		}
 
+		if (TArray<FString>* SkeletalMeshPaths = SemanticIdToSkeletalMeshPaths.Find(SemanticId))
+		{
+			for (const FString& MeshPath : *SkeletalMeshPaths)
+			{
+				ClassInfo->add_skeletal_mesh_types(TCHAR_TO_UTF8(*MeshPath));
+			}
+		}
+
 		if (TArray<FName>* ComponentTags = SemanticIdToComponentTags.Find(SemanticId))
 		{
 			for (const FName& ComponentTag : *ComponentTags)
 			{
 				ClassInfo->add_component_tags(TCHAR_TO_UTF8(*ComponentTag.ToString()));
+			}
+		}
+
+		if (TArray<FName>* ActorTags = SemanticIdToActorTags.Find(SemanticId))
+		{
+			for (const FName& ActorTag : *ActorTags)
+			{
+				ClassInfo->add_actor_tags(TCHAR_TO_UTF8(*ActorTag.ToString()));
 			}
 		}
 	}
@@ -333,7 +387,7 @@ void UTempoActorLabeler::HandleGetAllStaticMeshTypes(const TempoCore::Empty& Req
 		for (UNiagaraComponent* NiagaraComponent : NiagaraComponents)
 		{
 			TArray<FString> MeshPaths;
-			GetComponentStaticMeshPaths(NiagaraComponent, MeshPaths);
+			GetComponentMeshPaths(NiagaraComponent, MeshPaths);
 			for (const FString& MeshPath : MeshPaths)
 			{
 				MeshInstanceCounts.FindOrAdd(MeshPath)++;
@@ -354,7 +408,7 @@ void UTempoActorLabeler::HandleGetAllStaticMeshTypes(const TempoCore::Empty& Req
 		MeshInfo->set_instance_count(InstanceCount);
 
 		// Determine current semantic ID: check overrides first, then DataTable
-		MeshInfo->set_current_semantic_id(ResolveStaticMeshSemanticId(MeshPath).Get(-1));
+		MeshInfo->set_current_semantic_id(ResolveMeshSemanticId(MeshPath).Get(-1));
 	}
 
 	ResponseContinuation.ExecuteIfBound(Response, grpc::Status_OK);
@@ -391,7 +445,7 @@ void UTempoActorLabeler::HandleSetStaticMeshTypeSemanticId(const TempoSensors::S
 		for (UPrimitiveComponent* PrimitiveComponent : PrimitiveComponents)
 		{
 			TArray<FString> MeshPaths;
-			GetComponentStaticMeshPaths(PrimitiveComponent, MeshPaths);
+			GetComponentMeshPaths(PrimitiveComponent, MeshPaths);
 			if (MeshPaths.Contains(MeshPath))
 			{
 				UnLabelComponent(PrimitiveComponent);
@@ -535,6 +589,68 @@ void UTempoActorLabeler::HandleSetLabelRowOverrides(const TempoSensors::SetLabel
 	ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
 }
 
+void UTempoActorLabeler::HandleSetActorTagSemanticId(const TempoSensors::SetActorTagSemanticIdRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation)
+{
+	const int32 SemanticId = Request.semantic_id();
+
+	// Validate range
+	if (SemanticId < -1 || SemanticId > 255)
+	{
+		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+			"semantic_id must be -1 (revert) or 0-255"));
+		return;
+	}
+
+	const FString ActorTagName(UTF8_TO_TCHAR(Request.actor_tag().c_str()));
+	if (ActorTagName.IsEmpty())
+	{
+		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "actor_tag must not be empty"));
+		return;
+	}
+	const FName ActorTag(*ActorTagName);
+
+	// Store or clear override
+	if (SemanticId < 0)
+	{
+		ActorTagSemanticIdOverrides.Remove(ActorTag);
+	}
+	else
+	{
+		ActorTagSemanticIdOverrides.Add(ActorTag, SemanticId);
+	}
+
+	// Re-label every Actor carrying this tag. Unlike an Actor type, a tag can be added to an Actor
+	// at any time, so there is no set of "already tagged" Actors to consult — walk the world.
+	for (TActorIterator<AActor> ActorItr(GetWorld()); ActorItr; ++ActorItr)
+	{
+		if (ActorItr->Tags.Contains(ActorTag))
+		{
+			UnLabelActor(*ActorItr);
+			LabelActor(*ActorItr);
+		}
+	}
+
+	ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
+}
+
+void UTempoActorLabeler::HandleGetLabelTableAsJson(const TempoCore::Empty& Request, const TResponseDelegate<TempoSensors::GetLabelTableAsJsonResponse>& ResponseContinuation) const
+{
+	const UDataTable* ActiveSemanticLabelTable = GetDefault<UTempoSensorsSettings>()->GetSemanticLabelTable();
+	if (!ActiveSemanticLabelTable)
+	{
+		ResponseContinuation.ExecuteIfBound(TempoSensors::GetLabelTableAsJsonResponse(),
+			grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "No semantic label table is set"));
+		return;
+	}
+
+	TempoSensors::GetLabelTableAsJsonResponse Response;
+	Response.set_json(TCHAR_TO_UTF8(*ExportSemanticLabelTableToJson(ActiveSemanticLabelTable)));
+
+	ResponseContinuation.ExecuteIfBound(Response, grpc::Status_OK);
+}
+
 void UTempoActorLabeler::HandleGetAllActorLabels(const TempoCore::Empty& Request, const TResponseDelegate<TempoSensors::GetAllActorLabelsResponse>& ResponseContinuation)
 {
 	TempoSensors::GetAllActorLabelsResponse Response;
@@ -663,7 +779,9 @@ void UTempoActorLabeler::BuildLabelMaps()
 	// table is replaced, so start from empty rather than accumulating the previous table's entries.
 	ActorSemanticLabels.Reset();
 	StaticMeshLabels.Reset();
+	SkeletalMeshLabels.Reset();
 	ComponentTagLabels.Reset();
+	ActorTagLabels.Reset();
 	SemanticIds.Reset();
 	NoLabelId = 0;
 
@@ -709,6 +827,39 @@ void UTempoActorLabeler::BuildLabelMaps()
 			{
 				UE_LOG(LogTempoSensors, Warning, TEXT("Null static mesh associated with label %s"), *Label.ToString());
 			}
+		}
+
+		for (const TSoftObjectPtr<USkeletalMesh>& SkeletalMeshAsset : Value.SkeletalMeshTypes)
+		{
+			if (const USkeletalMesh* SkeletalMesh = SkeletalMeshAsset.LoadSynchronous())
+			{
+				const FString MeshFullPath = SkeletalMesh->GetPathName();
+				if (SkeletalMeshLabels.Contains(MeshFullPath))
+				{
+					UE_LOG(LogTempoSensors, Error, TEXT("Skeletal mesh type %s is associated with more than one label (%s and %s)"), *MeshFullPath, *SkeletalMeshLabels[MeshFullPath].ToString(), *Label.ToString());
+					continue;
+				}
+				SkeletalMeshLabels.Add(MeshFullPath, Label);
+			}
+			else
+			{
+				UE_LOG(LogTempoSensors, Warning, TEXT("Null skeletal mesh associated with label %s"), *Label.ToString());
+			}
+		}
+
+		for (const FName& ActorTag : Value.ActorTags)
+		{
+			if (ActorTag.IsNone())
+			{
+				UE_LOG(LogTempoSensors, Warning, TEXT("Empty actor tag associated with label %s"), *Label.ToString());
+				continue;
+			}
+			if (ActorTagLabels.Contains(ActorTag))
+			{
+				UE_LOG(LogTempoSensors, Error, TEXT("Actor tag %s is associated with more than one label (%s and %s)"), *ActorTag.ToString(), *ActorTagLabels[ActorTag].ToString(), *Label.ToString());
+				continue;
+			}
+			ActorTagLabels.Add(ActorTag, Label);
 		}
 
 		for (const FName& ComponentTag : Value.ComponentTags)
@@ -780,57 +931,17 @@ void UTempoActorLabeler::LabelActor(AActor* Actor)
 		return;
 	}
 
-	const FName ActorTypeName = Actor->GetClass()->GetFName();
-
-	// Check for type-level override first (before DataTable lookup)
-	if (const int32* TypeOverride = ActorTypeSemanticIdOverrides.Find(ActorTypeName))
+	FInstanceSemanticIdPair ActorIdPair;
+	if (const TOptional<int32> SemanticId = ResolveActorSemanticId(Actor))
 	{
-		FInstanceSemanticIdPair ActorIdPair;
-		ActorIdPair.SemanticId = *TypeOverride;
-		if (TOptional<int32> InstanceId = InstanceIdAllocator.Allocate())
+		ActorIdPair.SemanticId = *SemanticId;
+		if (const TOptional<int32> InstanceId = InstanceIdAllocator.Allocate())
 		{
 			ActorIdPair.InstanceId = *InstanceId;
 			// Track actor class names that have been assigned instance IDs
 			if (GetDefault<UTempoSensorsSettings>()->GetLabelType() == ELabelType::Instance)
 			{
-				LabeledActorClassNames.Add(ActorTypeName);
-			}
-		}
-		LabeledObjects.Add(Actor, ActorIdPair);
-		LabelAllComponents(Actor, ActorIdPair);
-		return;
-	}
-
-	FInstanceSemanticIdPair ActorIdPair;
-	FName AssignedLabel = NoLabelName;
-	for (const auto& Elem : ActorSemanticLabels)
-	{
-		const TSubclassOf<AActor>& ActorType = Elem.Key;
-		const FName& ActorLabel = Elem.Value;
-		if (Actor->GetClass()->IsChildOf(ActorType.Get()))
-		{
-			if (const int32* SemanticId = SemanticIds.Find(ActorLabel))
-			{
-				if (AssignedLabel != NoLabelName && *ActorLabel.ToString() != AssignedLabel)
-				{
-					UE_LOG(LogTempoSensors, Error, TEXT("Labels %s and %s have overlapping actor types"), *ActorLabel.ToString(), *AssignedLabel.ToString());
-					continue;
-				}
-				AssignedLabel = ActorLabel;
-				if (TOptional<int32> InstanceId = InstanceIdAllocator.Allocate())
-				{
-					ActorIdPair.InstanceId = *InstanceId;
-					// Track actor class names that have been assigned instance IDs
-					if (GetDefault<UTempoSensorsSettings>()->GetLabelType() == ELabelType::Instance)
-					{
-						LabeledActorClassNames.Add(ActorTypeName);
-					}
-				}
-				ActorIdPair.SemanticId = *SemanticId;
-			}
-			else
-			{
-				UE_LOG(LogTempoSensors, Error, TEXT("Label %s did not have an associated ID"), *ActorLabel.ToString());
+				LabeledActorClassNames.Add(Actor->GetClass()->GetFName());
 			}
 		}
 	}
@@ -838,6 +949,63 @@ void UTempoActorLabeler::LabelActor(AActor* Actor)
 	LabeledObjects.Add(Actor, ActorIdPair);
 
 	LabelAllComponents(Actor, ActorIdPair);
+}
+
+TOptional<int32> UTempoActorLabeler::ResolveActorSemanticId(const AActor* Actor) const
+{
+	// Most specific rule wins, mirroring ResolveComponentSemanticId. An Actor tag names particular
+	// Actors, so it beats the type rules, which name every Actor of a class at once. An Actor
+	// carrying tags for two different labels resolves to whichever its Tags array lists first —
+	// the same first-match rule component tags follow.
+	for (const FName& ActorTag : Actor->Tags)
+	{
+		// Runtime overrides take precedence over the label table.
+		if (const int32* OverrideSemanticId = ActorTagSemanticIdOverrides.Find(ActorTag))
+		{
+			return *OverrideSemanticId;
+		}
+
+		if (const FName* TagLabel = ActorTagLabels.Find(ActorTag))
+		{
+			if (const int32* TagLabelId = SemanticIds.Find(*TagLabel))
+			{
+				return *TagLabelId;
+			}
+			UE_LOG(LogTempoSensors, Error, TEXT("Label %s did not have an associated ID"), *TagLabel->ToString());
+		}
+	}
+
+	if (const int32* OverrideSemanticId = ActorTypeSemanticIdOverrides.Find(Actor->GetClass()->GetFName()))
+	{
+		return *OverrideSemanticId;
+	}
+
+	TOptional<int32> ResolvedSemanticId;
+	FName AssignedLabel = NAME_None;
+	for (const auto& [ActorType, ActorLabel] : ActorSemanticLabels)
+	{
+		if (!Actor->GetClass()->IsChildOf(ActorType.Get()))
+		{
+			continue;
+		}
+
+		if (const int32* SemanticId = SemanticIds.Find(ActorLabel))
+		{
+			if (!AssignedLabel.IsNone() && ActorLabel != AssignedLabel)
+			{
+				UE_LOG(LogTempoSensors, Error, TEXT("Labels %s and %s have overlapping actor types"), *ActorLabel.ToString(), *AssignedLabel.ToString());
+				continue;
+			}
+			AssignedLabel = ActorLabel;
+			ResolvedSemanticId = *SemanticId;
+		}
+		else
+		{
+			UE_LOG(LogTempoSensors, Error, TEXT("Label %s did not have an associated ID"), *ActorLabel.ToString());
+		}
+	}
+
+	return ResolvedSemanticId;
 }
 
 void UTempoActorLabeler::LabelAllComponents(const AActor* Actor, FInstanceSemanticIdPair ActorIdPair)
@@ -916,10 +1084,10 @@ TOptional<int32> UTempoActorLabeler::ResolveComponentSemanticId(const UPrimitive
 	}
 
 	TArray<FString> MeshPaths;
-	GetComponentStaticMeshPaths(Component, MeshPaths);
+	GetComponentMeshPaths(Component, MeshPaths);
 	for (const FString& MeshPath : MeshPaths)
 	{
-		if (const TOptional<int32> MeshSemanticId = ResolveStaticMeshSemanticId(MeshPath))
+		if (const TOptional<int32> MeshSemanticId = ResolveMeshSemanticId(MeshPath))
 		{
 			return MeshSemanticId;
 		}
@@ -928,7 +1096,7 @@ TOptional<int32> UTempoActorLabeler::ResolveComponentSemanticId(const UPrimitive
 	return TOptional<int32>();
 }
 
-TOptional<int32> UTempoActorLabeler::ResolveStaticMeshSemanticId(const FString& MeshPath) const
+TOptional<int32> UTempoActorLabeler::ResolveMeshSemanticId(const FString& MeshPath) const
 {
 	// Runtime overrides take precedence over the label table.
 	if (const int32* OverrideSemanticId = StaticMeshTypeSemanticIdOverrides.Find(MeshPath))
@@ -936,25 +1104,44 @@ TOptional<int32> UTempoActorLabeler::ResolveStaticMeshSemanticId(const FString& 
 		return *OverrideSemanticId;
 	}
 
-	if (const FName* StaticMeshLabel = StaticMeshLabels.Find(MeshPath))
+	// Static and skeletal meshes are labeled from separate table columns but share one asset path
+	// space, so a given path can only ever be in one of these maps.
+	const FName* MeshLabel = StaticMeshLabels.Find(MeshPath);
+	if (!MeshLabel)
 	{
-		if (const int32* StaticMeshLabelId = SemanticIds.Find(*StaticMeshLabel))
+		MeshLabel = SkeletalMeshLabels.Find(MeshPath);
+	}
+
+	if (MeshLabel)
+	{
+		if (const int32* MeshLabelId = SemanticIds.Find(*MeshLabel))
 		{
-			return *StaticMeshLabelId;
+			return *MeshLabelId;
 		}
-		UE_LOG(LogTempoSensors, Error, TEXT("Label %s did not have an associated ID"), *StaticMeshLabel->ToString());
+		UE_LOG(LogTempoSensors, Error, TEXT("Label %s did not have an associated ID"), *MeshLabel->ToString());
 	}
 
 	return TOptional<int32>();
 }
 
-void UTempoActorLabeler::GetComponentStaticMeshPaths(const UPrimitiveComponent* Component, TArray<FString>& OutMeshPaths)
+void UTempoActorLabeler::GetComponentMeshPaths(const UPrimitiveComponent* Component, TArray<FString>& OutMeshPaths)
 {
 	if (const UStaticMeshComponent* StaticMeshComponent = Cast<UStaticMeshComponent>(Component))
 	{
 		if (const UStaticMesh* StaticMesh = StaticMeshComponent->GetStaticMesh())
 		{
 			OutMeshPaths.Add(StaticMesh->GetPathName());
+		}
+		return;
+	}
+
+	// USkinnedMeshComponent covers USkeletalMeshComponent and the other skinned variants, and its
+	// asset is a USkinnedAsset — USkeletalMesh among them.
+	if (const USkinnedMeshComponent* SkinnedMeshComponent = Cast<USkinnedMeshComponent>(Component))
+	{
+		if (const USkinnedAsset* SkinnedAsset = SkinnedMeshComponent->GetSkinnedAsset())
+		{
+			OutMeshPaths.Add(SkinnedAsset->GetPathName());
 		}
 		return;
 	}

--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -5,7 +5,6 @@
 #include "TempoActorLabeler.h"
 #include "TempoCameraVideoEncoder.h"
 #include "TempoCoreUtils.h"
-#include "TempoLabelTypes.h"
 #include "TempoSensorsConstants.h"
 #include "TempoMultiViewCapture.h"
 #include "TempoSensors.h"
@@ -1873,40 +1872,20 @@ void UTempoCamera::SetTileDepthEnabled(FTempoCameraTile& Tile, bool bTileDepthEn
 		Tile.PostProcessMaterialInstance->SetScalarParameterValue(TEXT("UseRadialDistance"), bRadial ? 1.0f : 0.0f);
 	}
 
-	// Look up optional label override pair.
-	UDataTable* SemanticLabelTable = TempoSensorsSettings->GetSemanticLabelTable();
-	const FName OverridableLabelRowName = TempoSensorsSettings->GetOverridableLabelRowName();
-	const FName OverridingLabelRowName = TempoSensorsSettings->GetOverridingLabelRowName();
-	TOptional<int32> OverridableLabel;
-	TOptional<int32> OverridingLabel;
-	if (SemanticLabelTable && !OverridableLabelRowName.IsNone())
-	{
-		SemanticLabelTable->ForeachRow<FSemanticLabel>(TEXT(""),
-			[&OverridableLabelRowName, &OverridingLabelRowName, &OverridableLabel, &OverridingLabel]
-			(const FName& Key, const FSemanticLabel& Value)
-			{
-				if (Key == OverridableLabelRowName)
-				{
-					OverridableLabel = Value.Label;
-				}
-				if (Key == OverridingLabelRowName)
-				{
-					OverridingLabel = Value.Label;
-				}
-			});
-	}
-
-	if (OverridableLabel.IsSet() && OverridingLabel.IsSet())
-	{
-		Tile.PostProcessMaterialInstance->SetScalarParameterValue(TEXT("OverridableLabel"), OverridableLabel.GetValue());
-		Tile.PostProcessMaterialInstance->SetScalarParameterValue(TEXT("OverridingLabel"), OverridingLabel.GetValue());
-	}
-	else
-	{
-		Tile.PostProcessMaterialInstance->SetScalarParameterValue(TEXT("OverridingLabel"), 0.0);
-	}
+	ApplyLabelOverrideParameters(Tile.PostProcessMaterialInstance);
 
 	Tile.PostProcessMaterialInstance->EnsureIsComplete();
+}
+
+void UTempoCamera::ApplyLabelOverridesToTiles()
+{
+	for (FTempoCameraTile& Tile : Tiles)
+	{
+		if (Tile.bActive)
+		{
+			ApplyLabelOverrideParameters(Tile.PostProcessMaterialInstance);
+		}
+	}
 }
 
 void UTempoCamera::ApplyTilePostProcess(FTempoCameraTile& Tile)

--- a/TempoSensors/Source/TempoSensors/Private/TempoLidar.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoLidar.cpp
@@ -7,7 +7,6 @@
 
 #include "TempoConversion.h"
 #include "TempoCoreUtils.h"
-#include "TempoLabelTypes.h"
 #include "TempoMultiViewCapture.h"
 
 #include "TempoSensors/Common.pb.h"
@@ -273,6 +272,17 @@ void UTempoLidar::DeactivateTile(FTempoLidarTile& Tile)
 	Tile.bCameraCut = false;
 }
 
+void UTempoLidar::ApplyLabelOverridesToTiles()
+{
+	for (FTempoLidarTile& Tile : Tiles)
+	{
+		if (Tile.bActive)
+		{
+			ApplyLabelOverrideParameters(Tile.PostProcessMaterialInstance);
+		}
+	}
+}
+
 void UTempoLidar::ApplyTilePostProcess(FTempoLidarTile& Tile)
 {
 	const UTempoSensorsSettings* TempoSensorsSettings = GetDefault<UTempoSensorsSettings>();
@@ -309,38 +319,7 @@ void UTempoLidar::ApplyTilePostProcess(FTempoLidarTile& Tile)
 		Tile.PostProcessMaterialInstance->SetScalarParameterValue(TEXT("MaxDiscreteDepth"), GTempoCamera_Max_Discrete_Depth);
 	}
 
-	// Optional label overrides.
-	UDataTable* SemanticLabelTable = TempoSensorsSettings->GetSemanticLabelTable();
-	const FName OverridableLabelRowName = TempoSensorsSettings->GetOverridableLabelRowName();
-	const FName OverridingLabelRowName = TempoSensorsSettings->GetOverridingLabelRowName();
-	TOptional<int32> OverridableLabel;
-	TOptional<int32> OverridingLabel;
-	if (SemanticLabelTable && !OverridableLabelRowName.IsNone())
-	{
-		SemanticLabelTable->ForeachRow<FSemanticLabel>(TEXT(""),
-			[&OverridableLabelRowName, &OverridingLabelRowName, &OverridableLabel, &OverridingLabel]
-			(const FName& Key, const FSemanticLabel& Value)
-			{
-				if (Key == OverridableLabelRowName)
-				{
-					OverridableLabel = Value.Label;
-				}
-				if (Key == OverridingLabelRowName)
-				{
-					OverridingLabel = Value.Label;
-				}
-			});
-	}
-
-	if (OverridableLabel.IsSet() && OverridingLabel.IsSet())
-	{
-		Tile.PostProcessMaterialInstance->SetScalarParameterValue(TEXT("OverridableLabel"), OverridableLabel.GetValue());
-		Tile.PostProcessMaterialInstance->SetScalarParameterValue(TEXT("OverridingLabel"), OverridingLabel.GetValue());
-	}
-	else
-	{
-		Tile.PostProcessMaterialInstance->SetScalarParameterValue(TEXT("OverridingLabel"), 0.0);
-	}
+	ApplyLabelOverrideParameters(Tile.PostProcessMaterialInstance);
 
 	Tile.PostProcessMaterialInstance->EnsureIsComplete();
 

--- a/TempoSensors/Source/TempoSensors/Private/TempoSensorServiceSubsystem.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoSensorServiceSubsystem.cpp
@@ -33,6 +33,7 @@ using LabelImage = TempoSensors::LabelImage;
 using LidarScanSegment = TempoSensors::LidarScanSegment;
 using VideoRequest = TempoSensors::VideoRequest;
 using VideoFrame = TempoSensors::VideoFrame;
+using SetPipelinedRenderingEnabledRequest = TempoSensors::SetPipelinedRenderingEnabledRequest;
 
 void UTempoSensorServiceSubsystem::RegisterServices(FTempoServer& Server)
 {
@@ -43,8 +44,18 @@ void UTempoSensorServiceSubsystem::RegisterServices(FTempoServer& Server)
 		StreamingRequestHandler(&SensorAsyncService::RequestStreamLabelImages, &UTempoSensorServiceSubsystem::StreamLabelImages),
 		StreamingRequestHandler(&SensorAsyncService::RequestStreamBoundingBoxes, &UTempoSensorServiceSubsystem::StreamBoundingBoxes),
 		StreamingRequestHandler(&SensorAsyncService::RequestStreamLidarScans, &UTempoSensorServiceSubsystem::StreamLidarScans),
-		StreamingRequestHandler(&SensorAsyncService::RequestStreamVideo, &UTempoSensorServiceSubsystem::StreamVideo)
+		StreamingRequestHandler(&SensorAsyncService::RequestStreamVideo, &UTempoSensorServiceSubsystem::StreamVideo),
+		SimpleRequestHandler(&SensorAsyncService::RequestSetPipelinedRenderingEnabled, &UTempoSensorServiceSubsystem::SetPipelinedRenderingEnabled)
 		);
+}
+
+void UTempoSensorServiceSubsystem::SetPipelinedRenderingEnabled(const SetPipelinedRenderingEnabledRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation) const
+{
+	// Read fresh at every readback barrier, so this takes effect on the next frame with no
+	// sensor teardown. Measurements already in flight keep whichever policy they were captured under.
+	GetMutableDefault<UTempoSensorsSettings>()->SetPipelinedRendering(Request.enabled());
+
+	ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
 }
 
 void UTempoSensorServiceSubsystem::Initialize(FSubsystemCollectionBase& Collection)

--- a/TempoSensors/Source/TempoSensors/Private/TempoSensorsSettings.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoSensorsSettings.cpp
@@ -2,6 +2,8 @@
 
 #include "TempoSensorsSettings.h"
 
+#include "Engine/DataTable.h"
+
 UTempoSensorsSettings::UTempoSensorsSettings()
 {
 	CategoryName = TEXT("Tempo");
@@ -48,6 +50,64 @@ void UTempoSensorsSettings::PostInitProperties()
 	SetIfNull(LidarPostProcessMaterialWithColor, TEXT("/TempoSensors/Materials/M_LidarPostProcess_WithColor.M_LidarPostProcess_WithColor"));
 }
 
+void UTempoSensorsSettings::SetRuntimeSemanticLabelTable(UDataTable* SemanticLabelTableIn)
+{
+	if (RuntimeSemanticLabelTable == SemanticLabelTableIn)
+	{
+		return;
+	}
+
+	RuntimeSemanticLabelTable = SemanticLabelTableIn;
+
+	TempoSensorsLabelSettingsChangedEvent.Broadcast();
+	// The overridable/overriding row names are unchanged, but the rows they name now live in a
+	// different table and may resolve to different label IDs.
+	TempoSensorsLabelOverridesChangedEvent.Broadcast();
+}
+
+void UTempoSensorsSettings::SetLabelType(ELabelType LabelTypeIn)
+{
+	if (LabelType == LabelTypeIn)
+	{
+		return;
+	}
+
+	LabelType = LabelTypeIn;
+
+	TempoSensorsLabelSettingsChangedEvent.Broadcast();
+}
+
+void UTempoSensorsSettings::SetGloballyUniqueInstanceLabels(bool bGloballyUniqueInstanceLabelsIn)
+{
+	// Read live by the instance ID allocator, so this only governs allocations from here on.
+	// Instance IDs already assigned keep theirs.
+	bGloballyUniqueInstanceLabels = bGloballyUniqueInstanceLabelsIn;
+}
+
+void UTempoSensorsSettings::SetInstantaneouslyUniqueInstanceLabels(bool bInstantaneouslyUniqueInstanceLabelsIn)
+{
+	bInstantaneouslyUniqueInstanceLabels = bInstantaneouslyUniqueInstanceLabelsIn;
+}
+
+void UTempoSensorsSettings::SetLabelRowNameOverrides(FName OverridableLabelRowNameIn, FName OverridingLabelRowNameIn)
+{
+	if (OverridableLabelRowName == OverridableLabelRowNameIn && OverridingLabelRowName == OverridingLabelRowNameIn)
+	{
+		return;
+	}
+
+	OverridableLabelRowName = OverridableLabelRowNameIn;
+	OverridingLabelRowName = OverridingLabelRowNameIn;
+
+	TempoSensorsLabelOverridesChangedEvent.Broadcast();
+}
+
+void UTempoSensorsSettings::SetPipelinedRendering(bool bPipelinedRenderingIn)
+{
+	// Read live everywhere it matters (the FixedStep readback barrier), so no listeners to notify.
+	bPipelinedRendering = bPipelinedRenderingIn;
+}
+
 #if WITH_EDITOR
 FText UTempoSensorsSettings::GetSectionText() const
 {
@@ -60,10 +120,22 @@ void UTempoSensorsSettings::PostEditChangeProperty(FPropertyChangedEvent& Proper
 {
 	Super::PostEditChangeProperty(PropertyChangedEvent);
 
-	const FString PropertyChangedName = PropertyChangedEvent.Property->GetName();
-	if (PropertyChangedName == GET_MEMBER_NAME_CHECKED(UTempoSensorsSettings, LabelType))
+	if (!PropertyChangedEvent.Property)
+	{
+		return;
+	}
+
+	const FName PropertyChangedName = PropertyChangedEvent.Property->GetFName();
+	if (PropertyChangedName == GET_MEMBER_NAME_CHECKED(UTempoSensorsSettings, LabelType)
+		|| PropertyChangedName == GET_MEMBER_NAME_CHECKED(UTempoSensorsSettings, SemanticLabelTable))
 	{
 		TempoSensorsLabelSettingsChangedEvent.Broadcast();
+	}
+	if (PropertyChangedName == GET_MEMBER_NAME_CHECKED(UTempoSensorsSettings, SemanticLabelTable)
+		|| PropertyChangedName == GET_MEMBER_NAME_CHECKED(UTempoSensorsSettings, OverridableLabelRowName)
+		|| PropertyChangedName == GET_MEMBER_NAME_CHECKED(UTempoSensorsSettings, OverridingLabelRowName))
+	{
+		TempoSensorsLabelOverridesChangedEvent.Broadcast();
 	}
 }
 #endif

--- a/TempoSensors/Source/TempoSensors/Private/TempoSensorsUtils.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoSensorsUtils.cpp
@@ -2,6 +2,12 @@
 
 #include "TempoSensorsUtils.h"
 
+#include "TempoLabelTypes.h"
+#include "TempoSensorsSettings.h"
+
+#include "Engine/DataTable.h"
+#include "Materials/MaterialInstanceDynamic.h"
+
 void OptimizeShowFlagsForNoColor(FEngineShowFlags& ShowFlags)
 {
 	ShowFlags.SetPostProcessing(true);
@@ -130,4 +136,45 @@ void ApplyPhotorealisticRenderSettings(FPostProcessSettings& OutPostProcess,
 	OutShowFlags.SetVolumetricFog(true);
 	OutShowFlags.SetTonemapper(true);
 	OutShowFlags.SetScreenPercentage(true);
+}
+
+void ApplyLabelOverrideParameters(UMaterialInstanceDynamic* MaterialInstance)
+{
+	if (!MaterialInstance)
+	{
+		return;
+	}
+
+	const UTempoSensorsSettings* TempoSensorsSettings = GetDefault<UTempoSensorsSettings>();
+	const UDataTable* SemanticLabelTable = TempoSensorsSettings->GetSemanticLabelTable();
+	const FName OverridableLabelRowName = TempoSensorsSettings->GetOverridableLabelRowName();
+	const FName OverridingLabelRowName = TempoSensorsSettings->GetOverridingLabelRowName();
+	TOptional<int32> OverridableLabel;
+	TOptional<int32> OverridingLabel;
+	if (SemanticLabelTable && !OverridableLabelRowName.IsNone())
+	{
+		SemanticLabelTable->ForeachRow<FSemanticLabel>(TEXT(""),
+			[&OverridableLabelRowName, &OverridingLabelRowName, &OverridableLabel, &OverridingLabel]
+			(const FName& Key, const FSemanticLabel& Value)
+			{
+				if (Key == OverridableLabelRowName)
+				{
+					OverridableLabel = Value.Label;
+				}
+				if (Key == OverridingLabelRowName)
+				{
+					OverridingLabel = Value.Label;
+				}
+			});
+	}
+
+	if (OverridableLabel.IsSet() && OverridingLabel.IsSet())
+	{
+		MaterialInstance->SetScalarParameterValue(TEXT("OverridableLabel"), OverridableLabel.GetValue());
+		MaterialInstance->SetScalarParameterValue(TEXT("OverridingLabel"), OverridingLabel.GetValue());
+	}
+	else
+	{
+		MaterialInstance->SetScalarParameterValue(TEXT("OverridingLabel"), 0.0);
+	}
 }

--- a/TempoSensors/Source/TempoSensors/Private/TempoSensorsUtils.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoSensorsUtils.cpp
@@ -6,7 +6,12 @@
 #include "TempoSensorsSettings.h"
 
 #include "Engine/DataTable.h"
+#include "Engine/SkeletalMesh.h"
+#include "Engine/StaticMesh.h"
+#include "GameFramework/Actor.h"
 #include "Materials/MaterialInstanceDynamic.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
 
 void OptimizeShowFlagsForNoColor(FEngineShowFlags& ShowFlags)
 {
@@ -177,4 +182,104 @@ void ApplyLabelOverrideParameters(UMaterialInstanceDynamic* MaterialInstance)
 	{
 		MaterialInstance->SetScalarParameterValue(TEXT("OverridingLabel"), 0.0);
 	}
+}
+
+namespace
+{
+	// Write a row's TSet column as a sorted JSON array. Sorting is what makes two exports of the
+	// same table comparable; TSet iteration order is not stable.
+	void WriteSortedStringArray(const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>>& JsonWriter,
+		const TCHAR* ColumnName, TArray<FString>& Values)
+	{
+		Values.Sort();
+		JsonWriter->WriteArrayStart(ColumnName);
+		for (const FString& Value : Values)
+		{
+			JsonWriter->WriteValue(Value);
+		}
+		JsonWriter->WriteArrayEnd();
+	}
+
+	TArray<FString> ToStringArray(const TSet<FName>& Names)
+	{
+		TArray<FString> Strings;
+		Strings.Reserve(Names.Num());
+		for (const FName& Name : Names)
+		{
+			Strings.Add(Name.ToString());
+		}
+		return Strings;
+	}
+}
+
+FString ExportSemanticLabelTableToJson(const UDataTable* SemanticLabelTable)
+{
+	FString Json;
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter =
+		TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Json);
+
+	JsonWriter->WriteArrayStart();
+
+	if (SemanticLabelTable)
+	{
+		TArray<TPair<FString, const FSemanticLabel*>> Rows;
+		SemanticLabelTable->ForeachRow<FSemanticLabel>(TEXT(""), [&Rows](const FName& Key, const FSemanticLabel& Value)
+		{
+			Rows.Emplace(Key.ToString(), &Value);
+		});
+		Rows.Sort([](const TPair<FString, const FSemanticLabel*>& A, const TPair<FString, const FSemanticLabel*>& B)
+		{
+			return A.Key < B.Key;
+		});
+
+		for (const auto& [RowName, Row] : Rows)
+		{
+			JsonWriter->WriteObjectStart();
+			JsonWriter->WriteValue(TEXT("Name"), RowName);
+			JsonWriter->WriteValue(TEXT("Label"), Row->Label);
+
+			TArray<FString> ActorTypes;
+			for (const TSubclassOf<AActor>& ActorType : Row->ActorTypes)
+			{
+				if (const UClass* ActorClass = ActorType.Get())
+				{
+					ActorTypes.Add(ActorClass->GetPathName());
+				}
+			}
+			WriteSortedStringArray(JsonWriter, TEXT("ActorTypes"), ActorTypes);
+
+			TArray<FString> ActorTags = ToStringArray(Row->ActorTags);
+			WriteSortedStringArray(JsonWriter, TEXT("ActorTags"), ActorTags);
+
+			TArray<FString> StaticMeshTypes;
+			for (const TSoftObjectPtr<UStaticMesh>& StaticMeshType : Row->StaticMeshTypes)
+			{
+				if (!StaticMeshType.IsNull())
+				{
+					StaticMeshTypes.Add(StaticMeshType.ToSoftObjectPath().ToString());
+				}
+			}
+			WriteSortedStringArray(JsonWriter, TEXT("StaticMeshTypes"), StaticMeshTypes);
+
+			TArray<FString> SkeletalMeshTypes;
+			for (const TSoftObjectPtr<USkeletalMesh>& SkeletalMeshType : Row->SkeletalMeshTypes)
+			{
+				if (!SkeletalMeshType.IsNull())
+				{
+					SkeletalMeshTypes.Add(SkeletalMeshType.ToSoftObjectPath().ToString());
+				}
+			}
+			WriteSortedStringArray(JsonWriter, TEXT("SkeletalMeshTypes"), SkeletalMeshTypes);
+
+			TArray<FString> ComponentTags = ToStringArray(Row->ComponentTags);
+			WriteSortedStringArray(JsonWriter, TEXT("ComponentTags"), ComponentTags);
+
+			JsonWriter->WriteObjectEnd();
+		}
+	}
+
+	JsonWriter->WriteArrayEnd();
+	JsonWriter->Close();
+
+	return Json;
 }

--- a/TempoSensors/Source/TempoSensors/Private/TempoTiledSceneCaptureComponent.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoTiledSceneCaptureComponent.cpp
@@ -99,6 +99,9 @@ void UTempoTiledSceneCaptureComponent::BeginPlay()
 	SyncTiles();
 	UpdateInternalMirrors();
 
+	GetMutableDefault<UTempoSensorsSettings>()->TempoSensorsLabelOverridesChangedEvent.AddUObject(
+		this, &UTempoTiledSceneCaptureComponent::ApplyLabelOverridesToTiles);
+
 	if (UTempoCoreUtils::IsGameWorld(this))
 	{
 		// Activate() runs when added to a live world, but may be skipped in some registration
@@ -135,6 +138,8 @@ void UTempoTiledSceneCaptureComponent::Deactivate()
 
 void UTempoTiledSceneCaptureComponent::OnUnregister()
 {
+	GetMutableDefault<UTempoSensorsSettings>()->TempoSensorsLabelOverridesChangedEvent.RemoveAll(this);
+
 	// Destroy tile view states while the scene is still valid, before Super unregisters us from it
 	// (matches USceneCaptureComponent::OnUnregister, which destroys the inherited ViewStates here).
 	DeactivateAllTiles();

--- a/TempoSensors/Source/TempoSensors/Private/Tests/TempoLabelTableTest.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/Tests/TempoLabelTableTest.cpp
@@ -1,8 +1,10 @@
 // Copyright Tempo Simulation, LLC. All Rights Reserved
 
 #include "TempoLabelTypes.h"
+#include "TempoSensorsUtils.h"
 
 #include "Engine/DataTable.h"
+#include "Engine/SkeletalMesh.h"
 #include "Engine/StaticMeshActor.h"
 #include "Misc/AutomationTest.h"
 
@@ -41,6 +43,8 @@ bool FTempoLabelTableImportTest::RunTest(const FString& Parameters)
 			"Name": "Vehicle",
 			"Label": 14,
 			"ActorTypes": [ "/Script/Engine.StaticMeshActor" ],
+			"ActorTags": [ "HeroVehicle" ],
+			"SkeletalMeshTypes": [ "/Engine/EngineMeshes/SkeletalCube.SkeletalCube" ],
 			"ComponentTags": [ "Chassis", "Wheels" ]
 		}
 	])");
@@ -66,9 +70,19 @@ bool FTempoLabelTableImportTest::RunTest(const FString& Parameters)
 	TestEqual(TEXT("Vehicle component tag count"), Vehicle->ComponentTags.Num(), 2);
 	TestTrue(TEXT("Vehicle component tags imported"),
 		Vehicle->ComponentTags.Contains(TEXT("Chassis")) && Vehicle->ComponentTags.Contains(TEXT("Wheels")));
+	TestEqual(TEXT("Vehicle actor tag count"), Vehicle->ActorTags.Num(), 1);
+	TestTrue(TEXT("Vehicle actor tag imported"), Vehicle->ActorTags.Contains(TEXT("HeroVehicle")));
 
 	// Columns a row omits are left at the row struct's defaults, not rejected.
-	TestEqual(TEXT("Omitted StaticMeshTypes defaults to empty"), Vehicle->StaticMeshTypes.Num(), 0);
+	// SkeletalMeshTypes must resolve to a real asset, not be dropped on the floor.
+	TestEqual(TEXT("Vehicle skeletal mesh type count"), Vehicle->SkeletalMeshTypes.Num(), 1);
+	if (Vehicle->SkeletalMeshTypes.Num() == 1)
+	{
+		const TSoftObjectPtr<USkeletalMesh> SkeletalMeshType = Vehicle->SkeletalMeshTypes.Array()[0];
+		TestNotNull(TEXT("Skeletal mesh in SkeletalMeshTypes loads"), SkeletalMeshType.LoadSynchronous());
+	}
+
+	TestEqual(TEXT("Omitted StaticMeshTypes defaults to empty"), NoLabel->StaticMeshTypes.Num(), 0);
 	TestEqual(TEXT("Omitted ActorTypes defaults to empty"), NoLabel->ActorTypes.Num(), 0);
 
 	return true;
@@ -93,6 +107,61 @@ bool FTempoLabelTableImportProblemsTest::RunTest(const FString& Parameters)
 
 	ImportLabelTable(TEXT(R"([ { "Name": "Tree", "Label": 3, "NotAColumn": 1 } ])"), Problems);
 	TestFalse(TEXT("An unrecognized column is a problem"), Problems.IsEmpty());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoLabelTableRoundTripTest,
+	"Tempo.Sensors.LabelTable.RoundTrip", TempoLabelTableTestFlags)
+bool FTempoLabelTableRoundTripTest::RunTest(const FString& Parameters)
+{
+	// GetLabelTableAsJson exists so a client can fetch the live table, edit it, and load it back
+	// through LoadLabelTable. That only works if the export is exactly what the importer reads, so
+	// pin the round trip down rather than the export's spelling.
+	const FString SourceJson = TEXT(R"([
+		{ "Name": "NoLabel", "Label": 0 },
+		{
+			"Name": "Vehicle",
+			"Label": 14,
+			"ActorTypes": [ "/Script/Engine.StaticMeshActor" ],
+			"ActorTags": [ "HeroVehicle", "Parked" ],
+			"SkeletalMeshTypes": [ "/Engine/EngineMeshes/SkeletalCube.SkeletalCube" ],
+			"ComponentTags": [ "Chassis" ]
+		}
+	])");
+
+	TArray<FString> Problems;
+	const UDataTable* Original = ImportLabelTable(SourceJson, Problems);
+	if (!TestTrue(TEXT("Source table imports"), Problems.IsEmpty()))
+	{
+		return false;
+	}
+
+	const FString ExportedJson = ExportSemanticLabelTableToJson(Original);
+	const UDataTable* Reimported = ImportLabelTable(ExportedJson, Problems);
+	if (!TestTrue(FString::Printf(TEXT("Exported table re-imports (got: %s)"), *FString::Join(Problems, TEXT(" "))), Problems.IsEmpty()))
+	{
+		return false;
+	}
+
+	TestEqual(TEXT("Row count survives the round trip"), Reimported->GetRowNames().Num(), Original->GetRowNames().Num());
+
+	const FSemanticLabel* Vehicle = Reimported->FindRow<FSemanticLabel>(TEXT("Vehicle"), TEXT(""), false);
+	if (!TestNotNull(TEXT("Vehicle row survives"), Vehicle))
+	{
+		return false;
+	}
+	TestEqual(TEXT("Label survives"), Vehicle->Label, 14);
+	TestTrue(TEXT("Actor type survives"), Vehicle->ActorTypes.Contains(AStaticMeshActor::StaticClass()));
+	TestEqual(TEXT("Actor tag count survives"), Vehicle->ActorTags.Num(), 2);
+	TestTrue(TEXT("Actor tags survive"),
+		Vehicle->ActorTags.Contains(TEXT("HeroVehicle")) && Vehicle->ActorTags.Contains(TEXT("Parked")));
+	TestTrue(TEXT("Component tag survives"), Vehicle->ComponentTags.Contains(TEXT("Chassis")));
+	TestEqual(TEXT("Skeletal mesh type survives"), Vehicle->SkeletalMeshTypes.Num(), 1);
+
+	// A second export of the same content must be byte-identical, or a client diffing two fetches
+	// would see spurious changes from TSet and row map iteration order.
+	TestEqual(TEXT("Export is stable across tables built separately"), ExportSemanticLabelTableToJson(Reimported), ExportedJson);
 
 	return true;
 }

--- a/TempoSensors/Source/TempoSensors/Private/Tests/TempoLabelTableTest.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/Tests/TempoLabelTableTest.cpp
@@ -1,0 +1,100 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#include "TempoLabelTypes.h"
+
+#include "Engine/DataTable.h"
+#include "Engine/StaticMeshActor.h"
+#include "Misc/AutomationTest.h"
+
+// Covers importing a semantic label table from JSON, the path LabelService's LoadLabelTable RPC
+// takes. FSemanticLabel's columns are TSets — of classes, of soft mesh pointers, of names — so
+// this pins down that the runtime DataTable JSON importer handles them, and that a malformed
+// table is reported rather than silently accepted. Run via Scripts/Test.sh, or from the editor
+// console with
+//   Automation RunTests Tempo.Sensors.LabelTable
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+namespace
+{
+	constexpr EAutomationTestFlags TempoLabelTableTestFlags =
+		EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter;
+
+	UDataTable* ImportLabelTable(const FString& Json, TArray<FString>& OutProblems)
+	{
+		UDataTable* Table = NewObject<UDataTable>(GetTransientPackage(), NAME_None, RF_Transient);
+		Table->RowStruct = FSemanticLabel::StaticStruct();
+		// Mirrors UTempoActorLabeler::HandleLoadLabelTable.
+		Table->bIgnoreMissingFields = true;
+		OutProblems = Table->CreateTableFromJSONString(Json);
+		return Table;
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoLabelTableImportTest,
+	"Tempo.Sensors.LabelTable.Import", TempoLabelTableTestFlags)
+bool FTempoLabelTableImportTest::RunTest(const FString& Parameters)
+{
+	const FString Json = TEXT(R"([
+		{ "Name": "NoLabel", "Label": 0 },
+		{
+			"Name": "Vehicle",
+			"Label": 14,
+			"ActorTypes": [ "/Script/Engine.StaticMeshActor" ],
+			"ComponentTags": [ "Chassis", "Wheels" ]
+		}
+	])");
+
+	TArray<FString> Problems;
+	const UDataTable* Table = ImportLabelTable(Json, Problems);
+	TestTrue(FString::Printf(TEXT("Import reports no problems (got: %s)"), *FString::Join(Problems, TEXT(" "))), Problems.IsEmpty());
+
+	const FSemanticLabel* NoLabel = Table->FindRow<FSemanticLabel>(TEXT("NoLabel"), TEXT(""), false);
+	if (!TestNotNull(TEXT("NoLabel row imported"), NoLabel))
+	{
+		return false;
+	}
+	TestEqual(TEXT("NoLabel ID"), NoLabel->Label, 0);
+
+	const FSemanticLabel* Vehicle = Table->FindRow<FSemanticLabel>(TEXT("Vehicle"), TEXT(""), false);
+	if (!TestNotNull(TEXT("Vehicle row imported"), Vehicle))
+	{
+		return false;
+	}
+	TestEqual(TEXT("Vehicle ID"), Vehicle->Label, 14);
+	TestTrue(TEXT("Vehicle actor type resolved to a class"), Vehicle->ActorTypes.Contains(AStaticMeshActor::StaticClass()));
+	TestEqual(TEXT("Vehicle component tag count"), Vehicle->ComponentTags.Num(), 2);
+	TestTrue(TEXT("Vehicle component tags imported"),
+		Vehicle->ComponentTags.Contains(TEXT("Chassis")) && Vehicle->ComponentTags.Contains(TEXT("Wheels")));
+
+	// Columns a row omits are left at the row struct's defaults, not rejected.
+	TestEqual(TEXT("Omitted StaticMeshTypes defaults to empty"), Vehicle->StaticMeshTypes.Num(), 0);
+	TestEqual(TEXT("Omitted ActorTypes defaults to empty"), NoLabel->ActorTypes.Num(), 0);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoLabelTableImportProblemsTest,
+	"Tempo.Sensors.LabelTable.ImportProblems", TempoLabelTableTestFlags)
+bool FTempoLabelTableImportProblemsTest::RunTest(const FString& Parameters)
+{
+	// LoadLabelTable rejects a table whose import reported any problem, so every malformed input
+	// below has to surface one rather than importing partially.
+	TArray<FString> Problems;
+
+	ImportLabelTable(TEXT(""), Problems);
+	TestFalse(TEXT("Empty input is a problem"), Problems.IsEmpty());
+
+	ImportLabelTable(TEXT("not json"), Problems);
+	TestFalse(TEXT("Unparseable JSON is a problem"), Problems.IsEmpty());
+
+	ImportLabelTable(TEXT(R"([ { "Label": 3 } ])"), Problems);
+	TestFalse(TEXT("A row with no Name key is a problem"), Problems.IsEmpty());
+
+	ImportLabelTable(TEXT(R"([ { "Name": "Tree", "Label": 3, "NotAColumn": 1 } ])"), Problems);
+	TestFalse(TEXT("An unrecognized column is a problem"), Problems.IsEmpty());
+
+	return true;
+}
+
+#endif

--- a/TempoSensors/Source/TempoSensors/Public/Camera.proto
+++ b/TempoSensors/Source/TempoSensors/Public/Camera.proto
@@ -47,7 +47,7 @@ message BoundingBox2D {
   uint32 max_x_px = 3;
   // Bottom-right Y in pixels.
   uint32 max_y_px = 4;
-  // Instance ID from the matching label image (1-255).
+  // Instance ID from the matching label image (1-253).
   uint32 instance_id = 5;
   // Semantic class ID.
   uint32 semantic_id = 6;

--- a/TempoSensors/Source/TempoSensors/Public/Labels.proto
+++ b/TempoSensors/Source/TempoSensors/Public/Labels.proto
@@ -37,6 +37,8 @@ message SemanticClassInfo {
   repeated string actor_types = 3;        // Actor types assigned to this class
   repeated string static_mesh_types = 4;  // Static mesh paths assigned to this class
   repeated string component_tags = 5;     // Component tags assigned to this class
+  repeated string actor_tags = 6;         // Actor tags assigned to this class
+  repeated string skeletal_mesh_types = 7;  // Skeletal mesh paths assigned to this class
 }
 
 message GetSemanticClassesResponse {
@@ -46,6 +48,13 @@ message GetSemanticClassesResponse {
 message SetActorTypeSemanticIdRequest {
   // Class name. A Blueprint class may be named with or without its generated "_C" suffix.
   string actor_type = 1;    // e.g., "CBP_QuantumCharacter_C" (class name)
+  int32 semantic_id = 2;    // 0-255 to set, -1 to revert to DataTable default
+}
+
+message SetActorTagSemanticIdRequest {
+  // An Actor tag, as it appears in the Actor's Tags array. Beats the Actor's type, so it labels
+  // one particular Actor differently from others of its class.
+  string actor_tag = 1;
   int32 semantic_id = 2;    // 0-255 to set, -1 to revert to DataTable default
 }
 
@@ -81,7 +90,8 @@ message SetLabelTypeRequest {
 message LoadLabelTableRequest {
   // The label table as an Unreal DataTable JSON document: a JSON array of row objects, each
   // with a "Name" key (the label's row name) plus any of the row's columns — "Label" (the
-  // integer ID written to the label image), "ActorTypes", "StaticMeshTypes", "ComponentTags".
+  // integer ID written to the label image), "ActorTypes", "ActorTags", "StaticMeshTypes",
+  // "SkeletalMeshTypes", "ComponentTags".
   // Asset references are full object paths, e.g. "/Game/Vehicles/BP_Car.BP_Car_C". A column a row
   // omits is left empty; an unrecognized column name is an error. Include a "NoLabel" row: it
   // names the ID used for everything the table does not otherwise match.
@@ -109,6 +119,14 @@ message SetLabelRowOverridesRequest {
   string overriding_row_name = 2;
 }
 
+message GetLabelTableAsJsonResponse {
+  // The label table currently in effect, in the same Unreal DataTable JSON format LoadLabelTable
+  // accepts, so it can be fetched, edited, and loaded back. Rows and the entries within each row
+  // are sorted by name, so two exports of the same table diff cleanly. Runtime per-type overrides
+  // set through SetActorTypeSemanticId and friends are NOT folded in — this is the table itself.
+  string json = 1;
+}
+
 service LabelService {
   rpc GetInstanceToSemanticIdMap(TempoCore.Empty) returns (InstanceToSemanticIdMap);
 
@@ -123,6 +141,10 @@ service LabelService {
   rpc GetAllStaticMeshTypes(TempoCore.Empty) returns (GetAllStaticMeshTypesResponse);
 
   rpc SetStaticMeshTypeSemanticId(SetStaticMeshTypeSemanticIdRequest) returns (TempoCore.Empty);
+
+  rpc SetActorTagSemanticId(SetActorTagSemanticIdRequest) returns (TempoCore.Empty);
+
+  rpc GetLabelTableAsJson(TempoCore.Empty) returns (GetLabelTableAsJsonResponse);
 
   rpc SetLabelType(SetLabelTypeRequest) returns (TempoCore.Empty);
 

--- a/TempoSensors/Source/TempoSensors/Public/Labels.proto
+++ b/TempoSensors/Source/TempoSensors/Public/Labels.proto
@@ -65,6 +65,50 @@ message GetAllStaticMeshTypesResponse {
   repeated StaticMeshTypeInfo mesh_types = 1;
 }
 
+// The global label type. Determines what the label image and lidar label channel carry:
+// the semantic class ID shared by every object of a class, or a per-object instance ID.
+enum LabelType {
+  LT_UNKNOWN = 0;
+  LT_SEMANTIC = 1;
+  LT_INSTANCE = 2;
+}
+
+message SetLabelTypeRequest {
+  LabelType label_type = 1;
+}
+
+// The table is supplied either inline or by path. Exactly one of json and json_file must be set.
+message LoadLabelTableRequest {
+  // The label table as an Unreal DataTable JSON document: a JSON array of row objects, each
+  // with a "Name" key (the label's row name) plus any of the row's columns — "Label" (the
+  // integer ID written to the label image), "ActorTypes", "StaticMeshTypes", "ComponentTags".
+  // Asset references are full object paths, e.g. "/Game/Vehicles/BP_Car.BP_Car_C". A column a row
+  // omits is left empty; an unrecognized column name is an error. Include a "NoLabel" row: it
+  // names the ID used for everything the table does not otherwise match.
+  string json = 1;
+  // Path to a file holding the same JSON document. Relative paths resolve against the
+  // project directory.
+  string json_file = 2;
+}
+
+message SetInstanceLabelUniquenessRequest {
+  // If true, an instance ID is never handed out again once its object is destroyed. Only 255 IDs
+  // exist, so a long run that spawns and destroys labeled objects will eventually exhaust them.
+  bool globally_unique = 1;
+  // If true, objects go unlabeled once all 255 IDs are in use, rather than sharing an ID with
+  // another live object. If false, IDs are reused and an ID may name several live objects at once.
+  bool instantaneously_unique = 2;
+}
+
+message SetLabelRowOverridesRequest {
+  // Row name of the label that a material may override through its subsurface color.
+  // Empty to disable overriding entirely.
+  string overridable_row_name = 1;
+  // Row name of the label substituted wherever an object labeled overridable_row_name has a
+  // non-zero subsurface color.
+  string overriding_row_name = 2;
+}
+
 service LabelService {
   rpc GetInstanceToSemanticIdMap(TempoCore.Empty) returns (InstanceToSemanticIdMap);
 
@@ -79,4 +123,12 @@ service LabelService {
   rpc GetAllStaticMeshTypes(TempoCore.Empty) returns (GetAllStaticMeshTypesResponse);
 
   rpc SetStaticMeshTypeSemanticId(SetStaticMeshTypeSemanticIdRequest) returns (TempoCore.Empty);
+
+  rpc SetLabelType(SetLabelTypeRequest) returns (TempoCore.Empty);
+
+  rpc LoadLabelTable(LoadLabelTableRequest) returns (TempoCore.Empty);
+
+  rpc SetInstanceLabelUniqueness(SetInstanceLabelUniquenessRequest) returns (TempoCore.Empty);
+
+  rpc SetLabelRowOverrides(SetLabelRowOverridesRequest) returns (TempoCore.Empty);
 }

--- a/TempoSensors/Source/TempoSensors/Public/Labels.proto
+++ b/TempoSensors/Source/TempoSensors/Public/Labels.proto
@@ -48,19 +48,19 @@ message GetSemanticClassesResponse {
 message SetActorTypeSemanticIdRequest {
   // Class name. A Blueprint class may be named with or without its generated "_C" suffix.
   string actor_type = 1;    // e.g., "CBP_QuantumCharacter_C" (class name)
-  int32 semantic_id = 2;    // 0-255 to set, -1 to revert to DataTable default
+  int32 semantic_id = 2;    // 0-253 to set, -1 to revert to DataTable default
 }
 
 message SetActorTagSemanticIdRequest {
   // An Actor tag, as it appears in the Actor's Tags array. Beats the Actor's type, so it labels
   // one particular Actor differently from others of its class.
   string actor_tag = 1;
-  int32 semantic_id = 2;    // 0-255 to set, -1 to revert to DataTable default
+  int32 semantic_id = 2;    // 0-253 to set, -1 to revert to DataTable default
 }
 
 message SetStaticMeshTypeSemanticIdRequest {
   string static_mesh_path = 1;  // Full asset path, e.g., "/Game/Meshes/SM_Tree.SM_Tree"
-  int32 semantic_id = 2;        // 0-255 to set, -1 to clear override
+  int32 semantic_id = 2;        // 0-253 to set, -1 to clear override
 }
 
 message StaticMeshTypeInfo {
@@ -102,10 +102,10 @@ message LoadLabelTableRequest {
 }
 
 message SetInstanceLabelUniquenessRequest {
-  // If true, an instance ID is never handed out again once its object is destroyed. Only 255 IDs
+  // If true, an instance ID is never handed out again once its object is destroyed. Only 253 IDs
   // exist, so a long run that spawns and destroys labeled objects will eventually exhaust them.
   bool globally_unique = 1;
-  // If true, objects go unlabeled once all 255 IDs are in use, rather than sharing an ID with
+  // If true, objects go unlabeled once all 253 IDs are in use, rather than sharing an ID with
   // another live object. If false, IDs are reused and an ID may name several live objects at once.
   bool instantaneously_unique = 2;
 }

--- a/TempoSensors/Source/TempoSensors/Public/Sensors.proto
+++ b/TempoSensors/Source/TempoSensors/Public/Sensors.proto
@@ -31,6 +31,14 @@ message AvailableSensorsResponse {
   repeated SensorDescriptor available_sensors = 1;
 }
 
+message SetPipelinedRenderingEnabledRequest {
+  // When enabled, FixedStep time mode lets the game thread advance without waiting for sensor
+  // readback. Images may arrive one or two frames late — their MeasurementHeader still carries
+  // the capture time and sequence ID of the frame they were captured on — but the game, render,
+  // and readback pipelines run in parallel, raising throughput.
+  bool enabled = 1;
+}
+
 service SensorService {
   rpc GetAvailableSensors(TempoCore.Empty) returns (AvailableSensorsResponse);
 
@@ -45,4 +53,6 @@ service SensorService {
   rpc StreamLidarScans(TempoSensors.LidarScanRequest) returns (stream TempoSensors.LidarScanSegment);
 
   rpc StreamVideo(TempoSensors.VideoRequest) returns (stream TempoSensors.VideoFrame);
+
+  rpc SetPipelinedRenderingEnabled(SetPipelinedRenderingEnabledRequest) returns (TempoCore.Empty);
 }

--- a/TempoSensors/Source/TempoSensors/Public/TempoActorLabeler.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoActorLabeler.h
@@ -55,6 +55,10 @@ namespace TempoSensors
 	class SetActorTypeSemanticIdRequest;
 	class GetAllStaticMeshTypesResponse;
 	class SetStaticMeshTypeSemanticIdRequest;
+	class SetLabelTypeRequest;
+	class LoadLabelTableRequest;
+	class SetInstanceLabelUniquenessRequest;
+	class SetLabelRowOverridesRequest;
 }
 
 /**
@@ -89,6 +93,14 @@ public:
 	void HandleGetAllStaticMeshTypes(const TempoCore::Empty& Request, const TResponseDelegate<TempoSensors::GetAllStaticMeshTypesResponse>& ResponseContinuation);
 
 	void HandleSetStaticMeshTypeSemanticId(const TempoSensors::SetStaticMeshTypeSemanticIdRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
+
+	void HandleSetLabelType(const TempoSensors::SetLabelTypeRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
+
+	void HandleLoadLabelTable(const TempoSensors::LoadLabelTableRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
+
+	void HandleSetInstanceLabelUniqueness(const TempoSensors::SetInstanceLabelUniquenessRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
+
+	void HandleSetLabelRowOverrides(const TempoSensors::SetLabelRowOverridesRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
 
 	const TSet<FName>& GetLabeledActorClassNames() const { return LabeledActorClassNames; }
 
@@ -127,7 +139,9 @@ protected:
 
 	void UnLabelComponent(UPrimitiveComponent* Component);
 
-	void ReLabelAllActors();
+	// Re-derive everything cached from the semantic label table, then re-label the world from
+	// scratch. Bound to the settings' label-settings-changed event.
+	void OnLabelSettingsChanged();
 
 	static void AssignId(UPrimitiveComponent* Component, FInstanceSemanticIdPair IdPair);
 

--- a/TempoSensors/Source/TempoSensors/Public/TempoActorLabeler.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoActorLabeler.h
@@ -55,6 +55,8 @@ namespace TempoSensors
 	class SetActorTypeSemanticIdRequest;
 	class GetAllStaticMeshTypesResponse;
 	class SetStaticMeshTypeSemanticIdRequest;
+	class SetActorTagSemanticIdRequest;
+	class GetLabelTableAsJsonResponse;
 	class SetLabelTypeRequest;
 	class LoadLabelTableRequest;
 	class SetInstanceLabelUniquenessRequest;
@@ -94,6 +96,10 @@ public:
 
 	void HandleSetStaticMeshTypeSemanticId(const TempoSensors::SetStaticMeshTypeSemanticIdRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
 
+	void HandleSetActorTagSemanticId(const TempoSensors::SetActorTagSemanticIdRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
+
+	void HandleGetLabelTableAsJson(const TempoCore::Empty& Request, const TResponseDelegate<TempoSensors::GetLabelTableAsJsonResponse>& ResponseContinuation) const;
+
 	void HandleSetLabelType(const TempoSensors::SetLabelTypeRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
 
 	void HandleLoadLabelTable(const TempoSensors::LoadLabelTableRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
@@ -119,15 +125,21 @@ protected:
 
 	void LabelComponent(UPrimitiveComponent* Component, FInstanceSemanticIdPair ActorIdPair);
 
+	// Resolves the label an Actor earns, honoring runtime overrides over the label table. Unset
+	// means nothing in the table matches the Actor and it should go unlabeled.
+	TOptional<int32> ResolveActorSemanticId(const AActor* Actor) const;
+
 	// Resolves the label a Component earns in its own right, independent of its owning Actor.
 	// Unset means the Component has no label of its own and should inherit its Actor's.
 	TOptional<int32> ResolveComponentSemanticId(const UPrimitiveComponent* Component) const;
 
-	// Resolves the label a static mesh asset path earns, honoring runtime overrides over the label table.
-	TOptional<int32> ResolveStaticMeshSemanticId(const FString& MeshPath) const;
+	// Resolves the label a mesh asset path earns, static or skeletal, honoring runtime overrides
+	// over the label table.
+	TOptional<int32> ResolveMeshSemanticId(const FString& MeshPath) const;
 
-	// The static mesh assets a Component renders: its own mesh, or the meshes a Niagara system instances.
-	static void GetComponentStaticMeshPaths(const UPrimitiveComponent* Component, TArray<FString>& OutMeshPaths);
+	// The mesh assets a Component renders: its own static or skeletal mesh, or the meshes a Niagara
+	// system instances.
+	static void GetComponentMeshPaths(const UPrimitiveComponent* Component, TArray<FString>& OutMeshPaths);
 
 	void UnLabelAllActors();
 
@@ -155,7 +167,13 @@ protected:
 	TMap<FString, FName> StaticMeshLabels;
 
 	UPROPERTY(VisibleAnywhere)
+	TMap<FString, FName> SkeletalMeshLabels;
+
+	UPROPERTY(VisibleAnywhere)
 	TMap<FName, FName> ComponentTagLabels;
+
+	UPROPERTY(VisibleAnywhere)
+	TMap<FName, FName> ActorTagLabels;
 
 	UPROPERTY(VisibleAnywhere)
 	TMap<FName, int32> SemanticIds;
@@ -182,6 +200,11 @@ protected:
 	// Takes precedence over DataTable definitions (StaticMeshLabels)
 	UPROPERTY()
 	TMap<FString, int32> StaticMeshTypeSemanticIdOverrides;
+
+	// Runtime overrides for actor tags (tag -> semantic ID)
+	// Takes precedence over DataTable definitions (ActorTagLabels)
+	UPROPERTY()
+	TMap<FName, int32> ActorTagSemanticIdOverrides;
 
 	FInstanceIdAllocator InstanceIdAllocator = FInstanceIdAllocator(1, 255);
 };

--- a/TempoSensors/Source/TempoSensors/Public/TempoActorLabeler.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoActorLabeler.h
@@ -7,6 +7,8 @@
 #include "CoreMinimal.h"
 #include "Subsystems/WorldSubsystem.h"
 
+#include "TempoSensorsConstants.h"
+
 #include "TempoServiceProvider.h"
 #include "TempoServer.h"
 #include "TempoSubsystems.h"
@@ -206,5 +208,7 @@ protected:
 	UPROPERTY()
 	TMap<FName, int32> ActorTagSemanticIdOverrides;
 
-	FInstanceIdAllocator InstanceIdAllocator = FInstanceIdAllocator(1, 255);
+	// 0 is reserved for "unlabeled", and the camera cannot encode an ID above
+	// GTempoCamera_Max_Label, so instance IDs run 1..GTempoCamera_Max_Label.
+	FInstanceIdAllocator InstanceIdAllocator = FInstanceIdAllocator(1, GTempoCamera_Max_Label);
 };

--- a/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
@@ -314,6 +314,7 @@ protected:
 	virtual void ReconfigureTilesNow() override;
 	virtual void UpdateInternalMirrors() override;
 	virtual void DeactivateAllTiles() override;
+	virtual void ApplyLabelOverridesToTiles() override;
 	// End UTempoTiledSceneCaptureComponent tile interface
 
 	// Returns SharedFinalTextureTarget so OnRenderCompleted reads from the merged output.

--- a/TempoSensors/Source/TempoSensors/Public/TempoLabelTypes.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoLabelTypes.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Engine/DataTable.h"
+#include "Engine/SkeletalMesh.h"
 
 #include "TempoLabelTypes.generated.h"
 
@@ -20,10 +21,23 @@ struct FSemanticLabel: public FTableRowBase
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TSet<TSubclassOf<AActor>> ActorTypes;
 
+	// The Actor tags which should be tagged with this label (overrides labels at the actor type level).
+	// The escape hatch for Actors their class can't distinguish: one instance of a class labeled
+	// differently from the rest, or an Actor assembled at runtime whose class says nothing useful.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TSet<FName> ActorTags;
+
 	// The StaticMesh types which should be tagged with this label (overrides labels at the actor level).
 	// Also matches the meshes a Niagara mesh renderer instances.
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TSet<TSoftObjectPtr<UStaticMesh>> StaticMeshTypes;
+
+	// The SkeletalMesh types which should be tagged with this label (overrides labels at the actor level).
+	// Separate from StaticMeshTypes rather than one widened column, because the two asset types share
+	// no base narrower than UStreamableRenderAsset (which textures also derive from) and the existing
+	// static-mesh RPCs name their type on the wire.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TSet<TSoftObjectPtr<USkeletalMesh>> SkeletalMeshTypes;
 
 	// The component tags which should be tagged with this label (overrides labels at the mesh and actor levels).
 	// The escape hatch for components no mesh asset can identify: components whose mesh is built at

--- a/TempoSensors/Source/TempoSensors/Public/TempoLidar.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoLidar.h
@@ -258,6 +258,7 @@ protected:
 	virtual void ReconfigureTilesNow() override;
 	virtual void UpdateInternalMirrors() override;
 	virtual void DeactivateAllTiles() override;
+	virtual void ApplyLabelOverridesToTiles() override;
 	// End UTempoTiledSceneCaptureComponent tile interface
 
 	void ConfigureTile(FTempoLidarTile& Tile, double InYawOffset, double SubHorizontalFOV, int32 SubHorizontalBeams, bool bActivate);

--- a/TempoSensors/Source/TempoSensors/Public/TempoSensorServiceSubsystem.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoSensorServiceSubsystem.h
@@ -30,6 +30,7 @@ namespace TempoSensors
 	class LidarScanSegment;
 	class VideoRequest;
 	class VideoFrame;
+	class SetPipelinedRenderingEnabledRequest;
 }
 
 UCLASS()
@@ -63,6 +64,8 @@ public:
 	void StreamLidarScans(const TempoSensors::LidarScanRequest& Request, const TResponseDelegate<TempoSensors::LidarScanSegment>& ResponseContinuation) const;
 
 	void StreamVideo(const TempoSensors::VideoRequest& Request, const TResponseDelegate<TempoSensors::VideoFrame>& ResponseContinuation) const;
+
+	void SetPipelinedRenderingEnabled(const TempoSensors::SetPipelinedRenderingEnabledRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation) const;
 
 protected:
 	void OnRenderFrameCompleted() const;

--- a/TempoSensors/Source/TempoSensors/Public/TempoSensorsSettings.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoSensorsSettings.h
@@ -103,7 +103,7 @@ private:
 	UPROPERTY(EditAnywhere, Config, Category="Labels", meta=(EditCondition="LabelType == ELabelType::Instance"))
 	bool bGloballyUniqueInstanceLabels = false;
 
-	// Whether to reuse instance labels after exhausting our 256 unique labels.
+	// Whether to reuse instance labels after exhausting our 253 unique labels.
 	UPROPERTY(EditAnywhere, Config, Category="Labels", meta=(EditCondition="LabelType == ELabelType::Instance"))
 	bool bInstantaneouslyUniqueInstanceLabels = false;
 

--- a/TempoSensors/Source/TempoSensors/Public/TempoSensorsSettings.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoSensorsSettings.h
@@ -9,7 +9,15 @@
 
 #include "TempoSensorsSettings.generated.h"
 
+class UDataTable;
+
+// Broadcast when the set of labels, or which objects earn them, changes. Listeners must re-derive
+// everything they cached from the label table and re-label the world.
 DECLARE_MULTICAST_DELEGATE(FTempoSensorsLabelSettingsChanged);
+
+// Broadcast when the overridable/overriding label row pair changes, including when the label table
+// they name rows in is replaced. Listeners must re-resolve the pair to label IDs and re-push them.
+DECLARE_MULTICAST_DELEGATE(FTempoSensorsLabelOverridesChanged);
 
 /**
  * TempoSensors Plugin Settings.
@@ -29,10 +37,17 @@ public:
 #endif
 
 	// Labels
-	TObjectPtr<UDataTable> GetSemanticLabelTable() const { return SemanticLabelTable.LoadSynchronous(); }
+	TObjectPtr<UDataTable> GetSemanticLabelTable() const { return RuntimeSemanticLabelTable ? ToRawPtr(RuntimeSemanticLabelTable) : SemanticLabelTable.LoadSynchronous(); }
 	ELabelType GetLabelType() const { return LabelType; }
 	bool GetGloballyUniqueInstanceLabels() const { return bGloballyUniqueInstanceLabels; }
 	bool GetInstantaneouslyUniqueInstanceLabels() const { return bInstantaneouslyUniqueInstanceLabels; }
+	// Supersede the configured SemanticLabelTable with a table built at runtime, for the life of the
+	// process. Pass nullptr to fall back to the configured asset.
+	void SetRuntimeSemanticLabelTable(UDataTable* SemanticLabelTableIn);
+	void SetLabelType(ELabelType LabelTypeIn);
+	void SetGloballyUniqueInstanceLabels(bool bGloballyUniqueInstanceLabelsIn);
+	void SetInstantaneouslyUniqueInstanceLabels(bool bInstantaneouslyUniqueInstanceLabelsIn);
+	void SetLabelRowNameOverrides(FName OverridableLabelRowNameIn, FName OverridingLabelRowNameIn);
 
 	// Camera
 	TObjectPtr<UMaterialInterface> GetCameraPostProcessMaterialNoDepth() const { return CameraPostProcessMaterialNoDepth.LoadSynchronous(); }
@@ -49,7 +64,9 @@ public:
 	FName GetOverridingLabelRowName() const { return OverridingLabelRowName; }
 	int32 GetMaxRenderBufferSize() const { return MaxRenderBufferSize; }
 	bool GetPipelinedRendering() const { return bPipelinedRendering; }
+	void SetPipelinedRendering(bool bPipelinedRenderingIn);
 	FTempoSensorsLabelSettingsChanged TempoSensorsLabelSettingsChangedEvent;
+	FTempoSensorsLabelOverridesChanged TempoSensorsLabelOverridesChangedEvent;
 
 	// Lidar
 	float GetMaxLidarDepth() const { return MaxLidarDepth; }
@@ -72,6 +89,11 @@ private:
 	// In Instance label mode we will label all instances of objects that appear in the semantic label table.
 	UPROPERTY(EditAnywhere, Config, Category="Labels")
 	TSoftObjectPtr<UDataTable> SemanticLabelTable;
+
+	// A label table built at runtime (from JSON, via the API), which supersedes SemanticLabelTable
+	// while set. Not Config: a table with no asset behind it has no path to save.
+	UPROPERTY(Transient)
+	TObjectPtr<UDataTable> RuntimeSemanticLabelTable;
 
 	// The global label type to use.
 	UPROPERTY(EditAnywhere, Config, Category="Labels")

--- a/TempoSensors/Source/TempoSensors/Public/TempoSensorsUtils.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoSensorsUtils.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "Engine/Scene.h"
 
+class UDataTable;
 class UMaterialInstanceDynamic;
 
 void TEMPOSENSORS_API OptimizeShowFlagsForNoColor(FEngineShowFlags& ShowFlags);
@@ -23,3 +24,12 @@ void TEMPOSENSORS_API ApplyPhotorealisticRenderSettings(FPostProcessSettings& Ou
 // subsurface color. Sets OverridingLabel to 0 — disabling the substitution — whenever the pair
 // does not resolve, so clearing the row names at runtime takes effect on an already-built MID.
 void TEMPOSENSORS_API ApplyLabelOverrideParameters(UMaterialInstanceDynamic* MaterialInstance);
+
+// Serialize a semantic label table to an Unreal DataTable JSON document, in the format
+// UDataTable::CreateTableFromJSONString reads back — so a client can fetch the live table, edit it,
+// and load it again. UDataTable's own GetTableAsJSON is editor-only, hence this.
+//
+// Rows, and the entries within each row, are sorted by name: the table's row map and the row's
+// TSet columns iterate in an order that says nothing, and an export meant to be diffed has to be
+// stable across runs. Unresolved entries are dropped, having no path left to write.
+FString TEMPOSENSORS_API ExportSemanticLabelTableToJson(const UDataTable* SemanticLabelTable);

--- a/TempoSensors/Source/TempoSensors/Public/TempoSensorsUtils.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoSensorsUtils.h
@@ -5,6 +5,8 @@
 #include "CoreMinimal.h"
 #include "Engine/Scene.h"
 
+class UMaterialInstanceDynamic;
+
 void TEMPOSENSORS_API OptimizeShowFlagsForNoColor(FEngineShowFlags& ShowFlags);
 
 // Configure the given post-process settings, show flags, and ray-tracing toggle for a
@@ -14,3 +16,10 @@ void TEMPOSENSORS_API OptimizeShowFlagsForNoColor(FEngineShowFlags& ShowFlags);
 // and UTempoLidar (only when bColorEnabled is true).
 void TEMPOSENSORS_API ApplyPhotorealisticRenderSettings(FPostProcessSettings& OutPostProcess,
 	FEngineShowFlags& OutShowFlags, bool& OutUseRayTracingIfEnabled);
+
+// Resolve the settings' overridable/overriding label row names against the active semantic label
+// table and push the resulting label IDs onto a sensor's post-process material instance, which
+// substitutes the overriding label wherever an object labeled overridable carries a non-zero
+// subsurface color. Sets OverridingLabel to 0 — disabling the substitution — whenever the pair
+// does not resolve, so clearing the row names at runtime takes effect on an already-built MID.
+void TEMPOSENSORS_API ApplyLabelOverrideParameters(UMaterialInstanceDynamic* MaterialInstance);

--- a/TempoSensors/Source/TempoSensors/Public/TempoTiledSceneCaptureComponent.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoTiledSceneCaptureComponent.h
@@ -70,6 +70,11 @@ protected:
 	// ReconfigureTilesNow (which need to drain tiles before teardown / re-sync).
 	virtual void DeactivateAllTiles() PURE_VIRTUAL(UTempoTiledSceneCaptureComponent::DeactivateAllTiles, );
 
+	// Re-push the resolved overridable/overriding label IDs onto every active tile's post-process
+	// material instance. Called when the label table or the row names naming that pair change, so
+	// a live sensor picks the change up without a full tile reconfigure.
+	virtual void ApplyLabelOverridesToTiles() PURE_VIRTUAL(UTempoTiledSceneCaptureComponent::ApplyLabelOverridesToTiles, );
+
 	// Returns true iff any watched property differs from its internal mirror.
 	virtual bool HasDetectedParameterChange() const PURE_VIRTUAL(UTempoTiledSceneCaptureComponent::HasDetectedParameterChange, return false;);
 

--- a/TempoSensors/Source/TempoSensors/TempoSensors.Build.cs
+++ b/TempoSensors/Source/TempoSensors/TempoSensors.Build.cs
@@ -34,6 +34,9 @@ public class TempoSensors : TempoModuleRules
 				// Unreal
 				"CoreUObject",
 				"DeveloperSettings",
+				// The label table is exported as JSON for clients to edit and load back.
+				// UDataTable's own JSON export is editor-only.
+				"Json",
 				"RenderCore",
 				"RHI",
 				"Slate",

--- a/docs/plugins/tempo-sensors.md
+++ b/docs/plugins/tempo-sensors.md
@@ -50,10 +50,11 @@ API at whatever rate you configure.
   `bAutoTextureFilterType` / `TextureFilterType`. Depth on equidistant lens models is reported as
   Euclidean distance from the camera origin, not depth along the camera axis, avoiding seam
   discontinuities.
-- **Two label-override mechanisms.** Per-mesh labels via the Label Table data table (Static Mesh
-  and Actor-class entries; Static Mesh wins). Visually imperceptible per-pixel overrides via
-  subsurface color — used, for example, to label lane-line decals differently from the road they
-  live on.
+- **Labels down to the individual component.** The Label Table matches on Actor class, Actor tag,
+  Static Mesh asset, Skeletal Mesh asset, or component tag, most specific winning — so a lane-line
+  decal can be `LaneLine` on top of a road actor labeled `Road`. On top of that, visually
+  imperceptible per-pixel overrides via subsurface color. The whole table can be replaced at
+  runtime from JSON, without restarting the sim.
 - **Hardware-encoded H.264 video**, alongside raw color. [See below](#stream-h264-video).
 
 ## Getting started
@@ -192,36 +193,88 @@ convention so client-side point-cloud math renders right-handed Z-up directly.
 `UTempoActorLabeler`, a world subsystem, writes labels into the custom-depth stencil at
 `BeginPlay` and whenever a primitive component registers. It reads the mapping from the
 `SemanticLabelTable` you configure in Project Settings — a `DataTable` of `FSemanticLabel` rows,
-each with a stencil value plus a set of Actor classes and/or Static Mesh assets that should
-receive that label.
+each with a stencil value plus the things that should receive that label. TempoSample's
+`Content/Labels/TempoSampleLabelTable` is a worked example of such a table.
 
-Static Mesh entries take precedence over Actor entries, so you can label a base-mesh actor one way
-and selected meshes on it another — lane decals as `LaneLine` on top of road actors labeled
-`Road`, for instance. TempoSample's `Content/Labels/TempoSampleLabelTable` is a worked example of such a table.
+Each row matches on five columns, and the most specific match wins:
+
+| Column | Matches | Beats |
+|---|---|---|
+| `ActorTypes` | Every Actor of a class, and its subclasses | — |
+| `ActorTags` | Actors carrying that tag | `ActorTypes` |
+| `StaticMeshTypes` | Components rendering that static mesh — ISMC / foliage and Niagara mesh renderers included | `ActorTags`, `ActorTypes` |
+| `SkeletalMeshTypes` | Skinned components rendering that skeletal mesh | `ActorTags`, `ActorTypes` |
+| `ComponentTags` | Components carrying that tag | everything above |
+
+So you can label a base-mesh actor one way and selected meshes on it another — lane decals as
+`LaneLine` on top of road actors labeled `Road`, for instance. The two tag columns are the escape
+hatches for what no class or asset can pick out: one instance of a class labeled differently from
+the rest, or geometry built at runtime. An Actor carrying tags for two different labels resolves
+to whichever its `Tags` array lists first.
+
+Static and skeletal meshes get separate columns because the two asset types share no base class
+narrower than `UStreamableRenderAsset`, which textures also derive from. They resolve through one
+path-keyed lookup, so a mesh asset carries at most one label either way.
+
+!!! warning "Label IDs run 0–253, not 0–255"
+
+    The camera packs the label into the exponent field of its fp32 alpha channel, biased by `+1`,
+    which keeps the alpha a normal, finite float for every `(label, depth)` pair — at the cost of
+    the top two IDs. See `TempoSensorsConstants.h`. An out-of-range ID corrupts both the label
+    *and* the depth of every pixel it covers, so the labeler logs an error for one at startup.
 
 In `Instance` label mode (`Project Settings → Tempo → Sensors → Label Type`), each labeled actor
-also gets a unique 1–255 instance ID. Two flags control reuse:
+also gets a unique 1–253 instance ID. Two flags control reuse:
 
 - **Globally Unique Instance Labels** — don't reclaim IDs of destroyed actors.
-- **Instantaneously Unique Instance Labels** — don't repeat IDs even after exhausting all 256.
+- **Instantaneously Unique Instance Labels** — don't repeat IDs even after exhausting all 253.
 
 Bounding-box requests use the instance label image to compute axis-aligned 2D boxes per instance,
 attaching the corresponding semantic ID via the labeler's instance→semantic map.
 
 #### Inspecting and editing labels from a client
 
-The label table is also reachable over the API, which is what you want when generating datasets
-across many scenes rather than hand-editing a `DataTable`:
+Everything above is also reachable over the API, which is what you want when generating datasets
+across many scenes rather than hand-editing a `DataTable`. Reading what's in effect:
 
 | RPC | What it does |
 |---|---|
-| `get_semantic_classes` | List the semantic classes in the label table. |
+| `get_semantic_classes` | List the semantic classes in the label table, and what each one matches. |
 | `get_all_actor_labels` | Every actor's current label. |
 | `get_labeled_actor_types` | The actor classes the table assigns labels to. |
 | `get_all_static_mesh_types` | The static meshes the table knows about. |
-| `set_actor_type_semantic_id` | Assign a semantic ID to an actor class. |
-| `set_static_mesh_type_semantic_id` | Assign a semantic ID to a static mesh — takes precedence over the actor-class entry. |
 | `get_instance_to_semantic_id_map` | Map instance IDs back to semantic IDs, for decoding instance label images. |
+| `get_label_table_as_json` | The whole table, in exactly the format `load_label_table` reads. |
+
+Per-entry overrides, each taking `-1` to revert to whatever the table says:
+
+| RPC | What it does |
+|---|---|
+| `set_actor_type_semantic_id` | Assign a semantic ID to an actor class. |
+| `set_actor_tag_semantic_id` | Assign a semantic ID to an Actor tag — beats the actor's class. |
+| `set_static_mesh_type_semantic_id` | Assign a semantic ID to a static mesh — beats both of the above. |
+
+These sit in a layer *above* the table and survive a `load_label_table`, so clear one with `-1` if
+you want a newly loaded table to decide.
+
+Whole-table and mode changes, each of which re-labels the world in place:
+
+| RPC | What it does |
+|---|---|
+| `load_label_table` | Replace the entire table from a JSON string (`json`) or a file (`json_file`) — Unreal's DataTable JSON format, an array of rows keyed by `"Name"`. Supersedes the configured `SemanticLabelTable` for the life of the process. A table that fails to import is rejected whole, leaving the active one in place. |
+| `set_label_type` | Switch between `LT_SEMANTIC` and `LT_INSTANCE`. |
+| `set_instance_label_uniqueness` | Set the two instance-ID reuse flags. Governs future allocations only — already-labeled objects keep their IDs. |
+| `set_label_row_overrides` | Set the `OverridableLabelRowName` / `OverridingLabelRowName` pair driving the subsurface-color per-pixel override, or clear both to disable it. Live sensors pick it up without a capture restart. |
+
+!!! tip "Fetch, edit, load"
+
+    `get_label_table_as_json` emits rows — and the entries within each row — in sorted order, so
+    two fetches of the same table are byte-identical and a diff shows only what you changed. Round
+    trip it: fetch, edit, `load_label_table`.
+
+    One sharp edge: an asset path the importer cannot resolve is accepted without complaint — an
+    unknown class lands in the row as a null, an unknown mesh as a soft pointer that never loads.
+    Check the result with `get_semantic_classes` if a label doesn't appear where you expect.
 
 ## Timing: pipelined or synchronous
 
@@ -232,6 +285,10 @@ Setting `Project Settings → Tempo → Sensors → Pipelined Rendering = true` 
 continue while game / render / readback run in parallel — higher throughput at the cost of 1–2
 frames of latency. Each measurement carries the correct `capture_time_s` and `sequence_id`
 regardless, so a client always knows which simulation frame it is looking at.
+
+`set_pipelined_rendering_enabled` flips the same switch at runtime. The barrier reads it fresh
+every frame, so the change lands on the next one — no sensor teardown, no reconfigure. Useful for
+running a scene fast and then dropping into lockstep for the frames you actually want to capture.
 
 ## Performance notes
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -59,10 +59,10 @@ Tempo's plugin settings live in **Project Settings → Plugins**, and are stored
 
 | Setting | Type | Default | What it does |
 |---|---|---|---|
-| `SemanticLabelTable` | `DataTable` | — | Maps Actor classes and Static Meshes to semantic labels. In `Instance` mode, every instance of an object appearing in this table is labeled. |
+| `SemanticLabelTable` | `DataTable` | — | Maps Actor classes, Actor tags, Static Mesh assets, Skeletal Mesh assets and component tags to semantic labels. In `Instance` mode, every instance of an object appearing in this table is labeled. Can be replaced at runtime with `load_label_table`. |
 | `LabelType` | enum | `Semantic` | `Semantic` or `Instance`. |
 | `bGloballyUniqueInstanceLabels` | `bool` | `false` | Don't reclaim instance IDs of destroyed actors. (Instance mode only.) |
-| `bInstantaneouslyUniqueInstanceLabels` | `bool` | `false` | Don't repeat instance IDs even after exhausting all 256. (Instance mode only.) |
+| `bInstantaneouslyUniqueInstanceLabels` | `bool` | `false` | Don't repeat instance IDs even after exhausting all 253. (Instance mode only.) |
 
 [:octicons-arrow-right-24: Working with labels](../plugins/tempo-sensors.md#working-with-labels)
 
@@ -86,7 +86,7 @@ Tempo's plugin settings live in **Project Settings → Plugins**, and are stored
 
 | Setting | Type | Default | What it does |
 |---|---|---|---|
-| `bPipelinedRendering` | `bool` | `false` | In Fixed Step mode, let the game thread advance without waiting for sensor readback. Higher throughput, 1–2 frames of latency. Each measurement still carries the correct `CaptureTime` and `SequenceId`. |
+| `bPipelinedRendering` | `bool` | `false` | In Fixed Step mode, let the game thread advance without waiting for sensor readback. Higher throughput, 1–2 frames of latency. Each measurement still carries the correct `CaptureTime` and `SequenceId`. Also settable at runtime with `set_pipelined_rendering_enabled`. |
 | `MaxRenderBufferSize` | `int32` | `4` | Max frames per camera to buffer before dropping, with a warning. |
 | `bEnableRayTracingSceneReadbackBuffersOverrunWorkaround` | `bool` | `true` | Works around an `FRayTracingScene` buffer-overrun bug that otherwise asserts when many ray-tracing scene captures run in one frame. |
 | `RayTracingSceneMaxReadbackBuffersOverride` | `uint32` | `128` | Size of the `FRayTracingScene` readback rings when the workaround is on. Must exceed (RT renders per frame) × (GPU frames in flight + margin). |


### PR DESCRIPTION
Exposes the TempoSensors label and rendering configuration over gRPC, so a client can reconfigure labeling on a running sim instead of restarting it, and widens what the label table can match.

## Runtime configuration

`SensorService`:

| RPC | Effect |
| --- | --- |
| `SetPipelinedRenderingEnabled` | Toggles the FixedStep readback barrier. Read fresh at every barrier, so it takes effect next frame with no sensor teardown. |

`LabelService`:

| RPC | Effect |
| --- | --- |
| `LoadLabelTable` | Replaces the whole table from a JSON string or a file, superseding the configured `SemanticLabelTable` asset for the life of the process. |
| `GetLabelTableAsJson` | Returns the live table in exactly the format `LoadLabelTable` reads, so a client can fetch it, edit it, and load it back. |
| `SetLabelType` | Switches between `LT_SEMANTIC` and `LT_INSTANCE`, re-labeling the world. |
| `SetInstanceLabelUniqueness` | Sets the globally- / instantaneously-unique instance ID flags. |
| `SetLabelRowOverrides` | Sets the overridable / overriding row-name pair driving the subsurface-color per-pixel override, or clears both. |
| `SetActorTagSemanticId` | Per-tag runtime override, matching the existing per-type ones. |

## New label table columns

The table previously matched on Actor class, static mesh asset, and component tag. Two columns are added, and the most specific match still wins:

| Row column | Matches | Beats |
| --- | --- | --- |
| `ActorTypes` | Every Actor of a class (and its subclasses) | — |
| **`ActorTags`** | Actors carrying that tag | `ActorTypes` |
| `StaticMeshTypes` | Components rendering that static mesh, ISMC / foliage and Niagara mesh renderers included | `ActorTags`, `ActorTypes` |
| **`SkeletalMeshTypes`** | Skinned components rendering that skeletal mesh | `ActorTags`, `ActorTypes` |
| `ComponentTags` | Components carrying that tag | everything above |

`ActorTags` is the escape hatch on the Actor side that `ComponentTags` already provided on the component side: one instance of a class labeled differently from the rest. `SkeletalMeshTypes` reaches skinned components, which nothing in the table could label before.

Skeletal meshes get their own column rather than widening `StaticMeshTypes`, because the two asset types share no base class narrower than `UStreamableRenderAsset` (which textures also derive from), and the existing `GetAllStaticMeshTypes` / `SetStaticMeshTypeSemanticId` RPCs name their type on the wire. Both columns resolve through one path-keyed lookup.

## Max label ID is 253, not 255

5fb8d8ed biased the label into the fp32 exponent field so the camera's packed alpha stays a normal, finite float. That capped label IDs at 253, but only the label-table validation was updated to match:

- The instance ID allocator still handed out `1`–`255`, so a scene with more than 253 live labeled objects silently corrupted the label *and* the depth of every pixel covered by the 254th and 255th.
- `SetActorTypeSemanticId`, `SetActorTagSemanticId`, and `SetStaticMeshTypeSemanticId` all accepted `254` and `255` with the same result.

Both now take their bound from `GTempoCamera_Max_Label`, and the proto comments, settings tooltip, and docs quote 253.

## Compatibility

The proto changes are purely additive — `git diff origin/main -- Labels.proto` has no removals. No RPC, message, or field was renamed or removed, and no existing label table asset needs migrating.

## Notes on the implementation

**How changes propagate.** `UTempoSensorsSettings` gained runtime setters plus a second delegate. The existing label-settings event now drives a handler that re-reads the table, rebuilds the label maps, and re-labels — unlabeling *before* the rebuild, since `UnLabelActor` reads the old `NoLabelId` to decide which instance IDs to reclaim. A new label-overrides event reaches live cameras and lidars, which re-push the resolved label IDs onto their existing post-process MIDs: no tile reconfigure, no TAA history reset. The overridable/overriding lookup was duplicated verbatim in `TempoCamera.cpp` and `TempoLidar.cpp` and is now one helper.

**JSON export is hand-written.** `UDataTable::GetTableAsJSON` is `WITH_EDITOR`-only. Rows and the entries within each row are sorted by name, because the row map and the `TSet` columns iterate in an order that says nothing and an export meant to be diffed has to be stable across runs.

**Two importer behaviors worth knowing**, both found by testing rather than reading:
- The runtime DataTable JSON importer treats *missing* columns as problems, not just extra ones. A row assigning only `ActorTypes` would have been rejected, so the import sets `bIgnoreMissingFields`. Unrecognized column names stay an error — those are typos that would silently drop labels.
- An asset path the importer cannot resolve is accepted without complaint: an unknown class lands in the row as a null, an unknown mesh as a soft pointer that never loads. `GetLabelTableAsJson` plus `GetSemanticClasses` is currently how you'd spot that.

**Latent bug fixed.** Folding the Actor-side rules into `ResolveActorSemanticId` also fixes an inline loop that allocated a fresh instance ID for every matching class rather than once per Actor. With a single match it behaved identically, so this was not observable.

## Documentation

Rebased onto the readthedocs move (#568), so the prose landed in `docs/` rather than `TempoSensors/README.md`:

- `docs/plugins/tempo-sensors.md` — the five match columns, the 0–253 range, and the runtime `LabelService` / `set_pipelined_rendering_enabled` RPCs.
- `docs/reference/settings.md` — carried the same stale 256 instance-ID count, and described `SemanticLabelTable` as mapping only classes and static meshes.

The generated gRPC reference needed no edit: `gen_api_reference.py` renders it from the protos, so the new RPCs and the corrected `0-253` field comments come through on their own. `mkdocs build --strict` passes.

## Testing

`Scripts/Test.sh` — 27 automation tests pass, including three new ones over the label table: import of every column type, malformed-document rejection, and an export/import round trip that also pins the export being byte-stable across separately built tables.

## Parked

A `SemanticLabelTableFile` setting — driving the table from a committed JSON file with no RPC — is on `label_table_json_file`, working and tested, but held back: with both an asset and a file, which is the source of truth is ambiguous, and hand-writing full asset object paths is awkward enough that it may not be the right authoring format. `GetLabelTableAsJson` may cover the underlying want without a second source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExHJkAz4GgsGmxHXr6Hx2b


