### PR TITLE
Fix Ghosting with Low Light and Slow Adaptation in Tiled Renders

### DIFF
--- a/Scripts/Package.sh
+++ b/Scripts/Package.sh
@@ -121,6 +121,25 @@ if [ "$LOW_MEMORY_MODE" = "true" ]; then
   echo "Low memory mode enabled: at most 3 compile actions, single cook process, partial GC, no UBA/XGE"
 fi
 
+# Clear the previous build's output for this platform before staging over it.
+#
+# UAT copies into the archive directory but never removes files the new build no longer produces,
+# so artifacts of a differently-configured previous build survive alongside the new ones. The case
+# that cost real debugging time: a build made before -skipiostore leaves pakchunk0-Mac.utoc/.ucas
+# behind, the engine mounts that stale container at startup and resolves packages through it, and
+# every asset that now lives only in the freshly built .pak reads as
+#   LoadPackage: SkipPackage: ... does not exist on disk or in the loader
+# even though it is right there in the pak. The build looks clean and the sim is silently broken.
+#
+# Only this platform's staged output is removed. Packaged/API and Packaged/Metadata are repopulated
+# further down and are left alone. A failed package leaves no previous build to fall back on, which
+# is the intended trade: a stale mixed build is worse than none.
+STALE_PLATFORM_DIR="$PROJECT_ROOT/Packaged/$TARGET_PLATFORM"
+if [ -d "$STALE_PLATFORM_DIR" ]; then
+  echo "Removing previous $TARGET_PLATFORM build at $STALE_PLATFORM_DIR"
+  rm -rf "$STALE_PLATFORM_DIR"
+fi
+
 # Filter out our custom flags before passing to UAT
 PASSTHROUGH_ARGS=()
 for arg in "$@"; do

--- a/Scripts/Package.sh
+++ b/Scripts/Package.sh
@@ -121,25 +121,6 @@ if [ "$LOW_MEMORY_MODE" = "true" ]; then
   echo "Low memory mode enabled: at most 3 compile actions, single cook process, partial GC, no UBA/XGE"
 fi
 
-# Clear the previous build's output for this platform before staging over it.
-#
-# UAT copies into the archive directory but never removes files the new build no longer produces,
-# so artifacts of a differently-configured previous build survive alongside the new ones. The case
-# that cost real debugging time: a build made before -skipiostore leaves pakchunk0-Mac.utoc/.ucas
-# behind, the engine mounts that stale container at startup and resolves packages through it, and
-# every asset that now lives only in the freshly built .pak reads as
-#   LoadPackage: SkipPackage: ... does not exist on disk or in the loader
-# even though it is right there in the pak. The build looks clean and the sim is silently broken.
-#
-# Only this platform's staged output is removed. Packaged/API and Packaged/Metadata are repopulated
-# further down and are left alone. A failed package leaves no previous build to fall back on, which
-# is the intended trade: a stale mixed build is worse than none.
-STALE_PLATFORM_DIR="$PROJECT_ROOT/Packaged/$TARGET_PLATFORM"
-if [ -d "$STALE_PLATFORM_DIR" ]; then
-  echo "Removing previous $TARGET_PLATFORM build at $STALE_PLATFORM_DIR"
-  rm -rf "$STALE_PLATFORM_DIR"
-fi
-
 # Filter out our custom flags before passing to UAT
 PASSTHROUGH_ARGS=()
 for arg in "$@"; do

--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -19,6 +19,8 @@
 #include "Kismet/GameplayStatics.h"
 #include "Kismet/KismetRenderingLibrary.h"
 #include "Materials/MaterialInstanceDynamic.h"
+#include "Math/Box2D.h"
+#include "Interfaces/Interface_PostProcessVolume.h"
 #include "Misc/ScopeLock.h"
 #include "TextureResource.h"
 
