### PR TITLE
Report the sensor settings' soft references to the cooker

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoSensorsSettings.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoSensorsSettings.cpp
@@ -2,6 +2,8 @@
 
 #include "TempoSensorsSettings.h"
 
+#include "UObject/UnrealType.h"
+
 UTempoSensorsSettings::UTempoSensorsSettings()
 {
 	CategoryName = TEXT("Tempo");
@@ -46,6 +48,19 @@ void UTempoSensorsSettings::PostInitProperties()
 	SetIfNull(CameraProxyTonemapMaterial, TEXT("/TempoSensors/Materials/M_TempoStitch_Proxy.M_TempoStitch_Proxy"));
 	SetIfNull(LidarPostProcessMaterial, TEXT("/TempoSensors/Materials/M_LidarPostProcess.M_LidarPostProcess"));
 	SetIfNull(LidarPostProcessMaterialWithColor, TEXT("/TempoSensors/Materials/M_LidarPostProcess_WithColor.M_LidarPostProcess_WithColor"));
+
+#if WITH_EDITOR
+	// The cooker only cooks soft references it has been told about. FSoftObjectPath::ImportTextItem reports
+	// each path it reads from config to GRedirectCollector, and the cooker seeds its requests from that, so a
+	// path set in DefaultPlugins.ini gets its package cooked. Paths assigned from C++ (the constructor
+	// defaults and the fallbacks above) never pass through ImportTextItem, so nothing would cook the
+	// plugin's materials and a packaged build would fail to load them. Report every soft reference this
+	// object holds, whatever its source, the same way a config-loaded one is reported.
+	for (TFieldIterator<FSoftObjectProperty> It(GetClass()); It; ++It)
+	{
+		It->GetPropertyValue_InContainer(this).ToSoftObjectPath().PostLoadPath(nullptr);
+	}
+#endif
 }
 
 #if WITH_EDITOR


### PR DESCRIPTION
Fixes the packaging problem #567 worked around with `-skipiostore` and a plugin-wide `DirectoriesToAlwaysCook`, at its actual cause, so iostore stays on and no cook rule is needed for the sensor materials.

## What was actually wrong

The cooker only cooks soft references it has been told about. `FSoftObjectPath::ImportTextItem` reports every path it reads from config to `GRedirectCollector` ("Consider this a load, so Config string references get cooked"), and the cooker seeds its initial requests from that list. So a material named in `DefaultPlugins.ini` reaches a packaged build, which is how these materials were cooked before #409.

#409 moved the material defaults out of config and into the `UTempoSensorsSettings` constructor as `FSoftObjectPath(TEXT(...))`. A path assigned from C++ never passes through `ImportTextItem`, so from then on nothing cooked the camera and lidar post-process materials, the stitch materials or the distortion map. A packaged sim started clean and then logged

```
LoadPackage: SkipPackage: /TempoSensors/Materials/M_TempoCamera_Distort_NoDepth ... does not exist on disk or in the loader
PostProcessMaterialNoDepth is not set in TempoSensors settings
```

the first time a camera was used.

The iostore part of the #567 diagnosis does not hold up. `Soft: Unknown reference chain. Soft From Unassigned Package?` in `AllChunksInfo.csv` is the label *every* startup soft reference gets (the `/TempoSensors/Materials/M_LabelPreview` entries carry it on `main` today), and such packages go to chunk 0 and into the container like anything else. With the materials cooked, iostore packages them fine.

## The fix

`UTempoSensorsSettings::PostInitProperties` now reports every soft reference the object holds to the redirect collector, the same way a config-loaded one is reported. That covers the constructor defaults, the `=None` fallbacks, and anything a project overrides in config. Nothing else is needed: no `DirectoriesToAlwaysCook`, no AssetManager rules, no `-skipiostore`.

## Verification

All on Mac, `bUseIoStore=True`, no `DirectoriesToAlwaysCook` entry in any config, `Scripts/Package.sh -map=LowerSector`.

| Build | Settings materials cooked | In `pakchunk0-Mac.utoc` |
|---|---|---|
| `main` | 0 of 9 | n/a |
| this branch | 9 of 9, plus `T_DistortionMap` and `MF_TempoTextureFilter` | all present (`UnrealPak -List`) |

A packaged sim from this branch streams color images from a spawned `BP_SensorRig` camera with no `SkipPackage` lines in its log.

## Not in this PR

- `-skipiostore` in CI is a separate, real issue (a cold cook cannot find engine content under `Saved/Temp`) and stays as is.
- `Scripts/Package.sh` still leaves a previous build's files in `Packaged/<Platform>`, so switching a machine between `-skipiostore` and iostore builds leaves a stale `.utoc` that shadows the fresh `.pak`. #567 had a `rm -rf` for this; it is worth doing separately.
- `BP_SensorRig` is referenced by nothing in a host project, so on `main` it is not in a packaged build either, and `test_sensors.py` cannot spawn it. #567's test level references it, and that level is cooked on every cook through `[AlwaysCookMaps]` in the plugin's `Config/Editor.ini`, so once #567 lands the rig is packaged too. Note that a plugin `Config/DefaultGame.ini` is not merged into the config hierarchy at all (the layering uses the bare base name, so only `Game.ini`, `Engine.ini`, `Editor.ini` work), and `DirectoriesToAlwaysCook` only scans `*.uasset`, never `*.umap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBtP3AmHk7u75Ki6kGguj