@@ -57,6 +59,191 @@
 namespace
 {
 	constexpr double MaxPerspectiveFOVPerCapture = 120.0;
+
+	// Bound on the exposure bias the controller may apply, in EV. Wide enough for a physically lit
+	// sun (bias near -20) and a moonless night (bias near +10).
+	constexpr float MaxSharedExposureBias = 24.0f;
+
+	float GetViewStateLastAverageSceneLuminance(FSceneViewStateInterface* ViewState)
+	{
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 7
+		return static_cast<FSceneViewState*>(ViewState)->GetLastAverageSceneLuminance();
+#else
+		return ViewState->GetLastAverageSceneLuminance();
+#endif
+	}
+
+	bool IsExtendedLuminanceRangeEnabled()
+	{
+		static const auto* CVar = IConsoleManager::Get().FindTConsoleVariableDataInt(TEXT("r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange"));
+		return CVar && CVar->GetValueOnGameThread() != 0;
+	}
+
+	// The engine's LuminanceMaxFromLensAttenuation on the game thread: the luminance that saturates
+	// the sensor at EV100. 1.0 unless the extended luminance range is on, and 1.0 even then at the
+	// default lens attenuation.
+	float GetLuminanceMax()
+	{
+		if (!IsExtendedLuminanceRangeEnabled())
+		{
+			return 1.0f;
+		}
+		static const IConsoleVariable* CVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.EyeAdaptation.LensAttenuation"));
+		const float LensAttenuation = CVar ? CVar->GetFloat() : 0.78f;
+		constexpr float ISOSaturationSpeedConstant = 0.78f;
+		return ISOSaturationSpeedConstant / FMath::Max(LensAttenuation, 0.01f);
+	}
+
+	// Auto exposure brightness settings are EV100 with the extended luminance range and absolute
+	// luminance otherwise.
+	float BrightnessToLuminance(float Brightness, float LuminanceMax)
+	{
+		return IsExtendedLuminanceRangeEnabled() ? LuminanceMax * FMath::Exp2(Brightness) : Brightness;
+	}
+
+	float LuminanceToBrightness(float Luminance, float LuminanceMax)
+	{
+		return IsExtendedLuminanceRangeEnabled() ? FMath::Log2(Luminance / LuminanceMax) : Luminance;
+	}
+
+	// The auto exposure inputs the controller consumes, resolved the way the engine resolves a view's
+	// final post-process settings: project defaults, then the world's post process volumes at the
+	// view location in priority order, then the component's own overrides.
+	struct FTempoAutoExposureSettings
+	{
+		float Bias = 0.0f;
+		float MinBrightness = 0.0f;
+		float MaxBrightness = 0.0f;
+		float SpeedUp = 3.0f;
+		float SpeedDown = 1.0f;
+		bool bHasBiasCurve = false;
+	};
+
+	// Same blend as FSceneView::OverridePostProcessSettings for these fields.
+	void OverrideAutoExposureSettings(FTempoAutoExposureSettings& Dest, const FPostProcessSettings& Src, float Weight)
+	{
+		if (Src.bOverride_AutoExposureMinBrightness)
+		{
+			Dest.MinBrightness = FMath::Lerp(Dest.MinBrightness, Src.AutoExposureMinBrightness, Weight);
+		}
+		if (Src.bOverride_AutoExposureMaxBrightness)
+		{
+			Dest.MaxBrightness = FMath::Lerp(Dest.MaxBrightness, Src.AutoExposureMaxBrightness, Weight);
+		}
+		if (Src.bOverride_AutoExposureSpeedUp)
+		{
+			Dest.SpeedUp = FMath::Lerp(Dest.SpeedUp, Src.AutoExposureSpeedUp, Weight);
+		}
+		if (Src.bOverride_AutoExposureSpeedDown)
+		{
+			Dest.SpeedDown = FMath::Lerp(Dest.SpeedDown, Src.AutoExposureSpeedDown, Weight);
+		}
+		if (Src.bOverride_AutoExposureBias)
+		{
+			Dest.Bias = FMath::Lerp(Dest.Bias, Src.AutoExposureBias, Weight);
+		}
+		if (Src.bOverride_AutoExposureBiasCurve && Src.AutoExposureBiasCurve)
+		{
+			Dest.bHasBiasCurve = true;
+		}
+	}
+
+	FTempoAutoExposureSettings ResolveAutoExposureSettings(const UWorld* World, const FVector& ViewLocation, const FPostProcessSettings& ComponentSettings, float ComponentWeight)
+	{
+		FPostProcessSettings Base;
+		Base.SetBaseValues();
+
+		FTempoAutoExposureSettings Settings;
+		Settings.Bias = Base.AutoExposureBias;
+		Settings.MinBrightness = Base.AutoExposureMinBrightness;
+		Settings.MaxBrightness = Base.AutoExposureMaxBrightness;
+		Settings.SpeedUp = Base.AutoExposureSpeedUp;
+		Settings.SpeedDown = Base.AutoExposureSpeedDown;
+		Settings.bHasBiasCurve = Base.AutoExposureBiasCurve != nullptr;
+
+		// With auto exposure off as a project default the engine pins the base range to a fixed
+		// exposure of 1 (FSceneView::StartFinalPostprocessSettings).
+		static const auto* DefaultAutoExposureCVar = IConsoleManager::Get().FindTConsoleVariableDataInt(TEXT("r.DefaultFeature.AutoExposure"));
+		if (DefaultAutoExposureCVar && DefaultAutoExposureCVar->GetValueOnGameThread() == 0)
+		{
+			constexpr float EngineDefaultLuminanceMax = 1.2f;
+			const float FixedBrightness = IsExtendedLuminanceRangeEnabled() ? FMath::Log2(1.0f / EngineDefaultLuminanceMax) : 1.0f;
+			Settings.MinBrightness = FixedBrightness;
+			Settings.MaxBrightness = FixedBrightness;
+		}
+
+		// UWorld::AddPostProcessingSettings: volumes are kept sorted by ascending priority.
+		if (World)
+		{
+			for (IInterface_PostProcessVolume* Volume : World->PostProcessVolumes)
+			{
+				if (!Volume)
+				{
+					continue;
+				}
+				const FPostProcessVolumeProperties Properties = Volume->GetProperties();
+				if (!Properties.bIsEnabled || !Properties.Settings)
+				{
+					continue;
+				}
+				float Weight = FMath::Clamp(Properties.BlendWeight, 0.0f, 1.0f);
+				if (!Properties.bIsUnbound)
+				{
+					float DistanceToPoint = 0.0f;
+					Volume->EncompassesPoint(ViewLocation, 0.0f, &DistanceToPoint);
+					if (DistanceToPoint < 0.0f || DistanceToPoint > Properties.BlendRadius)
+					{
+						Weight = 0.0f;
+					}
+					else if (Properties.BlendRadius >= 1.0f)
+					{
+						Weight *= 1.0f - DistanceToPoint / Properties.BlendRadius;
+					}
+				}
+				if (Weight > 0.0f)
+				{
+					OverrideAutoExposureSettings(Settings, *Properties.Settings, Weight);
+				}
+			}
+		}
+
+		OverrideAutoExposureSettings(Settings, ComponentSettings, FMath::Clamp(ComponentWeight, 0.0f, 1.0f));
+		return Settings;
+	}
+
+	// The engine's ComputeEyeAdaptation (PostProcessHistogramCommon.ush) on the CPU: move the
+	// smoothed exposure luminance toward the target at the configured f-stops per second, switching
+	// from a linear to an exponential approach within the transition distance of the target.
+	float ComputeEyeAdaptation(float OldLuminance, float TargetLuminance, float DeltaTime, float SpeedUp, float SpeedDown)
+	{
+		static const IConsoleVariable* TransitionCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.EyeAdaptation.ExponentialTransitionDistance"));
+		const float StartDistance = FMath::Max(TransitionCVar ? TransitionCVar->GetFloat() : 1.5f, 0.001f);
+
+		const float LogTarget = FMath::Log2(TargetLuminance);
+		const float LogOld = FMath::Log2(OldLuminance);
+		const float LogDiff = LogTarget - LogOld;
+		const float Speed = LogDiff > 0.0f ? SpeedUp : SpeedDown;
+		if (Speed <= UE_KINDA_SMALL_NUMBER || DeltaTime <= 0.0f)
+		{
+			return OldLuminance;
+		}
+
+		// Slope modifier that matches the exponential branch to the linear one at the transition
+		// distance (GetEyeAdaptationParameters).
+		constexpr float FrameTimeEps = 1.0f / 60.0f;
+		const float StartTime = StartDistance / Speed;
+		const float M = FrameTimeEps / ((1.0f - FMath::Exp2(-FrameTimeEps * Speed)) * StartTime);
+
+		const float ExponentialFactor = 1.0f - FMath::Exp2(-DeltaTime * Speed);
+		const float LogExponential = LogOld + LogDiff * ExponentialFactor * M;
+
+		const float LinearOffset = DeltaTime * Speed;
+		const float LogLinear = LogOld < LogTarget
+			? FMath::Min(LogTarget, LogOld + LinearOffset)
+			: FMath::Max(LogTarget, LogOld - LinearOffset);
+
+		return FMath::Exp2(FMath::Abs(LogDiff) > StartDistance ? LogLinear : LogExponential);
+	}
 }
 FTempoCameraIntrinsics::FTempoCameraIntrinsics(const FIntPoint& SizeXY, float HorizontalFOV, const FVector2D& PrincipalPoint)
 	: Fx(SizeXY.X / 2.0 / FMath::Tan(FMath::DegreesToRadians(HorizontalFOV) / 2.0)),
@@ -1073,28 +1260,15 @@ void UTempoCamera::RenderCapture()
 	// on the seam).
 	const float K = FMath::Max(1.0f, UpsamplingFactor);
 
-	float SavedTSRShadingRejectionExposureOffset = 0.0f;
-	IConsoleVariable* TSRShadingRejectionExposureOffsetCVar =
-		IConsoleManager::Get().FindConsoleVariable(TEXT("r.TSR.ShadingRejection.ExposureOffset"));
-	if (!bSingleTileFastPath)
-	{
-		// Push `r.TSR.ShadingRejection.ExposureOffset` for the duration of this camera's renders.
-		// CVar mutation must happen on the game thread — calling Set() on the render thread hits a
-		// check(0) in FConsoleManager::OnCVarChange. The GT path propagates the new value to the RT
-		// shadow via an ENQUEUE_RENDER_COMMAND queued in FIFO order with subsequent renderer commands,
-		// so the bracket on the render thread is set→render→restore. Multiple TempoCameras in the
-		// same frame interleave correctly because each camera's GT push, renders, and GT pop produce
-		// three RT entries in that order. ECVF_SetByConsole is the highest priority and always wins,
-		// avoiding the engine warning about replacing constructor-default priority and silently being
-		// rejected if anything else has touched the CVar.
-		if (TSRShadingRejectionExposureOffsetCVar)
-		{
-			SavedTSRShadingRejectionExposureOffset = TSRShadingRejectionExposureOffsetCVar->GetFloat();
-			// 2.0 multiplier determined to work well empirically...
-			TSRShadingRejectionExposureOffsetCVar->Set(2.0f * SharedExposureBias, ECVF_SetByConsole);
-		}
-	}
-
+	// CVar pushes bracket this camera's renders. CVar mutation must happen on the game thread —
+	// calling Set() on the render thread hits a check(0) in FConsoleManager::OnCVarChange. The GT
+	// path propagates the new value to the RT shadow via an ENQUEUE_RENDER_COMMAND queued in FIFO
+	// order with subsequent renderer commands, so the bracket on the render thread is
+	// set→render→restore. Multiple TempoCameras in the same frame interleave correctly because
+	// each camera's GT push, renders, and GT pop produce three RT entries in that order.
+	// ECVF_SetByConsole is the highest priority and always wins, avoiding the engine warning about
+	// replacing constructor-default priority and silently being rejected if anything else has
+	// touched the CVar.
 	IConsoleVariable* TSRShadingRejectionFlickingFrameRateCapCVar =
 		IConsoleManager::Get().FindConsoleVariable(TEXT("r.TSR.ShadingRejection.Flickering.FrameRateCap"));
 	const float SavedTSRShadingRejectionFlickingFrameRateCap = TSRShadingRejectionFlickingFrameRateCapCVar->GetFloat();
@@ -1159,17 +1333,11 @@ void UTempoCamera::RenderCapture()
 		}
 		SingleActiveTile = &Tile;
 
-		// Multi-tile must run AEM_Manual + a shared EV bias so tiles don't diverge in brightness.
+		// Multi-tile runs manual exposure at the shared bias so tiles can't diverge in brightness.
 		// Re-set every frame so it's clean if we just transitioned out of fast-path.
 		if (!bSingleTileFastPath)
 		{
-			Tile.PostProcessSettings.bOverride_AutoExposureMethod = true;
-			Tile.PostProcessSettings.AutoExposureMethod = AEM_Manual;
-			if (bHasValidSharedExposure)
-			{
-				Tile.PostProcessSettings.bOverride_AutoExposureBias = true;
-				Tile.PostProcessSettings.AutoExposureBias = SharedExposureBias;
-			}
+			ApplyTileExposureSettings(Tile);
 		}
 
 		// Switch the distortion material's label encoding: bit-packed (label + 1 in the fp32
@@ -1287,15 +1455,25 @@ void UTempoCamera::RenderCapture()
 		// Multi-tile: HDR atlas (pre-tonemap) so the proxy capture below can run AE/tonemap once
 		// across the stitched output. Tile-appropriate show flags (no bloom/DOF/motionblur/etc)
 		// differ from the proxy's — swap them around the call.
+		// Eye adaptation stays on: the engine only honors the tiles' AutoExposureBias, and only
+		// computes a PreExposure for them, while it is. Manual exposure keeps it from adapting.
 		const FEngineShowFlags SavedShowFlags = ShowFlags;
 		ShowFlags.SetLocalExposure(false);
-		ShowFlags.SetEyeAdaptation(false);
 		ShowFlags.SetMotionBlur(false);
 		ShowFlags.SetLensFlares(false);
 		ShowFlags.SetBloom(false);
 		ShowFlags.SetColorGrading(false);
 		ShowFlags.SetVignette(false);
 		ShowFlags.SetDepthOfField(false);
+
+		// Record the bias these tiles render with; UpdateSharedExposure divides the proxy's lagging
+		// readback by the exposure of the capture it actually measured.
+		for (int32 Index = AppliedExposureBiasHistoryLength - 1; Index > 0; --Index)
+		{
+			AppliedExposureBiasHistory[Index] = AppliedExposureBiasHistory[Index - 1];
+		}
+		AppliedExposureBiasHistory[0] = SharedExposureBias;
+		++NumMultiTileCapturesSinceExposureSeed;
 
 		TempoMultiViewCapture::RenderTiles(Scene, this, SharedTextureTarget, ViewSetups, ESceneCaptureSource::SCS_FinalColorHDR, ResolutionFraction);
 
@@ -1404,31 +1582,47 @@ void UTempoCamera::RenderCapture()
 
 			// But wait! Lighting actually has to be on in order for exposure bias to be read back on the cpu
 			ShowFlags.SetLighting(true);
+
+			// Pin the proxy to an exposure of exactly 1 so it is only the light meter: the tiles
+			// already carry the camera's exposure (UpdateSharedExposure). A histogram method with an
+			// empty brightness range makes the engine force that one exposure every frame with no
+			// smoothing, while the histogram — whose readback the controller consumes — still runs.
+			// The camera's own range, speed and bias settings are applied by the controller instead.
+			FPostProcessSettings& ProxyPP = PostProcessSettings;
+			const uint8 SavedOverrideMethod = ProxyPP.bOverride_AutoExposureMethod;
+			const uint8 SavedOverrideMinBrightness = ProxyPP.bOverride_AutoExposureMinBrightness;
+			const uint8 SavedOverrideMaxBrightness = ProxyPP.bOverride_AutoExposureMaxBrightness;
+			const uint8 SavedOverrideBias = ProxyPP.bOverride_AutoExposureBias;
+			const TEnumAsByte<EAutoExposureMethod> SavedMethod = ProxyPP.AutoExposureMethod;
+			const float SavedMinBrightness = ProxyPP.AutoExposureMinBrightness;
+			const float SavedMaxBrightness = ProxyPP.AutoExposureMaxBrightness;
+			const float SavedBias = ProxyPP.AutoExposureBias;
+
+			const float MeterBrightness = LuminanceToBrightness(1.0f, GetLuminanceMax());
+			ProxyPP.bOverride_AutoExposureMethod = true;
+			ProxyPP.AutoExposureMethod = AEM_Histogram;
+			ProxyPP.bOverride_AutoExposureMinBrightness = true;
+			ProxyPP.AutoExposureMinBrightness = MeterBrightness;
+			ProxyPP.bOverride_AutoExposureMaxBrightness = true;
+			ProxyPP.AutoExposureMaxBrightness = MeterBrightness;
+			ProxyPP.bOverride_AutoExposureBias = true;
+			ProxyPP.AutoExposureBias = 0.0f;
+
 			CaptureScene();
+
+			ProxyPP.bOverride_AutoExposureMethod = SavedOverrideMethod;
+			ProxyPP.AutoExposureMethod = SavedMethod;
+			ProxyPP.bOverride_AutoExposureMinBrightness = SavedOverrideMinBrightness;
+			ProxyPP.AutoExposureMinBrightness = SavedMinBrightness;
+			ProxyPP.bOverride_AutoExposureMaxBrightness = SavedOverrideMaxBrightness;
+			ProxyPP.AutoExposureMaxBrightness = SavedMaxBrightness;
+			ProxyPP.bOverride_AutoExposureBias = SavedOverrideBias;
+			ProxyPP.AutoExposureBias = SavedBias;
 			ShowFlags = PrevShowFlags;
 		}
 	}
 
-	// Update SharedExposureBias from whichever view state ran the AE pass this frame.
-	{
-		FSceneViewStateInterface* SourceViewState = bSingleTileFastPath
-			? (SingleActiveTile ? SingleActiveTile->ViewState.GetReference() : nullptr)
-			: GetViewState(0);
-		if (SourceViewState)
-		{
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 7
-			const float Lum = static_cast<FSceneViewState*>(SourceViewState)->GetLastAverageSceneLuminance();
-#else
-			const float Lum = SourceViewState->GetLastAverageSceneLuminance();
-#endif
-			if (Lum > 0.0f)
-			{
-				constexpr float TargetMidGrey = 0.18f;
-				SharedExposureBias = FMath::Log2(TargetMidGrey / FMath::Max(Lum, static_cast<float>(KINDA_SMALL_NUMBER)));
-				bHasValidSharedExposure = true;
-			}
-		}
-	}
+	UpdateSharedExposure(bSingleTileFastPath, SingleActiveTile);
 
 	if (!bSingleTileFastPath)
 	{
@@ -1469,17 +1663,9 @@ void UTempoCamera::RenderCapture()
 			CapturedVideoSequenceId = CapturedVideoSequenceIdThisFrame;
 		});
 
-	// Pop: restore the prior CVar value. The propagation render command queued by Set() on
+	// Pop: restore the prior CVar values. The propagation render command queued by Set() on
 	// GT lands in RT FIFO after every render command this camera enqueued above, so each
 	// camera's renders consume the camera's own override before the restore takes effect.
-	if (!bSingleTileFastPath)
-	{
-		if (TSRShadingRejectionExposureOffsetCVar)
-		{
-			TSRShadingRejectionExposureOffsetCVar->Set(SavedTSRShadingRejectionExposureOffset, ECVF_SetByConsole);
-		}
-	}
-
 	if (TSRShadingRejectionFlickingFrameRateCapCVar)
 	{
 		TSRShadingRejectionFlickingFrameRateCapCVar->Set(SavedTSRShadingRejectionFlickingFrameRateCap, ECVF_SetByConsole);
@@ -1957,9 +2143,9 @@ void UTempoCamera::ApplyTilePostProcess(FTempoCameraTile& Tile)
 	Tile.PostProcessSettings = PostProcessSettings;
 
 	// Tiles must not do any per-tile exposure adaptation — divergent per-tile ViewStates would
-	// produce mismatched brightness across the stitched image. Tonemap runs once on the proxy.
-	Tile.PostProcessSettings.bOverride_AutoExposureMethod = true;
-	Tile.PostProcessSettings.AutoExposureMethod = AEM_Manual;
+	// produce mismatched brightness across the stitched image. Every tile gets the same manual
+	// exposure from the shared controller; tonemap runs once on the proxy.
+	ApplyTileExposureSettings(Tile);
 
 	// Rebuild blendables from the owner's user-authored list, filter out ProxyTonemapMID (it reads
 	// the post-stitch HDR target, and applying it inside a tile would feed last-frame's stitched
@@ -1972,12 +2158,138 @@ void UTempoCamera::ApplyTilePostProcess(FTempoCameraTile& Tile)
 	{
 		Tile.PostProcessSettings.WeightedBlendables.Array.Add(FWeightedBlendable(1.0, Tile.PostProcessMaterialInstance));
 	}
+}
 
-	if (bHasValidSharedExposure)
+void UTempoCamera::ApplyTileExposureSettings(FTempoCameraTile& Tile) const
+{
+	FPostProcessSettings& PP = Tile.PostProcessSettings;
+
+	// Manual exposure at the shared bias. With the physical camera off the white point sits at
+	// EV100 0, so the tile's exposure — and its PreExposure — is 2^SharedExposureBias / LuminanceMax,
+	// identical for every tile.
+	PP.bOverride_AutoExposureMethod = true;
+	PP.AutoExposureMethod = AEM_Manual;
+	PP.bOverride_AutoExposureBias = true;
+	PP.AutoExposureBias = SharedExposureBias;
+
+	// Physical camera exposure is a manual-mode feature the camera's histogram auto exposure never
+	// applied; folding ISO/aperture/shutter into the tiles would double it up with the controller.
+	PP.bOverride_AutoExposureApplyPhysicalCameraExposure = true;
+	PP.AutoExposureApplyPhysicalCameraExposure = false;
+
+	// A bias curve keyed on a tile's own, unmetered luminance would add an arbitrary compensation.
+	// The controller applies the camera's bias in one place.
+	PP.bOverride_AutoExposureBiasCurve = false;
+	PP.AutoExposureBiasCurve = nullptr;
+}
+
+void UTempoCamera::UpdateSharedExposure(bool bSingleTileFastPath, FTempoCameraTile* SingleActiveTile)
+{
+	const UWorld* World = GetWorld();
+	if (!World)
 	{
-		Tile.PostProcessSettings.bOverride_AutoExposureBias = true;
-		Tile.PostProcessSettings.AutoExposureBias = SharedExposureBias;
+		return;
 	}
+
+	// A tile at bias B renders at a manual exposure of 2^B / LuminanceMax (ApplyTileExposureSettings).
+	const float LuminanceMax = GetLuminanceMax();
+	const auto TileExposureFromBias = [LuminanceMax](float Bias)
+	{
+		return FMath::Exp2(Bias) / LuminanceMax;
+	};
+	const auto BiasFromTileExposure = [LuminanceMax](float Exposure)
+	{
+		return FMath::Clamp(FMath::Log2(FMath::Max(Exposure * LuminanceMax, UE_SMALL_NUMBER)), -MaxSharedExposureBias, MaxSharedExposureBias);
+	};
+
+	const FTempoAutoExposureSettings AE = ResolveAutoExposureSettings(World, GetComponentLocation(), PostProcessSettings, PostProcessBlendWeight);
+	if (AE.bHasBiasCurve && !bWarnedAboutExposureBiasCurve)
+	{
+		UE_LOG(LogTempoSensors, Warning, TEXT("Camera %s: an AutoExposureBiasCurve is set but the multi-tile exposure controller does not evaluate it; only AutoExposureBias applies."), *GetName());
+		bWarnedAboutExposureBiasCurve = true;
+	}
+
+	if (bSingleTileFastPath)
+	{
+		// The tile runs the engine's histogram auto exposure itself. Mirror its result into the
+		// controller so a switch into the multi-tile path continues from the same exposure.
+		FSceneViewStateInterface* TileViewState = SingleActiveTile ? SingleActiveTile->ViewState.GetReference() : nullptr;
+		const float TileExposure = TileViewState ? TileViewState->GetLastEyeAdaptationExposure() : 0.0f;
+		if (TileExposure > 0.0f)
+		{
+			SmoothedSceneLuminance = FMath::Exp2(AE.Bias) / TileExposure;
+			SharedExposureBias = BiasFromTileExposure(TileExposure);
+			for (float& AppliedBias : AppliedExposureBiasHistory)
+			{
+				AppliedBias = SharedExposureBias;
+			}
+			LastSharedExposureUpdateTime = World->GetTimeSeconds();
+			NumMultiTileCapturesSinceExposureSeed = 0;
+			bHasValidSharedExposure = true;
+		}
+		return;
+	}
+
+	// The readback lags by about two captures. Until that many multi-tile captures have rendered
+	// since the last seed, whatever the proxy reports is of an image whose exposure is unknown.
+	if (NumMultiTileCapturesSinceExposureSeed < AppliedExposureBiasHistoryLength - 1)
+	{
+		return;
+	}
+
+	FSceneViewStateInterface* ProxyViewState = GetViewState(0);
+	if (!ProxyViewState)
+	{
+		return;
+	}
+
+	// Nothing to do until the first histogram readback has landed (about two captures in).
+	const float MeasuredLuminance = GetViewStateLastAverageSceneLuminance(ProxyViewState);
+	if (MeasuredLuminance <= 0.0f)
+	{
+		return;
+	}
+
+	// The readback measured the stitched image, which already carries the bias its tiles rendered
+	// with. Undo that to recover the scene luminance the engine's rules are written against.
+	const float AppliedExposure = TileExposureFromBias(AppliedExposureBiasHistory[AppliedExposureBiasHistoryLength - 1]);
+	const float SceneLuminance = MeasuredLuminance / AppliedExposure;
+
+	// GetEyeAdaptationParameters + EyeAdaptationCommon: clamp the metered luminance to the configured
+	// range, adapt toward it, and expose so that it lands on middle grey times the compensation.
+	constexpr float MiddleGrey = 0.18f;
+	const float MaxWhitePointLuminance = BrightnessToLuminance(AE.MaxBrightness, LuminanceMax);
+	const float MinWhitePointLuminance = FMath::Min(BrightnessToLuminance(AE.MinBrightness, LuminanceMax), MaxWhitePointLuminance);
+	const float TargetLuminance = FMath::Clamp(SceneLuminance, MinWhitePointLuminance * MiddleGrey, MaxWhitePointLuminance * MiddleGrey) / MiddleGrey;
+
+	// The engine snaps to the target on a camera cut, with an empty range, or with invalid speeds.
+	const double Now = World->GetTimeSeconds();
+	const bool bSnapToTarget = !bHasValidSharedExposure
+		|| LastSharedExposureUpdateTime < 0.0
+		|| !(AE.MinBrightness < AE.MaxBrightness)
+		|| AE.SpeedUp < 0.0f
+		|| AE.SpeedDown < 0.0f;
+	if (bSnapToTarget)
+	{
+		SmoothedSceneLuminance = TargetLuminance;
+	}
+	else
+	{
+		const float DeltaTime = static_cast<float>(Now - LastSharedExposureUpdateTime);
+		SmoothedSceneLuminance = ComputeEyeAdaptation(FMath::Max(SmoothedSceneLuminance, UE_SMALL_NUMBER), TargetLuminance, DeltaTime, AE.SpeedUp, AE.SpeedDown);
+	}
+	SmoothedSceneLuminance = FMath::Clamp(SmoothedSceneLuminance, MinWhitePointLuminance, MaxWhitePointLuminance);
+	LastSharedExposureUpdateTime = Now;
+
+	const float ExposureScale = FMath::Exp2(AE.Bias) / FMath::Max(SmoothedSceneLuminance, 0.0001f);
+
+	// The proxy meter is pinned to an exposure of 1. Fold in whatever it actually reports so that,
+	// say, a partial PostProcessBlendWeight cannot double-expose the output.
+	const float ProxyExposure = ProxyViewState->GetLastEyeAdaptationExposure();
+	const float ProxyGain = ProxyExposure > 0.0f ? ProxyExposure : 1.0f;
+
+	SharedExposureBias = BiasFromTileExposure(ExposureScale / ProxyGain);
+	bHasValidSharedExposure = true;
 }
 
 void UTempoCamera::ConfigureTile(FTempoCameraTile& Tile, double YawOffset, double PitchOffset, double FOutput, const FIntPoint& TileSizeXY, const FIntPoint& TileDestOffset, const FIntPoint& OwnedOffset, const FIntPoint& OwnedSize, double AxisShiftXRd, double AxisShiftYRd, bool bActivate)

--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -12,6 +12,7 @@
 #include "TempoSensorsUtils.h"
 
 #include "CanvasItem.h"
+#include "Curves/CurveFloat.h"
 #include "Engine/Canvas.h"
 #include "Engine/TextureRenderTarget2D.h"
 #include "Engine/Texture2D.h"
@@ -116,7 +117,7 @@ namespace
 		float MaxBrightness = 0.0f;
 		float SpeedUp = 3.0f;
 		float SpeedDown = 1.0f;
-		bool bHasBiasCurve = false;
+		const UCurveFloat* BiasCurve = nullptr;
 	};
 
 	// Same blend as FSceneView::OverridePostProcessSettings for these fields.
@@ -144,7 +145,7 @@ namespace
 		}
 		if (Src.bOverride_AutoExposureBiasCurve && Src.AutoExposureBiasCurve)
 		{
-			Dest.bHasBiasCurve = true;
+			Dest.BiasCurve = Src.AutoExposureBiasCurve;
 		}
 	}
 
@@ -159,7 +160,7 @@ namespace
 		Settings.MaxBrightness = Base.AutoExposureMaxBrightness;
 		Settings.SpeedUp = Base.AutoExposureSpeedUp;
 		Settings.SpeedDown = Base.AutoExposureSpeedDown;
-		Settings.bHasBiasCurve = Base.AutoExposureBiasCurve != nullptr;
+		Settings.BiasCurve = Base.AutoExposureBiasCurve;
 
 		// With auto exposure off as a project default the engine pins the base range to a fixed
 		// exposure of 1 (FSceneView::StartFinalPostprocessSettings).
@@ -2138,7 +2139,7 @@ void UTempoCamera::ApplyTileExposureSettings(FTempoCameraTile& Tile) const
 	PP.AutoExposureApplyPhysicalCameraExposure = false;
 
 	// A bias curve keyed on a tile's own, unmetered luminance would add an arbitrary compensation.
-	// The controller applies the camera's bias in one place.
+	// The controller evaluates the camera's curve against the metered scene instead.
 	PP.bOverride_AutoExposureBiasCurve = false;
 	PP.AutoExposureBiasCurve = nullptr;
 }
@@ -2163,11 +2164,6 @@ void UTempoCamera::UpdateSharedExposure(bool bSingleTileFastPath, FTempoCameraTi
 	};
 
 	const FTempoAutoExposureSettings AE = ResolveAutoExposureSettings(World, GetComponentLocation(), PostProcessSettings, PostProcessBlendWeight);
-	if (AE.bHasBiasCurve && !bWarnedAboutExposureBiasCurve)
-	{
-		UE_LOG(LogTempoSensors, Warning, TEXT("Camera %s: an AutoExposureBiasCurve is set but the multi-tile exposure controller does not evaluate it; only AutoExposureBias applies."), *GetName());
-		bWarnedAboutExposureBiasCurve = true;
-	}
 
 	if (bSingleTileFastPath)
 	{
@@ -2241,7 +2237,17 @@ void UTempoCamera::UpdateSharedExposure(bool bSingleTileFastPath, FTempoCameraTi
 	SmoothedSceneLuminance = FMath::Clamp(SmoothedSceneLuminance, MinWhitePointLuminance, MaxWhitePointLuminance);
 	LastSharedExposureUpdateTime = Now;
 
-	const float ExposureScale = FMath::Exp2(AE.Bias) / FMath::Max(SmoothedSceneLuminance, 0.0001f);
+	// GetAutoExposureCompensationFromCurve: the bias curve is keyed on the metered scene's EV100
+	// (the unsmoothed average luminance, remapped from middle grey to white) and applied without
+	// smoothing, so the exposure compensation responds immediately to what the scene is doing.
+	float Bias = AE.Bias;
+	if (AE.BiasCurve)
+	{
+		const float SceneEV100 = FMath::Log2(SceneLuminance / LuminanceMax) + FMath::Log2(1.0f / MiddleGrey);
+		Bias += AE.BiasCurve->GetFloatValue(SceneEV100);
+	}
+
+	const float ExposureScale = FMath::Exp2(Bias) / FMath::Max(SmoothedSceneLuminance, 0.0001f);
 
 	// The proxy meter is pinned to an exposure of 1. Fold in whatever it actually reports so that,
 	// say, a partial PostProcessBlendWeight cannot double-expose the output.

--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -1260,34 +1260,6 @@ void UTempoCamera::RenderCapture()
 	// on the seam).
 	const float K = FMath::Max(1.0f, UpsamplingFactor);
 
-	// CVar pushes bracket this camera's renders. CVar mutation must happen on the game thread —
-	// calling Set() on the render thread hits a check(0) in FConsoleManager::OnCVarChange. The GT
-	// path propagates the new value to the RT shadow via an ENQUEUE_RENDER_COMMAND queued in FIFO
-	// order with subsequent renderer commands, so the bracket on the render thread is
-	// set→render→restore. Multiple TempoCameras in the same frame interleave correctly because
-	// each camera's GT push, renders, and GT pop produce three RT entries in that order.
-	// ECVF_SetByConsole is the highest priority and always wins, avoiding the engine warning about
-	// replacing constructor-default priority and silently being rejected if anything else has
-	// touched the CVar.
-	IConsoleVariable* TSRShadingRejectionFlickingFrameRateCapCVar =
-		IConsoleManager::Get().FindConsoleVariable(TEXT("r.TSR.ShadingRejection.Flickering.FrameRateCap"));
-	const float SavedTSRShadingRejectionFlickingFrameRateCap = TSRShadingRejectionFlickingFrameRateCapCVar->GetFloat();
-	TSRShadingRejectionFlickingFrameRateCapCVar->Set(RateHz, ECVF_SetByConsole);
-
-	// Lumen probe gather temporal filter is the dominant source of *Lumen* ghost trails — it
-	// blends each probe's radiance with prior frames so noise stays low, but in dim scenes the
-	// signal is weak and history dominates, so moving objects leave a Lumen-shaped trail behind
-	// them. Disabling it (0) trades temporal smoothness for accurate per-frame Lumen; the bumped
-	// LumenFinalGatherQuality in the constructor compensates by reducing the input noise.
-	int32 SavedLumenScreenProbeTemporalFilter = 1;
-	IConsoleVariable* LumenScreenProbeTemporalFilterCVar =
-		IConsoleManager::Get().FindConsoleVariable(TEXT("r.Lumen.ScreenProbeGather.TemporalFilterProbes"));
-	if (LumenScreenProbeTemporalFilterCVar)
-	{
-		SavedLumenScreenProbeTemporalFilter = LumenScreenProbeTemporalFilterCVar->GetInt();
-		LumenScreenProbeTemporalFilterCVar->Set(TEXT("0"), ECVF_SetByConsole);
-	}
-
 	// Per-tile view origin (shared across tiles) — the camera's world location.
 	const FTransform CameraWorld = GetComponentToWorld();
 	const FVector ViewLocation = CameraWorld.GetTranslation();
@@ -1452,11 +1424,11 @@ void UTempoCamera::RenderCapture()
 	}
 	else
 	{
-		// Multi-tile: HDR atlas (pre-tonemap) so the proxy capture below can run AE/tonemap once
+		// Multi-tile: HDR atlas (pre-tonemap) so the proxy capture below can meter and tonemap once
 		// across the stitched output. Tile-appropriate show flags (no bloom/DOF/motionblur/etc)
-		// differ from the proxy's — swap them around the call.
-		// Eye adaptation stays on: the engine only honors the tiles' AutoExposureBias, and only
-		// computes a PreExposure for them, while it is. Manual exposure keeps it from adapting.
+		// differ from the proxy's — swap them around the call. The EyeAdaptation show flag must
+		// remain set for the tiles: the engine only honors their AutoExposureBias, and only computes
+		// a PreExposure for them, while it is. Manual exposure is what stops them from adapting.
 		const FEngineShowFlags SavedShowFlags = ShowFlags;
 		ShowFlags.SetLocalExposure(false);
 		ShowFlags.SetMotionBlur(false);
@@ -1662,19 +1634,6 @@ void UTempoCamera::RenderCapture()
 		{
 			CapturedVideoSequenceId = CapturedVideoSequenceIdThisFrame;
 		});
-
-	// Pop: restore the prior CVar values. The propagation render command queued by Set() on
-	// GT lands in RT FIFO after every render command this camera enqueued above, so each
-	// camera's renders consume the camera's own override before the restore takes effect.
-	if (TSRShadingRejectionFlickingFrameRateCapCVar)
-	{
-		TSRShadingRejectionFlickingFrameRateCapCVar->Set(SavedTSRShadingRejectionFlickingFrameRateCap, ECVF_SetByConsole);
-	}
-
-	if (LumenScreenProbeTemporalFilterCVar)
-	{
-		LumenScreenProbeTemporalFilterCVar->Set(*FString::FromInt(SavedLumenScreenProbeTemporalFilter), ECVF_SetByConsole);
-	}
 
 	TextureReadQueue.Enqueue(MoveTemp(NewRead));
 }
@@ -2172,8 +2131,9 @@ void UTempoCamera::ApplyTileExposureSettings(FTempoCameraTile& Tile) const
 	PP.bOverride_AutoExposureBias = true;
 	PP.AutoExposureBias = SharedExposureBias;
 
-	// Physical camera exposure is a manual-mode feature the camera's histogram auto exposure never
-	// applied; folding ISO/aperture/shutter into the tiles would double it up with the controller.
+	// The controller reproduces histogram auto exposure, in which the physical camera settings play
+	// no part. Left on, manual mode's physical camera would fold ISO, aperture and shutter into the
+	// tiles on top of it.
 	PP.bOverride_AutoExposureApplyPhysicalCameraExposure = true;
 	PP.AutoExposureApplyPhysicalCameraExposure = false;
 

--- a/TempoSensors/Source/TempoSensors/Private/TempoMultiViewCapture.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoMultiViewCapture.cpp
@@ -178,8 +178,14 @@ namespace
 				ViewInitOptions.OverlayColor = FLinearColor::Black;
 			}
 
-			// Per-tile view state: critical for TAA / auto-exposure history independence per tile.
+			// Per-tile view state: critical for TAA history independence per tile.
 			ViewInitOptions.SceneViewStateInterface = Setup.ViewState;
+			// One eye adaptation state for the whole family, the engine's own facility for tiled
+			// rendering (Movie Render Queue's high-resolution tiles use it). Every tile's exposure
+			// buffer and PreExposure then come from the same view state, so tiles cannot drift apart
+			// even through a readback race. Tiles run manual exposure, so no per-tile histogram is
+			// lost by sharing.
+			ViewInitOptions.ExposureSceneViewStateInterface = Views[0].ViewState;
 			ViewInitOptions.LODDistanceFactor = FMath::Clamp(PrimaryComponent->LODDistanceFactor, .01f, 100.0f);
 			// Hack to pass Lumen's LUMEN_MAX_VIEWS=2 family-level gate (Lumen.cpp:239). The cube
 			// path in LumenSceneRendering.cpp:3099 is semantically honest for us: all tiles share
@@ -187,9 +193,9 @@ namespace
 			// is exactly what a multi-tile camera needs. Applied to every view so DFAO temporal
 			// history is suppressed uniformly (DistanceFieldLightingPost.cpp:305) — otherwise
 			// Views[0] would look noisier than the rest and leave a seam at the tile boundary.
-			// Other knock-on effects (eye-adaptation sharing via SceneView.cpp:1055) are no-ops
-			// here because tiles run AEM_Manual. Guarded on Views.Num() > 2 so we only take the
-			// cube-path hit when we'd otherwise lose Lumen entirely.
+			// Eye adaptation sharing, which the cube path also implies, is set explicitly above for
+			// every tile count. Guarded on Views.Num() > 2 so we only take the cube-path hit when
+			// we'd otherwise lose Lumen entirely.
 			ViewInitOptions.bIsSceneCaptureCube = Views.Num() > 2;
 			// Engine's SetupViewFamilyForSceneCapture consults GRayTracingSceneCaptures (a Renderer-
 			// private CVar used only for debug overrides). We don't link Renderer (see Build.cs note),

--- a/TempoSensors/Source/TempoSensors/Private/TempoSensorsUtils.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoSensorsUtils.cpp
@@ -104,11 +104,14 @@ void ApplyPhotorealisticRenderSettings(FPostProcessSettings& OutPostProcess,
 	OutPostProcess.bOverride_ReflectionMethod = true;
 	OutPostProcess.ReflectionMethod = EReflectionMethod::Lumen;
 
-	// Lumen final-gather denoiser leans on temporal history; in dim scenes the signal-to-noise
-	// ratio is poor and history dominates, which manifests as ghost trails behind slow movers.
-	// Bumping FinalGatherQuality reduces input noise and bumping the update speed shortens the
-	// effective history window so trails fade faster. Reflection quality has the same effect for
-	// specular ghosts.
+	// Lumen's screen probe gather accumulates its history in frames, not seconds, so at sensor
+	// rates a mover can trail its indirect lighting for a long time. FinalGatherQuality scales the
+	// rays traced per probe (by its square root), lowering the per-frame noise the accumulation
+	// exists to hide. LightingUpdateSpeed divides the frames accumulated (by its square root, so the
+	// engine's 10 becomes 5) and raises the radiance cache's per-frame trace budget, so lighting
+	// changes propagate faster. ReflectionQuality scales the reflection denoiser's spatial
+	// reconstruction sample count only; the reflection history length is set by
+	// r.Lumen.Reflections.Temporal.MaxFramesAccumulated.
 	OutPostProcess.bOverride_LumenFinalGatherQuality = true;
 	OutPostProcess.LumenFinalGatherQuality = 2.0f;
 	OutPostProcess.bOverride_LumenFinalGatherLightingUpdateSpeed = true;

--- a/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
@@ -559,10 +559,44 @@ protected:
 	// and ensure it is present in this component's PostProcessSettings.WeightedBlendables.
 	UMaterialInstanceDynamic* GetOrCreateProxyTonemapMID();
 
-	// Shared pre-exposure (EV stops) pushed onto every tile's AutoExposureBias before each capture.
-	// Driven by a P-controller fed from the proxy's AE-reported luminance.
+	// Exposure bias (EV) applied to every tile's manual exposure before each capture. In the
+	// multi-tile path the tiles carry the camera's entire exposure: a tile's PreExposure (what TSR,
+	// Lumen and the fp16 scene color see) is then the exposure of the final image, and the proxy
+	// capture is reduced to a light meter at a fixed exposure of 1. The bias is auto exposure
+	// re-derived on the CPU from the proxy's histogram readback with the engine's own target, range
+	// and speed rules (UpdateSharedExposure), so the camera's auto exposure settings keep their
+	// meaning. Eye adaptation stays enabled on the tile family: the engine only honors
+	// AutoExposureBias, and only computes a PreExposure, while it is, and a PreExposure of 1 starves
+	// TSR's shading rejection in dim scenes.
 	float SharedExposureBias = 0.0f;
 	bool bHasValidSharedExposure = false;
+
+	// Controller state: the engine's smoothed "exposure" luminance (its reciprocal, times the
+	// exposure compensation, is the exposure scale) and the world time of the last step.
+	float SmoothedSceneLuminance = 0.0f;
+	double LastSharedExposureUpdateTime = -1.0;
+
+	// Bias the tiles rendered with on recent captures, most recent first. The proxy's histogram
+	// readback reaches the game thread about two captures after the image it measured, and the
+	// controller has to divide the measurement by the exposure that produced it.
+	static constexpr int32 AppliedExposureBiasHistoryLength = 3;
+	float AppliedExposureBiasHistory[AppliedExposureBiasHistoryLength] = { 0.0f, 0.0f, 0.0f };
+
+	// Multi-tile captures since the controller was last (re)seeded. The proxy does not render in
+	// the fast path, so right after a switch its last readback describes some older image; the
+	// controller waits until a readback can only be of a capture it has the applied bias for.
+	int32 NumMultiTileCapturesSinceExposureSeed = 0;
+
+	bool bWarnedAboutExposureBiasCurve = false;
+
+	// Step the exposure controller once per capture: from the proxy's readback in the multi-tile
+	// path, or seeded from the tile's own auto exposure in the fast path so a later switch into the
+	// multi-tile path starts at the exposure the scene already has.
+	void UpdateSharedExposure(bool bSingleTileFastPath, FTempoCameraTile* SingleActiveTile);
+
+	// Push the per-tile exposure settings (manual method at the shared bias, no physical camera,
+	// no bias curve) onto a tile's post-process settings.
+	void ApplyTileExposureSettings(FTempoCameraTile& Tile) const;
 
 	// Tracks whether the previous capture used the single-tile fast path. When this flips, the
 	// active tile's TAA/AE history was conditioned on a different post-process configuration;

--- a/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
@@ -587,8 +587,6 @@ protected:
 	// controller waits until a readback can only be of a capture it has the applied bias for.
 	int32 NumMultiTileCapturesSinceExposureSeed = 0;
 
-	bool bWarnedAboutExposureBiasCurve = false;
-
 	// Step the exposure controller once per capture: from the proxy's readback in the multi-tile
 	// path, or seeded from the tile's own auto exposure in the fast path so a later switch into the
 	// multi-tile path starts at the exposure the scene already has.

--- a/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoCamera.h
@@ -565,9 +565,9 @@ protected:
 	// capture is reduced to a light meter at a fixed exposure of 1. The bias is auto exposure
 	// re-derived on the CPU from the proxy's histogram readback with the engine's own target, range
 	// and speed rules (UpdateSharedExposure), so the camera's auto exposure settings keep their
-	// meaning. Eye adaptation stays enabled on the tile family: the engine only honors
-	// AutoExposureBias, and only computes a PreExposure, while it is, and a PreExposure of 1 starves
-	// TSR's shading rejection in dim scenes.
+	// meaning. The tile family renders with the EyeAdaptation show flag set: the engine only honors
+	// AutoExposureBias, and only computes a PreExposure, while it is, and TSR's shading rejection
+	// is calibrated for pre-exposed input.
 	float SharedExposureBias = 0.0f;
 	bool bHasValidSharedExposure = false;
 

--- a/TempoSensors/Source/TempoSensors/Public/TempoMultiViewCapture.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoMultiViewCapture.h
@@ -23,8 +23,9 @@ namespace TempoMultiViewCapture
 {
 	struct FViewSetup
 	{
-		// Per-view scene view state (TAA / auto-exposure history). Must be valid per view so that
-		// tiles don't share history.
+		// Per-view scene view state (TAA history). Must be valid per view so that tiles don't share
+		// history. Exposure state is deliberately shared: every view is pointed at the first view's
+		// state for eye adaptation.
 		FSceneViewStateInterface* ViewState = nullptr;
 
 		// Per-view post-process settings (holds the distortion PPM blendable + AE bias).


### PR DESCRIPTION
## Problem

Tiled (multi-view) camera renders ghosted badly in dim scenes, worst on bright moving objects against a dark background, with trails persisting for many captures at 10 Hz. Single-tile renders did not.

The multi-tile path disabled the EyeAdaptation show flag on the tiles to stop per-tile adaptation. That has two engine side effects it did not intend:

- `FViewInfo::UpdatePreExposure` only computes a PreExposure while that flag is set, so every tile rendered, accumulated TSR history, and stored Lumen history in raw radiance.
- `GetEyeAdaptationParameters` forces the exposure compensation to 1 while the flag is off, so the shared `AutoExposureBias` pushed onto the tiles was silently ignored. Tiles agreed only because they were all at exposure 1.

TSR's shading rejection compares in a display-referred space and expects pre-exposed input. The `r.TSR.ShadingRejection.ExposureOffset` push tried to compensate, but with twice the correct gain (the error grows with the bias, so it was worst at night) and with a value that changed every capture, which TSR does not correct its guide and flicker histories for. Rejection stopped working on low-contrast parts of movers and the history persisted.

## Change

The tiles now own the camera's whole exposure, and the proxy capture is only a light meter.

- Tiles render with eye adaptation enabled, in manual mode, at a shared bias. Their PreExposure is therefore the exposure of the final image, which is what TSR, Lumen, and the fp16 scene color need.
- The proxy capture is pinned to an exposure of exactly 1 for the duration of its capture (histogram method with an empty brightness range and zero bias), so its histogram still runs but it no longer re-exposes the image.
- `UTempoCamera::UpdateSharedExposure` re-derives auto exposure on the CPU from the proxy's histogram readback with the engine's own rules: middle-grey target, min/max brightness range, the linear-then-exponential adaptation curve at the configured speeds, `AutoExposureBias`, and `AutoExposureBiasCurve` keyed on the metered EV100. Settings are resolved the way the engine resolves a view's final settings: project defaults, then world post-process volumes at the camera location, then the component's overrides. The camera's user-facing auto exposure settings keep their meaning.
- The readback reaches the game thread about two captures after the image it measured, so the controller keeps the bias each capture rendered with and divides the measurement by the exposure that produced it. It waits out that lag after a switch from the single-tile fast path, and it seeds itself from the fast-path tile's own exposure on that switch.
- Every tile view points `ExposureSceneViewStateInterface` at the first tile's state (the engine's Movie Render Queue tiling facility), so all tiles read PreExposure from one buffer.
- Physical camera exposure is forced off on tiles: it is a manual-mode feature the camera's histogram auto exposure never applied.
- All console-variable pushes around the tile render are gone. `ExposureOffset` is unnecessary now that the input is pre-exposed. `Flickering.FrameRateCap` was a no-op above 30 fps and in fixed step only kept TSR's ghost-permitting flicker heuristic armed. `Lumen.ScreenProbeGather.TemporalFilterProbes` already defaults to 0.
- Comments describe the current design; the Lumen settings comment in `ApplyPhotorealisticRenderSettings` now says what each setting controls.

## Behavior notes

- Adaptation smooths per capture interval. The proxy smoothed per engine frame, so at real-time frame rates the camera adapted about six times slower than its configured f-stops per second. Fixed-step runs see no difference.
- The first two multi-tile captures after startup render before a readback exists, then the exposure snaps to target. Previously the proxy ramped from exposure 1 over many captures.
- The single-tile fast path is unchanged; the engine runs the full auto exposure there as before.

## Testing

- Editor target builds on Mac (UE 5.7) with no warnings in the touched files.
- Manual check of low-light tiled renders with bright movers: markedly less ghosting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWr88UyzfhUh4Z4KoBGPdL
