### PR TITLE
Fix instance ID leaks and silent failures in the label config API

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoActorLabeler.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoActorLabeler.cpp
@@ -21,6 +21,7 @@
 #include "Components/SkinnedMeshComponent.h"
 #include "Engine/SkeletalMesh.h"
 #include "Engine/SkinnedAsset.h"
+#include "Engine/StaticMesh.h"
 #include "NiagaraComponent.h"
 #include "NiagaraEmitter.h"
 #include "NiagaraEmitterHandle.h"
@@ -108,6 +109,57 @@ void FInstanceIdAllocator::Return(int32 Id)
 using LabelService = TempoSensors::LabelService;
 using LabelAsyncService = TempoSensors::LabelService::AsyncService;
 
+namespace
+{
+	// The sentinel FInstanceSemanticIdPair carries when no instance ID was ever allocated for the
+	// object. The allocator hands out 1..GTempoCamera_Max_Label, so 0 can never be a live ID.
+	constexpr int32 NoInstanceId = 0;
+
+	// Every Set*SemanticId RPC takes the same semantic ID domain: a label the camera can encode, or
+	// -1 meaning "forget the override and let the table decide". Returns false and answers the
+	// request when the ID is outside it.
+	bool ValidateSemanticIdRange(int32 SemanticId, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation)
+	{
+		if (SemanticId >= -1 && SemanticId <= GTempoCamera_Max_Label)
+		{
+			return true;
+		}
+
+		const FString ErrorMsg = FString::Printf(TEXT("semantic_id must be -1 (revert) or 0-%d"), GTempoCamera_Max_Label);
+		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, TCHAR_TO_UTF8(*ErrorMsg)));
+		return false;
+	}
+
+	// Invert one of the label table's key -> row-name maps into semantic ID -> keys, then apply the
+	// runtime overrides on top: an overridden key moves out of whichever ID the table gave it and
+	// into the one the override names, which is what the labeler will actually draw.
+	template <typename KeyType>
+	TMap<int32, TArray<KeyType>> BuildSemanticIdToKeys(const TMap<KeyType, FName>& TableLabels,
+		const TMap<FName, int32>& SemanticIds, const TMap<KeyType, int32>& Overrides)
+	{
+		TMap<int32, TArray<KeyType>> SemanticIdToKeys;
+		for (const auto& [Key, LabelName] : TableLabels)
+		{
+			if (const int32* SemanticId = SemanticIds.Find(LabelName))
+			{
+				SemanticIdToKeys.FindOrAdd(*SemanticId).Add(Key);
+			}
+		}
+
+		for (const auto& [Key, OverrideSemanticId] : Overrides)
+		{
+			for (auto& [Id, Keys] : SemanticIdToKeys)
+			{
+				Keys.Remove(Key);
+			}
+			SemanticIdToKeys.FindOrAdd(OverrideSemanticId).Add(Key);
+		}
+
+		return SemanticIdToKeys;
+	}
+}
+
 void UTempoActorLabeler::RegisterServices(FTempoServer& Server)
 {
 	Server.RegisterService<LabelService>(
@@ -118,6 +170,8 @@ void UTempoActorLabeler::RegisterServices(FTempoServer& Server)
 		SimpleRequestHandler(&LabelAsyncService::RequestSetActorTypeSemanticId, &UTempoActorLabeler::HandleSetActorTypeSemanticId),
 		SimpleRequestHandler(&LabelAsyncService::RequestGetAllStaticMeshTypes, &UTempoActorLabeler::HandleGetAllStaticMeshTypes),
 		SimpleRequestHandler(&LabelAsyncService::RequestSetStaticMeshTypeSemanticId, &UTempoActorLabeler::HandleSetStaticMeshTypeSemanticId),
+		SimpleRequestHandler(&LabelAsyncService::RequestGetAllSkeletalMeshTypes, &UTempoActorLabeler::HandleGetAllSkeletalMeshTypes),
+		SimpleRequestHandler(&LabelAsyncService::RequestSetSkeletalMeshTypeSemanticId, &UTempoActorLabeler::HandleSetSkeletalMeshTypeSemanticId),
 		SimpleRequestHandler(&LabelAsyncService::RequestSetActorTagSemanticId, &UTempoActorLabeler::HandleSetActorTagSemanticId),
 		SimpleRequestHandler(&LabelAsyncService::RequestGetLabelTableAsJson, &UTempoActorLabeler::HandleGetLabelTableAsJson),
 		SimpleRequestHandler(&LabelAsyncService::RequestSetLabelType, &UTempoActorLabeler::HandleSetLabelType),
@@ -151,103 +205,27 @@ void UTempoActorLabeler::HandleGetSemanticClasses(const TempoCore::Empty& Reques
 {
 	TempoSensors::GetSemanticClassesResponse Response;
 
-	// Build reverse mapping: semantic_id -> actor types
-	TMap<int32, TArray<FName>> SemanticIdToActorTypes;
-
-	// Include DataTable assignments
+	// The overrides are keyed on class name, so reduce the table's class keys to names to match.
+	TMap<FName, FName> ActorTypeLabels;
 	for (const auto& [ActorClass, LabelName] : ActorSemanticLabels)
 	{
-		if (const int32* SemanticId = SemanticIds.Find(LabelName))
-		{
-			SemanticIdToActorTypes.FindOrAdd(*SemanticId).Add(ActorClass->GetFName());
-		}
+		ActorTypeLabels.Add(ActorClass->GetFName(), LabelName);
 	}
 
-	// Include runtime overrides (they take precedence)
-	for (const auto& [ActorTypeName, OverrideSemanticId] : ActorTypeSemanticIdOverrides)
-	{
-		// Remove from old mapping if present, add to new
-		for (auto& [Id, Types] : SemanticIdToActorTypes)
-		{
-			Types.Remove(ActorTypeName);
-		}
-		SemanticIdToActorTypes.FindOrAdd(OverrideSemanticId).Add(ActorTypeName);
-	}
+	const TMap<int32, TArray<FName>> SemanticIdToActorTypes = BuildSemanticIdToKeys(ActorTypeLabels, SemanticIds, ActorTypeSemanticIdOverrides);
+	const TMap<int32, TArray<FString>> SemanticIdToMeshPaths = BuildSemanticIdToKeys(StaticMeshLabels, SemanticIds, StaticMeshTypeSemanticIdOverrides);
+	const TMap<int32, TArray<FString>> SemanticIdToSkeletalMeshPaths = BuildSemanticIdToKeys(SkeletalMeshLabels, SemanticIds, SkeletalMeshTypeSemanticIdOverrides);
+	const TMap<int32, TArray<FName>> SemanticIdToActorTags = BuildSemanticIdToKeys(ActorTagLabels, SemanticIds, ActorTagSemanticIdOverrides);
+	// Component tags have no runtime override RPC, so the table is the whole story for them.
+	const TMap<int32, TArray<FName>> SemanticIdToComponentTags = BuildSemanticIdToKeys(ComponentTagLabels, SemanticIds, TMap<FName, int32>());
 
-	// Build reverse mapping: semantic_id -> static mesh paths
-	TMap<int32, TArray<FString>> SemanticIdToMeshPaths;
-
-	// Include DataTable static mesh assignments
-	for (const auto& [MeshPath, LabelName] : StaticMeshLabels)
-	{
-		if (const int32* SemanticId = SemanticIds.Find(LabelName))
-		{
-			SemanticIdToMeshPaths.FindOrAdd(*SemanticId).Add(MeshPath);
-		}
-	}
-
-	// Include runtime static mesh overrides (they take precedence)
-	for (const auto& [MeshPath, OverrideSemanticId] : StaticMeshTypeSemanticIdOverrides)
-	{
-		// Remove from old mapping if present, add to new
-		for (auto& [Id, Paths] : SemanticIdToMeshPaths)
-		{
-			Paths.Remove(MeshPath);
-		}
-		SemanticIdToMeshPaths.FindOrAdd(OverrideSemanticId).Add(MeshPath);
-	}
-
-	// Build reverse mapping: semantic_id -> skeletal mesh paths
-	TMap<int32, TArray<FString>> SemanticIdToSkeletalMeshPaths;
-
-	for (const auto& [MeshPath, LabelName] : SkeletalMeshLabels)
-	{
-		if (const int32* SemanticId = SemanticIds.Find(LabelName))
-		{
-			SemanticIdToSkeletalMeshPaths.FindOrAdd(*SemanticId).Add(MeshPath);
-		}
-	}
-
-	// Build reverse mapping: semantic_id -> component tags
-	TMap<int32, TArray<FName>> SemanticIdToComponentTags;
-
-	for (const auto& [ComponentTag, LabelName] : ComponentTagLabels)
-	{
-		if (const int32* SemanticId = SemanticIds.Find(LabelName))
-		{
-			SemanticIdToComponentTags.FindOrAdd(*SemanticId).Add(ComponentTag);
-		}
-	}
-
-	// Build reverse mapping: semantic_id -> actor tags
-	TMap<int32, TArray<FName>> SemanticIdToActorTags;
-
-	for (const auto& [ActorTag, LabelName] : ActorTagLabels)
-	{
-		if (const int32* SemanticId = SemanticIds.Find(LabelName))
-		{
-			SemanticIdToActorTags.FindOrAdd(*SemanticId).Add(ActorTag);
-		}
-	}
-
-	// Include runtime actor tag overrides (they take precedence)
-	for (const auto& [ActorTag, OverrideSemanticId] : ActorTagSemanticIdOverrides)
-	{
-		for (auto& [Id, Tags] : SemanticIdToActorTags)
-		{
-			Tags.Remove(ActorTag);
-		}
-		SemanticIdToActorTags.FindOrAdd(OverrideSemanticId).Add(ActorTag);
-	}
-
-	// Iterate DataTable to get all class definitions
 	for (const auto& [LabelName, SemanticId] : SemanticIds)
 	{
 		auto* ClassInfo = Response.add_classes();
 		ClassInfo->set_name(TCHAR_TO_UTF8(*LabelName.ToString()));
 		ClassInfo->set_label_id(SemanticId);
 
-		if (TArray<FName>* Types = SemanticIdToActorTypes.Find(SemanticId))
+		if (const TArray<FName>* Types = SemanticIdToActorTypes.Find(SemanticId))
 		{
 			for (const FName& TypeName : *Types)
 			{
@@ -255,7 +233,7 @@ void UTempoActorLabeler::HandleGetSemanticClasses(const TempoCore::Empty& Reques
 			}
 		}
 
-		if (TArray<FString>* MeshPaths = SemanticIdToMeshPaths.Find(SemanticId))
+		if (const TArray<FString>* MeshPaths = SemanticIdToMeshPaths.Find(SemanticId))
 		{
 			for (const FString& MeshPath : *MeshPaths)
 			{
@@ -263,7 +241,7 @@ void UTempoActorLabeler::HandleGetSemanticClasses(const TempoCore::Empty& Reques
 			}
 		}
 
-		if (TArray<FString>* SkeletalMeshPaths = SemanticIdToSkeletalMeshPaths.Find(SemanticId))
+		if (const TArray<FString>* SkeletalMeshPaths = SemanticIdToSkeletalMeshPaths.Find(SemanticId))
 		{
 			for (const FString& MeshPath : *SkeletalMeshPaths)
 			{
@@ -271,7 +249,7 @@ void UTempoActorLabeler::HandleGetSemanticClasses(const TempoCore::Empty& Reques
 			}
 		}
 
-		if (TArray<FName>* ComponentTags = SemanticIdToComponentTags.Find(SemanticId))
+		if (const TArray<FName>* ComponentTags = SemanticIdToComponentTags.Find(SemanticId))
 		{
 			for (const FName& ComponentTag : *ComponentTags)
 			{
@@ -279,7 +257,7 @@ void UTempoActorLabeler::HandleGetSemanticClasses(const TempoCore::Empty& Reques
 			}
 		}
 
-		if (TArray<FName>* ActorTags = SemanticIdToActorTags.Find(SemanticId))
+		if (const TArray<FName>* ActorTags = SemanticIdToActorTags.Find(SemanticId))
 		{
 			for (const FName& ActorTag : *ActorTags)
 			{
@@ -295,12 +273,8 @@ void UTempoActorLabeler::HandleSetActorTypeSemanticId(const TempoSensors::SetAct
 {
 	const int32 SemanticId = Request.semantic_id();
 
-	// Validate range
-	if (SemanticId < -1 || SemanticId > GTempoCamera_Max_Label)
+	if (!ValidateSemanticIdRange(SemanticId, ResponseContinuation))
 	{
-		const FString ErrorMsg = FString::Printf(TEXT("semantic_id must be -1 (revert) or 0-%d"), GTempoCamera_Max_Label);
-		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
-			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
 		return;
 	}
 
@@ -313,7 +287,7 @@ void UTempoActorLabeler::HandleSetActorTypeSemanticId(const TempoSensors::SetAct
 	{
 		const FString ErrorMsg = FString::Printf(TEXT("No actor class with name '%s' found"), *ActorTypeName);
 		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
-			grpc::Status(grpc::StatusCode::NOT_FOUND, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
+			grpc::Status(grpc::StatusCode::NOT_FOUND, TCHAR_TO_UTF8(*ErrorMsg)));
 		return;
 	}
 	const FName ActorType = ActorClass->GetFName();
@@ -341,16 +315,26 @@ void UTempoActorLabeler::HandleSetActorTypeSemanticId(const TempoSensors::SetAct
 	ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
 }
 
-void UTempoActorLabeler::HandleGetAllStaticMeshTypes(const TempoCore::Empty& Request, const TResponseDelegate<TempoSensors::GetAllStaticMeshTypesResponse>& ResponseContinuation)
+void UTempoActorLabeler::CountMeshInstances(bool bSkeletal, TMap<FString, int32>& OutMeshInstanceCounts) const
 {
-	TempoSensors::GetAllStaticMeshTypesResponse Response;
-
-	// Build map of mesh paths to instance counts
-	TMap<FString, int32> MeshInstanceCounts;
-
 	for (TActorIterator<AActor> ActorItr(GetWorld()); ActorItr; ++ActorItr)
 	{
 		AActor* Actor = *ActorItr;
+
+		if (bSkeletal)
+		{
+			// USkinnedMeshComponent covers USkeletalMeshComponent and the other skinned variants,
+			// matching what GetComponentMeshPaths reads a skeletal path from.
+			TInlineComponentArray<USkinnedMeshComponent*> SkinnedComponents(Actor);
+			for (USkinnedMeshComponent* SkinnedComponent : SkinnedComponents)
+			{
+				if (const USkinnedAsset* SkinnedAsset = SkinnedComponent->GetSkinnedAsset())
+				{
+					OutMeshInstanceCounts.FindOrAdd(SkinnedAsset->GetPathName())++;
+				}
+			}
+			continue;
+		}
 
 		// 1. Handle regular UStaticMeshComponent (non-instanced)
 		TInlineComponentArray<UStaticMeshComponent*> MeshComponents(Actor);
@@ -364,8 +348,7 @@ void UTempoActorLabeler::HandleGetAllStaticMeshTypes(const TempoCore::Empty& Req
 
 			if (const UStaticMesh* StaticMesh = MeshComponent->GetStaticMesh())
 			{
-				const FString MeshFullPath = StaticMesh->GetPathName();
-				MeshInstanceCounts.FindOrAdd(MeshFullPath)++;
+				OutMeshInstanceCounts.FindOrAdd(StaticMesh->GetPathName())++;
 			}
 		}
 
@@ -376,13 +359,13 @@ void UTempoActorLabeler::HandleGetAllStaticMeshTypes(const TempoCore::Empty& Req
 		{
 			if (const UStaticMesh* StaticMesh = ISMC->GetStaticMesh())
 			{
-				const FString MeshFullPath = StaticMesh->GetPathName();
-				MeshInstanceCounts.FindOrAdd(MeshFullPath) += ISMC->GetInstanceCount();
+				OutMeshInstanceCounts.FindOrAdd(StaticMesh->GetPathName()) += ISMC->GetInstanceCount();
 			}
 		}
 
 		// 3. Handle the meshes a Niagara mesh renderer instances. The live particle count varies
-		// every frame, so count the components drawing the mesh rather than the particles.
+		// every frame, so count the components drawing the mesh rather than the particles. Niagara
+		// mesh renderers instance static meshes only, so this has no skeletal counterpart.
 		TInlineComponentArray<UNiagaraComponent*> NiagaraComponents(Actor);
 		for (UNiagaraComponent* NiagaraComponent : NiagaraComponents)
 		{
@@ -390,20 +373,26 @@ void UTempoActorLabeler::HandleGetAllStaticMeshTypes(const TempoCore::Empty& Req
 			GetComponentMeshPaths(NiagaraComponent, MeshPaths);
 			for (const FString& MeshPath : MeshPaths)
 			{
-				MeshInstanceCounts.FindOrAdd(MeshPath)++;
+				OutMeshInstanceCounts.FindOrAdd(MeshPath)++;
 			}
 		}
 	}
+}
 
-	// Build response with mesh info
+void UTempoActorLabeler::HandleGetAllStaticMeshTypes(const TempoCore::Empty& Request, const TResponseDelegate<TempoSensors::GetAllStaticMeshTypesResponse>& ResponseContinuation)
+{
+	TempoSensors::GetAllStaticMeshTypesResponse Response;
+
+	TMap<FString, int32> MeshInstanceCounts;
+	CountMeshInstances(/*bSkeletal=*/false, MeshInstanceCounts);
+
 	for (const auto& [MeshPath, InstanceCount] : MeshInstanceCounts)
 	{
 		auto* MeshInfo = Response.add_mesh_types();
 		MeshInfo->set_mesh_path(TCHAR_TO_UTF8(*MeshPath));
 
 		// Extract display name from path (e.g., "/Game/Meshes/SM_Tree.SM_Tree" -> "SM_Tree")
-		FString DisplayName = FPaths::GetBaseFilename(MeshPath);
-		MeshInfo->set_display_name(TCHAR_TO_UTF8(*DisplayName));
+		MeshInfo->set_display_name(TCHAR_TO_UTF8(*FPaths::GetBaseFilename(MeshPath)));
 
 		MeshInfo->set_instance_count(InstanceCount);
 
@@ -414,28 +403,35 @@ void UTempoActorLabeler::HandleGetAllStaticMeshTypes(const TempoCore::Empty& Req
 	ResponseContinuation.ExecuteIfBound(Response, grpc::Status_OK);
 }
 
-void UTempoActorLabeler::HandleSetStaticMeshTypeSemanticId(const TempoSensors::SetStaticMeshTypeSemanticIdRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation)
+void UTempoActorLabeler::HandleGetAllSkeletalMeshTypes(const TempoCore::Empty& Request, const TResponseDelegate<TempoSensors::GetAllSkeletalMeshTypesResponse>& ResponseContinuation)
 {
-	const FString MeshPath = UTF8_TO_TCHAR(Request.static_mesh_path().c_str());
-	const int32 SemanticId = Request.semantic_id();
+	TempoSensors::GetAllSkeletalMeshTypesResponse Response;
 
-	// Validate range
-	if (SemanticId < -1 || SemanticId > GTempoCamera_Max_Label)
+	TMap<FString, int32> MeshInstanceCounts;
+	CountMeshInstances(/*bSkeletal=*/true, MeshInstanceCounts);
+
+	for (const auto& [MeshPath, InstanceCount] : MeshInstanceCounts)
 	{
-		const FString ErrorMsg = FString::Printf(TEXT("semantic_id must be -1 (revert) or 0-%d"), GTempoCamera_Max_Label);
-		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
-			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
-		return;
+		auto* MeshInfo = Response.add_mesh_types();
+		MeshInfo->set_mesh_path(TCHAR_TO_UTF8(*MeshPath));
+		MeshInfo->set_display_name(TCHAR_TO_UTF8(*FPaths::GetBaseFilename(MeshPath)));
+		MeshInfo->set_instance_count(InstanceCount);
+		MeshInfo->set_current_semantic_id(ResolveMeshSemanticId(MeshPath).Get(-1));
 	}
 
+	ResponseContinuation.ExecuteIfBound(Response, grpc::Status_OK);
+}
+
+void UTempoActorLabeler::SetMeshTypeSemanticIdOverride(const FString& MeshPath, int32 SemanticId, TMap<FString, int32>& Overrides)
+{
 	// Store or clear override
 	if (SemanticId < 0)
 	{
-		StaticMeshTypeSemanticIdOverrides.Remove(MeshPath);
+		Overrides.Remove(MeshPath);
 	}
 	else
 	{
-		StaticMeshTypeSemanticIdOverrides.Add(MeshPath, SemanticId);
+		Overrides.Add(MeshPath, SemanticId);
 	}
 
 	// Re-label all components rendering this mesh, Niagara mesh renderers included.
@@ -456,6 +452,54 @@ void UTempoActorLabeler::HandleSetStaticMeshTypeSemanticId(const TempoSensors::S
 			}
 		}
 	}
+}
+
+void UTempoActorLabeler::HandleSetStaticMeshTypeSemanticId(const TempoSensors::SetStaticMeshTypeSemanticIdRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation)
+{
+	const FString MeshPath = UTF8_TO_TCHAR(Request.static_mesh_path().c_str());
+	const int32 SemanticId = Request.semantic_id();
+
+	if (!ValidateSemanticIdRange(SemanticId, ResponseContinuation))
+	{
+		return;
+	}
+
+	// An override has to land in the map the reporting RPCs read for this asset kind, so a path
+	// naming something else belongs in the skeletal RPC (or nowhere). Resolving it also rejects a
+	// typo rather than recording an override no component will ever match. The table's own paths
+	// are already typed by the column they came from, so they need no load.
+	if (!StaticMeshLabels.Contains(MeshPath) && !Cast<UStaticMesh>(FSoftObjectPath(MeshPath).TryLoad()))
+	{
+		const FString ErrorMsg = FString::Printf(TEXT("'%s' does not name a static mesh. Skeletal meshes are set with SetSkeletalMeshTypeSemanticId."), *MeshPath);
+		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, TCHAR_TO_UTF8(*ErrorMsg)));
+		return;
+	}
+
+	SetMeshTypeSemanticIdOverride(MeshPath, SemanticId, StaticMeshTypeSemanticIdOverrides);
+
+	ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
+}
+
+void UTempoActorLabeler::HandleSetSkeletalMeshTypeSemanticId(const TempoSensors::SetSkeletalMeshTypeSemanticIdRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation)
+{
+	const FString MeshPath = UTF8_TO_TCHAR(Request.skeletal_mesh_path().c_str());
+	const int32 SemanticId = Request.semantic_id();
+
+	if (!ValidateSemanticIdRange(SemanticId, ResponseContinuation))
+	{
+		return;
+	}
+
+	if (!SkeletalMeshLabels.Contains(MeshPath) && !Cast<USkinnedAsset>(FSoftObjectPath(MeshPath).TryLoad()))
+	{
+		const FString ErrorMsg = FString::Printf(TEXT("'%s' does not name a skeletal mesh. Static meshes are set with SetStaticMeshTypeSemanticId."), *MeshPath);
+		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, TCHAR_TO_UTF8(*ErrorMsg)));
+		return;
+	}
+
+	SetMeshTypeSemanticIdOverride(MeshPath, SemanticId, SkeletalMeshTypeSemanticIdOverrides);
 
 	ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
 }
@@ -492,26 +536,33 @@ void UTempoActorLabeler::HandleSetLabelType(const TempoSensors::SetLabelTypeRequ
 void UTempoActorLabeler::HandleLoadLabelTable(const TempoSensors::LoadLabelTableRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation)
 {
 	FString Json = UTF8_TO_TCHAR(Request.json().c_str());
-	FString JsonFile = UTF8_TO_TCHAR(Request.json_file().c_str());
+	const FString RequestedJsonFile = UTF8_TO_TCHAR(Request.json_file().c_str());
 
-	if (Json.IsEmpty() == JsonFile.IsEmpty())
+	if (!Json.IsEmpty() && !RequestedJsonFile.IsEmpty())
 	{
 		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
-			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Exactly one of json and json_file must be set"));
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "At most one of json and json_file may be set"));
 		return;
 	}
 
-	if (!JsonFile.IsEmpty())
+	if (Json.IsEmpty() && RequestedJsonFile.IsEmpty())
 	{
-		if (FPaths::IsRelative(JsonFile))
-		{
-			JsonFile = FPaths::Combine(FPaths::ProjectDir(), JsonFile);
-		}
+		// Neither field set means "go back to the table configured in Project Settings". Without
+		// this there is no way out of a runtime table once one is loaded: it lives on the settings
+		// CDO and supersedes the configured asset for as long as it is set.
+		GetMutableDefault<UTempoSensorsSettings>()->SetRuntimeSemanticLabelTable(nullptr);
+		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(), grpc::Status_OK);
+		return;
+	}
+
+	if (!RequestedJsonFile.IsEmpty())
+	{
+		const FString JsonFile = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir(), RequestedJsonFile);
 		if (!FFileHelper::LoadFileToString(Json, *JsonFile))
 		{
 			const FString ErrorMsg = FString::Printf(TEXT("Could not read label table file '%s'"), *JsonFile);
 			ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
-				grpc::Status(grpc::StatusCode::NOT_FOUND, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
+				grpc::Status(grpc::StatusCode::NOT_FOUND, TCHAR_TO_UTF8(*ErrorMsg)));
 			return;
 		}
 	}
@@ -524,12 +575,26 @@ void UTempoActorLabeler::HandleLoadLabelTable(const TempoSensors::LoadLabelTable
 	// ComponentTags, so let an omitted column keep the row struct's default. Unrecognized columns
 	// stay an error: those are typos, and silently dropping one would silently drop its labels.
 	NewSemanticLabelTable->bIgnoreMissingFields = true;
-	const TArray<FString> Problems = NewSemanticLabelTable->CreateTableFromJSONString(Json);
-	if (!Problems.IsEmpty())
+	const TArray<FString> ImportProblems = NewSemanticLabelTable->CreateTableFromJSONString(Json);
+	if (!ImportProblems.IsEmpty())
 	{
-		const FString ErrorMsg = FString::Printf(TEXT("Could not import label table: %s"), *FString::Join(Problems, TEXT(" ")));
+		const FString ErrorMsg = FString::Printf(TEXT("Could not import label table: %s"), *FString::Join(ImportProblems, TEXT(" ")));
 		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
-			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, TCHAR_TO_UTF8(*ErrorMsg)));
+		return;
+	}
+
+	// The importer only reports what it could not parse. A table that parses can still be unusable
+	// — an unencodable label ID corrupts the depth of every pixel it covers, an unresolved asset
+	// path labels nothing — and none of that is visible to the client from a table it can no longer
+	// see. Check before installing, so a bad table is rejected here rather than discovered in the
+	// images.
+	const TArray<FString> ValidationProblems = ValidateSemanticLabelTable(NewSemanticLabelTable);
+	if (!ValidationProblems.IsEmpty())
+	{
+		const FString ErrorMsg = FString::Printf(TEXT("Label table is not usable: %s"), *FString::Join(ValidationProblems, TEXT(" ")));
+		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, TCHAR_TO_UTF8(*ErrorMsg)));
 		return;
 	}
 
@@ -566,16 +631,25 @@ void UTempoActorLabeler::HandleSetLabelRowOverrides(const TempoSensors::SetLabel
 	}
 
 	// Reject a row name the active table doesn't have, rather than accepting a setting that can
-	// only ever resolve to "no override".
-	if (SemanticLabelTable && !OverridableRowName.IsEmpty())
+	// only ever resolve to "no override". Checked against the table in effect rather than this
+	// subsystem's cached copy, which is null until OnWorldBeginPlay and would skip the check.
+	if (!OverridableRowName.IsEmpty())
 	{
+		const UDataTable* ActiveSemanticLabelTable = GetDefault<UTempoSensorsSettings>()->GetSemanticLabelTable();
+		if (!ActiveSemanticLabelTable)
+		{
+			ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
+				grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "No semantic label table is set"));
+			return;
+		}
+
 		for (const FString& RowName : { OverridableRowName, OverridingRowName })
 		{
-			if (!SemanticLabelTable->GetRowNames().Contains(FName(*RowName)))
+			if (!ActiveSemanticLabelTable->GetRowMap().Contains(FName(*RowName)))
 			{
 				const FString ErrorMsg = FString::Printf(TEXT("Semantic label table has no row named '%s'"), *RowName);
 				ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
-					grpc::Status(grpc::StatusCode::NOT_FOUND, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
+					grpc::Status(grpc::StatusCode::NOT_FOUND, TCHAR_TO_UTF8(*ErrorMsg)));
 				return;
 			}
 		}
@@ -593,12 +667,8 @@ void UTempoActorLabeler::HandleSetActorTagSemanticId(const TempoSensors::SetActo
 {
 	const int32 SemanticId = Request.semantic_id();
 
-	// Validate range
-	if (SemanticId < -1 || SemanticId > GTempoCamera_Max_Label)
+	if (!ValidateSemanticIdRange(SemanticId, ResponseContinuation))
 	{
-		const FString ErrorMsg = FString::Printf(TEXT("semantic_id must be -1 (revert) or 0-%d"), GTempoCamera_Max_Label);
-		ResponseContinuation.ExecuteIfBound(TempoCore::Empty(),
-			grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, std::string(TCHAR_TO_UTF8(*ErrorMsg))));
 		return;
 	}
 
@@ -680,7 +750,7 @@ TMap<uint8, uint8> UTempoActorLabeler::GetInstanceToSemanticIdMap() const
 	TMap<uint8, uint8> Result;
 	for (const auto& LabeledObject : LabeledObjects)
 	{
-		if (LabeledObject.Value.InstanceId != NoLabelId)
+		if (LabeledObject.Value.InstanceId != NoInstanceId)
 		{
 			Result.Add(LabeledObject.Value.InstanceId, LabeledObject.Value.SemanticId);
 		}
@@ -770,6 +840,16 @@ void UTempoActorLabeler::Deinitialize()
 {
 	Super::Deinitialize();
 
+	// Drop our binding before clearing the table below, so the resulting broadcast doesn't send us
+	// re-labeling a world that is going away.
+	GetMutableDefault<UTempoSensorsSettings>()->TempoSensorsLabelSettingsChangedEvent.RemoveAll(this);
+
+	// A table loaded over the API lives on the rooted settings CDO, not the world, so left in place
+	// it would silently supersede the configured asset in every later session of this process —
+	// including the next PIE run, where picking a different table in Project Settings would then
+	// appear to do nothing.
+	GetMutableDefault<UTempoSensorsSettings>()->SetRuntimeSemanticLabelTable(nullptr);
+
 	FTempoServer::Get().DeactivateService<LabelService>();
 }
 
@@ -783,31 +863,41 @@ void UTempoActorLabeler::BuildLabelMaps()
 	ComponentTagLabels.Reset();
 	ActorTagLabels.Reset();
 	SemanticIds.Reset();
-	NoLabelId = 0;
+
+	// A table set in the editor never passes through LoadLabelTable's check, so report the same
+	// problems here. Building the maps anyway is deliberate: whatever the table gets right still
+	// labels the world, and each problem below describes an entry that will be missing or wrong.
+	for (const FString& Problem : ValidateSemanticLabelTable(SemanticLabelTable))
+	{
+		UE_LOG(LogTempoSensors, Error, TEXT("Semantic label table: %s"), *Problem);
+	}
 
 	if (!SemanticLabelTable)
 	{
-		UE_LOG(LogTempoSensors, Error, TEXT("Semantic Label table was not set"));
 		return;
 	}
 
-	SemanticLabelTable->ForeachRow<FSemanticLabel>(TEXT(""), [this](const FName& Key, const FSemanticLabel& Value)
+	// Ingest one of the row's tag columns. The validator has already reported every key two rows
+	// both claim, so here the first claimant simply wins. An empty tag is dropped rather than
+	// keyed on NAME_None, which no Actor or component means to match.
+	auto IngestColumn = [](auto& Labels, const auto& Keys, const FName& Label)
 	{
-		const FName& Label = Key;
+		for (const FName& Key : Keys)
+		{
+			if (!Key.IsNone())
+			{
+				Labels.FindOrAdd(Key, Label);
+			}
+		}
+	};
+
+	SemanticLabelTable->ForeachRow<FSemanticLabel>(TEXT(""), [this, &IngestColumn](const FName& Label, const FSemanticLabel& Value)
+	{
 		for (const TSubclassOf<AActor>& ActorType : Value.ActorTypes)
 		{
 			if (ActorType.Get())
 			{
-				if (ActorSemanticLabels.Contains(ActorType))
-				{
-					UE_LOG(LogTempoSensors, Error, TEXT("Actor type %s is associated with more than one label (%s and %s)"), *ActorType->GetName(), *ActorSemanticLabels[ActorType].ToString(), *Label.ToString());
-					continue;
-				}
-				ActorSemanticLabels.Add(ActorType, Label);
-			}
-			else
-			{
-				UE_LOG(LogTempoSensors, Warning, TEXT("Null Actor associated with label %s"), *Label.ToString());
+				ActorSemanticLabels.FindOrAdd(ActorType, Label);
 			}
 		}
 
@@ -815,17 +905,7 @@ void UTempoActorLabeler::BuildLabelMaps()
 		{
 			if (const UStaticMesh* StaticMesh = StaticMeshAsset.LoadSynchronous())
 			{
-				const FString MeshFullPath = StaticMesh->GetPathName();
-				if (StaticMeshLabels.Contains(MeshFullPath))
-				{
-					UE_LOG(LogTempoSensors, Error, TEXT("Static mesh type %s is associated with more than one label (%s and %s)"), *MeshFullPath, *StaticMeshLabels[MeshFullPath].ToString(), *Label.ToString());
-					continue;
-				}
-				StaticMeshLabels.Add(MeshFullPath, Label);
-			}
-			else
-			{
-				UE_LOG(LogTempoSensors, Warning, TEXT("Null static mesh associated with label %s"), *Label.ToString());
+				StaticMeshLabels.FindOrAdd(StaticMesh->GetPathName(), Label);
 			}
 		}
 
@@ -833,77 +913,15 @@ void UTempoActorLabeler::BuildLabelMaps()
 		{
 			if (const USkeletalMesh* SkeletalMesh = SkeletalMeshAsset.LoadSynchronous())
 			{
-				const FString MeshFullPath = SkeletalMesh->GetPathName();
-				if (SkeletalMeshLabels.Contains(MeshFullPath))
-				{
-					UE_LOG(LogTempoSensors, Error, TEXT("Skeletal mesh type %s is associated with more than one label (%s and %s)"), *MeshFullPath, *SkeletalMeshLabels[MeshFullPath].ToString(), *Label.ToString());
-					continue;
-				}
-				SkeletalMeshLabels.Add(MeshFullPath, Label);
-			}
-			else
-			{
-				UE_LOG(LogTempoSensors, Warning, TEXT("Null skeletal mesh associated with label %s"), *Label.ToString());
+				SkeletalMeshLabels.FindOrAdd(SkeletalMesh->GetPathName(), Label);
 			}
 		}
 
-		for (const FName& ActorTag : Value.ActorTags)
-		{
-			if (ActorTag.IsNone())
-			{
-				UE_LOG(LogTempoSensors, Warning, TEXT("Empty actor tag associated with label %s"), *Label.ToString());
-				continue;
-			}
-			if (ActorTagLabels.Contains(ActorTag))
-			{
-				UE_LOG(LogTempoSensors, Error, TEXT("Actor tag %s is associated with more than one label (%s and %s)"), *ActorTag.ToString(), *ActorTagLabels[ActorTag].ToString(), *Label.ToString());
-				continue;
-			}
-			ActorTagLabels.Add(ActorTag, Label);
-		}
+		IngestColumn(ActorTagLabels, Value.ActorTags, Label);
+		IngestColumn(ComponentTagLabels, Value.ComponentTags, Label);
 
-		for (const FName& ComponentTag : Value.ComponentTags)
-		{
-			if (ComponentTag.IsNone())
-			{
-				UE_LOG(LogTempoSensors, Warning, TEXT("Empty component tag associated with label %s"), *Label.ToString());
-				continue;
-			}
-			if (ComponentTagLabels.Contains(ComponentTag))
-			{
-				UE_LOG(LogTempoSensors, Error, TEXT("Component tag %s is associated with more than one label (%s and %s)"), *ComponentTag.ToString(), *ComponentTagLabels[ComponentTag].ToString(), *Label.ToString());
-				continue;
-			}
-			ComponentTagLabels.Add(ComponentTag, Label);
-		}
-
-		const int32 LabelId = Value.Label;
-		if (LabelId < 0 || LabelId > GTempoCamera_Max_Label)
-		{
-			// The camera stores the label in the exponent field of the tile atlas's fp32 alpha,
-			// biased by +1. An ID outside 0..GTempoCamera_Max_Label pushes that field to 0 or 255,
-			// making the alpha subnormal or Inf/NaN. Either way the GPU destroys it and the pixel
-			// decodes to label 0 at MaxDepth, so the depth is lost as silently as the label.
-			UE_LOG(LogTempoSensors, Error, TEXT("Label name %s has ID %d, outside the encodable range 0-%d. Label and depth will both be corrupted wherever this label is visible."), *Label.ToString(), LabelId, GTempoCamera_Max_Label);
-		}
-		if (SemanticIds.Contains(Label))
-		{
-			UE_LOG(LogTempoSensors, Error, TEXT("Label name %s is associated with more than one label ID (%d and %d)"), *Label.ToString(), SemanticIds[Label], LabelId);
-		}
-		else
-		{
-			SemanticIds.Add(Label, LabelId);
-		}
+		SemanticIds.Add(Label, Value.Label);
 	});
-
-	if (const int32* NoLabelIdPtr = SemanticIds.Find(NoLabelName))
-	{
-		NoLabelId = *NoLabelIdPtr;
-	}
-	else
-	{
-		UE_LOG(LogTempoSensors, Error, TEXT("Label Table did not contain entry for NoLabel name"));
-	}
 }
 
 void UTempoActorLabeler::LabelAllActors()
@@ -957,14 +975,20 @@ TOptional<int32> UTempoActorLabeler::ResolveActorSemanticId(const AActor* Actor)
 	// Actors, so it beats the type rules, which name every Actor of a class at once. An Actor
 	// carrying tags for two different labels resolves to whichever its Tags array lists first —
 	// the same first-match rule component tags follow.
+
+	// Runtime overrides take precedence over the label table, so every tag is offered to the
+	// override map before any tag is offered to the table. Checking both per tag instead would let
+	// a table entry on an earlier tag beat an override on a later one.
 	for (const FName& ActorTag : Actor->Tags)
 	{
-		// Runtime overrides take precedence over the label table.
 		if (const int32* OverrideSemanticId = ActorTagSemanticIdOverrides.Find(ActorTag))
 		{
 			return *OverrideSemanticId;
 		}
+	}
 
+	for (const FName& ActorTag : Actor->Tags)
+	{
 		if (const FName* TagLabel = ActorTagLabels.Find(ActorTag))
 		{
 			if (const int32* TagLabelId = SemanticIds.Find(*TagLabel))
@@ -980,8 +1004,12 @@ TOptional<int32> UTempoActorLabeler::ResolveActorSemanticId(const AActor* Actor)
 		return *OverrideSemanticId;
 	}
 
+	// Most derived matching type wins, so a row listing a superclass as a catch-all doesn't
+	// outrank a row naming the Actor's own class. Single inheritance makes every pair of matching
+	// types comparable — both are ancestors of this class — so there is no ambiguous case to
+	// report; the table's own duplicate entries are the validator's business.
 	TOptional<int32> ResolvedSemanticId;
-	FName AssignedLabel = NAME_None;
+	const UClass* BestActorType = nullptr;
 	for (const auto& [ActorType, ActorLabel] : ActorSemanticLabels)
 	{
 		if (!Actor->GetClass()->IsChildOf(ActorType.Get()))
@@ -989,14 +1017,14 @@ TOptional<int32> UTempoActorLabeler::ResolveActorSemanticId(const AActor* Actor)
 			continue;
 		}
 
+		if (BestActorType && !ActorType->IsChildOf(BestActorType))
+		{
+			continue;
+		}
+
 		if (const int32* SemanticId = SemanticIds.Find(ActorLabel))
 		{
-			if (!AssignedLabel.IsNone() && ActorLabel != AssignedLabel)
-			{
-				UE_LOG(LogTempoSensors, Error, TEXT("Labels %s and %s have overlapping actor types"), *ActorLabel.ToString(), *AssignedLabel.ToString());
-				continue;
-			}
-			AssignedLabel = ActorLabel;
+			BestActorType = ActorType.Get();
 			ResolvedSemanticId = *SemanticId;
 		}
 		else
@@ -1006,6 +1034,19 @@ TOptional<int32> UTempoActorLabeler::ResolveActorSemanticId(const AActor* Actor)
 	}
 
 	return ResolvedSemanticId;
+}
+
+TOptional<FName> UTempoActorLabeler::ResolveSemanticIdRowName(int32 SemanticId) const
+{
+	for (const auto& [LabelName, RowSemanticId] : SemanticIds)
+	{
+		if (RowSemanticId == SemanticId)
+		{
+			return LabelName;
+		}
+	}
+
+	return TOptional<FName>();
 }
 
 void UTempoActorLabeler::LabelAllComponents(const AActor* Actor, FInstanceSemanticIdPair ActorIdPair)
@@ -1098,8 +1139,14 @@ TOptional<int32> UTempoActorLabeler::ResolveComponentSemanticId(const UPrimitive
 
 TOptional<int32> UTempoActorLabeler::ResolveMeshSemanticId(const FString& MeshPath) const
 {
-	// Runtime overrides take precedence over the label table.
+	// Runtime overrides take precedence over the label table. Static and skeletal overrides live in
+	// separate maps so each Set RPC reports back exactly what it accepts, but they share one asset
+	// path space, so at most one of them can hold any given path.
 	if (const int32* OverrideSemanticId = StaticMeshTypeSemanticIdOverrides.Find(MeshPath))
+	{
+		return *OverrideSemanticId;
+	}
+	if (const int32* OverrideSemanticId = SkeletalMeshTypeSemanticIdOverrides.Find(MeshPath))
 	{
 		return *OverrideSemanticId;
 	}
@@ -1208,12 +1255,14 @@ void UTempoActorLabeler::UnLabelActor(AActor* Actor)
 
 	UnLabelAllComponents(Actor);
 
-	if (GetDefault<UTempoSensorsSettings>()->GetLabelType() == ELabelType::Instance)
+	// LabelActor allocates an instance ID whatever the label type is, so reclaim it whatever the
+	// label type is. Gating this on Instance mode would strand every ID held at the moment the mode
+	// changed — SetLabelType flips the type before broadcasting, so the unlabel pass that precedes
+	// re-labeling would already see the new one — plus every ID an object spawned and destroyed in
+	// Semantic mode passed through.
+	if (const FInstanceSemanticIdPair* IdPair = LabeledObjects.Find(Actor); IdPair->InstanceId != NoInstanceId)
 	{
-		if (const FInstanceSemanticIdPair* IdPair = LabeledObjects.Find(Actor); IdPair->InstanceId != NoLabelId)
-		{
-			InstanceIdAllocator.Return(IdPair->InstanceId);
-		}
+		InstanceIdAllocator.Return(IdPair->InstanceId);
 	}
 
 	LabeledObjects.Remove(Actor);
@@ -1246,15 +1295,15 @@ void UTempoActorLabeler::UnLabelComponent(UPrimitiveComponent* Component)
 	Component->SetRenderCustomDepth(false);
 	Component->SetCustomDepthStencilValue(0);
 
-	if (GetDefault<UTempoSensorsSettings>()->GetLabelType() == ELabelType::Instance)
+	// Reclaim an ID the component holds in its own right, not one it merely inherited from its
+	// owning Actor — that one is the Actor's to return. Unconditional for the same reason as in
+	// UnLabelActor: LabelComponent allocates whatever the label type is.
+	if (const FInstanceSemanticIdPair* ComponentIdPair = LabeledObjects.Find(Component); ComponentIdPair && ComponentIdPair->InstanceId != NoInstanceId)
 	{
-		if (const FInstanceSemanticIdPair* ComponentIdPair = LabeledObjects.Find(Component))
+		const FInstanceSemanticIdPair* ActorIdPair = LabeledObjects.Find(Component->GetOwner());
+		if (!ActorIdPair || ActorIdPair->InstanceId != ComponentIdPair->InstanceId)
 		{
-			const FInstanceSemanticIdPair* ActorIdPair = LabeledObjects.Find(Component->GetOwner());
-			if (!ActorIdPair || (ActorIdPair->InstanceId != ComponentIdPair->InstanceId && ComponentIdPair->InstanceId != NoLabelId))
-			{
-				InstanceIdAllocator.Return(ComponentIdPair->InstanceId);
-			}
+			InstanceIdAllocator.Return(ComponentIdPair->InstanceId);
 		}
 	}
 
@@ -1263,13 +1312,27 @@ void UTempoActorLabeler::UnLabelComponent(UPrimitiveComponent* Component)
 
 void UTempoActorLabeler::OnLabelSettingsChanged()
 {
-	// Unlabel first, while the maps still describe the labels the world is currently wearing —
-	// UnLabelActor reads NoLabelId to decide which instance IDs to reclaim, and BuildLabelMaps
-	// re-derives NoLabelId from the new table.
+	// Unlabel first, while the maps still describe the labels the world is currently wearing, so
+	// every object gives its instance ID back before the labels it was resolved from change.
 	UnLabelAllActors();
 
-	SemanticLabelTable = GetDefault<UTempoSensorsSettings>()->GetSemanticLabelTable();
-	BuildLabelMaps();
+	UDataTable* ActiveSemanticLabelTable = GetDefault<UTempoSensorsSettings>()->GetSemanticLabelTable();
+	if (ActiveSemanticLabelTable != SemanticLabelTable)
+	{
+		SemanticLabelTable = ActiveSemanticLabelTable;
+		BuildLabelMaps();
+
+		// The row names naming the overridable/overriding pair are held separately from the table
+		// and outlive it, so a table that doesn't carry those rows silently disables the
+		// substitution. Say so once here rather than once per sensor tile.
+		const FName OverridableLabelRowName = GetDefault<UTempoSensorsSettings>()->GetOverridableLabelRowName();
+		int32 OverridableLabel = 0, OverridingLabel = 0;
+		if (!OverridableLabelRowName.IsNone() && !ResolveLabelRowOverrides(SemanticLabelTable, OverridableLabel, OverridingLabel))
+		{
+			UE_LOG(LogTempoSensors, Warning, TEXT("Label row overrides ('%s' overridden by '%s') do not resolve against the current label table. Per-pixel label overriding is disabled until both rows exist."),
+				*OverridableLabelRowName.ToString(), *GetDefault<UTempoSensorsSettings>()->GetOverridingLabelRowName().ToString());
+		}
+	}
 
 	LabelAllActors();
 }
@@ -1289,13 +1352,15 @@ void UTempoActorLabeler::AssignId(UPrimitiveComponent* Component, FInstanceSeman
 
 FName UTempoActorLabeler::GetActorClassification(const AActor* Actor) const
 {
-	for (const auto& Elem : ActorSemanticLabels)
+	// Route through the same resolution the label image is drawn from, so an Actor tag or a runtime
+	// override doesn't leave TempoWorld's overlap events reporting a different class than the
+	// camera renders for the same Actor. An ID no row carries — reachable by overriding to an ID
+	// the table doesn't define — has no name to report, so it falls through like no match at all.
+	if (const TOptional<int32> SemanticId = ResolveActorSemanticId(Actor))
 	{
-		const TSubclassOf<AActor>& ActorType = Elem.Key;
-		const FName& ActorLabel = Elem.Value;
-		if (Actor->GetClass()->IsChildOf(ActorType.Get()))
+		if (const TOptional<FName> RowName = ResolveSemanticIdRowName(*SemanticId))
 		{
-			return ActorLabel;
+			return *RowName;
 		}
 	}
 

--- a/TempoSensors/Source/TempoSensors/Private/TempoSensorsUtils.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoSensorsUtils.cpp
@@ -3,6 +3,7 @@
 #include "TempoSensorsUtils.h"
 
 #include "TempoLabelTypes.h"
+#include "TempoSensorsConstants.h"
 #include "TempoSensorsSettings.h"
 
 #include "Engine/DataTable.h"
@@ -146,6 +147,172 @@ void ApplyPhotorealisticRenderSettings(FPostProcessSettings& OutPostProcess,
 	OutShowFlags.SetScreenPercentage(true);
 }
 
+TArray<FString> ValidateSemanticLabelTable(const UDataTable* SemanticLabelTable)
+{
+	TArray<FString> Problems;
+
+	if (!SemanticLabelTable)
+	{
+		Problems.Add(TEXT("No semantic label table is set."));
+		return Problems;
+	}
+
+	// Which row already claimed each key, so the second claimant can name the first. A DataTable's
+	// row names are unique, so only the columns can collide.
+	TMap<const UClass*, FName> ClaimedActorTypes;
+	TMap<FString, FName> ClaimedMeshPaths;
+	TMap<FName, FName> ClaimedActorTags;
+	TMap<FName, FName> ClaimedComponentTags;
+
+	// A row claiming a key a previous row already claimed. BuildLabelMaps resolves the collision by
+	// keeping the first, which means the second row's entry silently does nothing.
+	auto ReportCollision = [&Problems](const TCHAR* Kind, const FString& Key, const FName& FirstRow, const FName& SecondRow)
+	{
+		Problems.Add(FString::Printf(TEXT("%s '%s' is claimed by rows '%s' and '%s'; only '%s' will take effect."),
+			Kind, *Key, *FirstRow.ToString(), *SecondRow.ToString(), *FirstRow.ToString()));
+	};
+
+	SemanticLabelTable->ForeachRow<FSemanticLabel>(TEXT(""),
+		[&](const FName& RowName, const FSemanticLabel& Row)
+	{
+		if (Row.Label < 0 || Row.Label > GTempoCamera_Max_Label)
+		{
+			// The camera packs the label into the exponent field of the tile atlas's fp32 alpha,
+			// biased by +1. Outside this range that field saturates to 0 or 255, making the alpha
+			// subnormal or Inf/NaN, and the GPU destroys it — the pixel decodes to label 0 at
+			// MaxDepth, so the depth goes with the label.
+			Problems.Add(FString::Printf(TEXT("Row '%s' has label ID %d, outside the encodable range 0-%d. Label and depth would both be corrupted wherever this label is visible."),
+				*RowName.ToString(), Row.Label, GTempoCamera_Max_Label));
+		}
+
+		for (const TSubclassOf<AActor>& ActorType : Row.ActorTypes)
+		{
+			const UClass* ActorClass = ActorType.Get();
+			if (!ActorClass)
+			{
+				// The importer resolves a class path eagerly and only logs when it cannot, leaving
+				// a null behind. The path it failed on is gone by the time we see the row, so all
+				// we can report is that the row carries one.
+				Problems.Add(FString::Printf(TEXT("Row '%s' has an actor type that did not resolve to a class. Check the paths in its ActorTypes for a typo."),
+					*RowName.ToString()));
+				continue;
+			}
+			if (const FName* FirstRow = ClaimedActorTypes.Find(ActorClass))
+			{
+				ReportCollision(TEXT("Actor type"), ActorClass->GetPathName(), *FirstRow, RowName);
+				continue;
+			}
+			ClaimedActorTypes.Add(ActorClass, RowName);
+		}
+
+		// Static and skeletal meshes are labeled from separate columns but share one asset path
+		// space, so they are checked for collisions against each other as well as themselves.
+		auto ValidateMeshColumn = [&](const TCHAR* Kind, const FSoftObjectPath& AssetPath, const UObject* LoadedAsset)
+		{
+			if (AssetPath.IsNull())
+			{
+				Problems.Add(FString::Printf(TEXT("Row '%s' has an empty %s entry."), *RowName.ToString(), Kind));
+				return;
+			}
+			if (!LoadedAsset)
+			{
+				Problems.Add(FString::Printf(TEXT("Row '%s' names %s '%s', which did not load as that type."),
+					*RowName.ToString(), Kind, *AssetPath.ToString()));
+				return;
+			}
+			const FString MeshFullPath = LoadedAsset->GetPathName();
+			if (const FName* FirstRow = ClaimedMeshPaths.Find(MeshFullPath))
+			{
+				ReportCollision(TEXT("Mesh"), MeshFullPath, *FirstRow, RowName);
+				return;
+			}
+			ClaimedMeshPaths.Add(MeshFullPath, RowName);
+		};
+
+		for (const TSoftObjectPtr<UStaticMesh>& StaticMeshAsset : Row.StaticMeshTypes)
+		{
+			ValidateMeshColumn(TEXT("static mesh"), StaticMeshAsset.ToSoftObjectPath(), StaticMeshAsset.LoadSynchronous());
+		}
+
+		for (const TSoftObjectPtr<USkeletalMesh>& SkeletalMeshAsset : Row.SkeletalMeshTypes)
+		{
+			ValidateMeshColumn(TEXT("skeletal mesh"), SkeletalMeshAsset.ToSoftObjectPath(), SkeletalMeshAsset.LoadSynchronous());
+		}
+
+		for (const FName& ActorTag : Row.ActorTags)
+		{
+			if (ActorTag.IsNone())
+			{
+				Problems.Add(FString::Printf(TEXT("Row '%s' has an empty actor tag."), *RowName.ToString()));
+				continue;
+			}
+			if (const FName* FirstRow = ClaimedActorTags.Find(ActorTag))
+			{
+				ReportCollision(TEXT("Actor tag"), ActorTag.ToString(), *FirstRow, RowName);
+				continue;
+			}
+			ClaimedActorTags.Add(ActorTag, RowName);
+		}
+
+		for (const FName& ComponentTag : Row.ComponentTags)
+		{
+			if (ComponentTag.IsNone())
+			{
+				Problems.Add(FString::Printf(TEXT("Row '%s' has an empty component tag."), *RowName.ToString()));
+				continue;
+			}
+			if (const FName* FirstRow = ClaimedComponentTags.Find(ComponentTag))
+			{
+				ReportCollision(TEXT("Component tag"), ComponentTag.ToString(), *FirstRow, RowName);
+				continue;
+			}
+			ClaimedComponentTags.Add(ComponentTag, RowName);
+		}
+	});
+
+	if (const FSemanticLabel* NoLabelRow = SemanticLabelTable->FindRow<FSemanticLabel>(FName(GNoLabelRowName), TEXT(""), false))
+	{
+		if (NoLabelRow->Label != 0)
+		{
+			// An object matching no row keeps FInstanceSemanticIdPair's default semantic ID of 0
+			// and is drawn with stencil 0, whatever this row says. A non-zero value here would name
+			// a class that nothing is ever labeled with.
+			Problems.Add(FString::Printf(TEXT("Row '%s' has label ID %d, but unmatched objects are always labeled 0. It must be 0."),
+				GNoLabelRowName, NoLabelRow->Label));
+		}
+	}
+	else
+	{
+		Problems.Add(FString::Printf(TEXT("Table has no '%s' row, which names the label worn by everything the table does not match."),
+			GNoLabelRowName));
+	}
+
+	return Problems;
+}
+
+bool ResolveLabelRowOverrides(const UDataTable* SemanticLabelTable, int32& OutOverridableLabel, int32& OutOverridingLabel)
+{
+	const UTempoSensorsSettings* TempoSensorsSettings = GetDefault<UTempoSensorsSettings>();
+	const FName OverridableLabelRowName = TempoSensorsSettings->GetOverridableLabelRowName();
+	const FName OverridingLabelRowName = TempoSensorsSettings->GetOverridingLabelRowName();
+
+	if (!SemanticLabelTable || OverridableLabelRowName.IsNone() || OverridingLabelRowName.IsNone())
+	{
+		return false;
+	}
+
+	const FSemanticLabel* OverridableRow = SemanticLabelTable->FindRow<FSemanticLabel>(OverridableLabelRowName, TEXT(""), false);
+	const FSemanticLabel* OverridingRow = SemanticLabelTable->FindRow<FSemanticLabel>(OverridingLabelRowName, TEXT(""), false);
+	if (!OverridableRow || !OverridingRow)
+	{
+		return false;
+	}
+
+	OutOverridableLabel = OverridableRow->Label;
+	OutOverridingLabel = OverridingRow->Label;
+	return true;
+}
+
 void ApplyLabelOverrideParameters(UMaterialInstanceDynamic* MaterialInstance)
 {
 	if (!MaterialInstance)
@@ -153,33 +320,12 @@ void ApplyLabelOverrideParameters(UMaterialInstanceDynamic* MaterialInstance)
 		return;
 	}
 
-	const UTempoSensorsSettings* TempoSensorsSettings = GetDefault<UTempoSensorsSettings>();
-	const UDataTable* SemanticLabelTable = TempoSensorsSettings->GetSemanticLabelTable();
-	const FName OverridableLabelRowName = TempoSensorsSettings->GetOverridableLabelRowName();
-	const FName OverridingLabelRowName = TempoSensorsSettings->GetOverridingLabelRowName();
-	TOptional<int32> OverridableLabel;
-	TOptional<int32> OverridingLabel;
-	if (SemanticLabelTable && !OverridableLabelRowName.IsNone())
+	int32 OverridableLabel = 0;
+	int32 OverridingLabel = 0;
+	if (ResolveLabelRowOverrides(GetDefault<UTempoSensorsSettings>()->GetSemanticLabelTable(), OverridableLabel, OverridingLabel))
 	{
-		SemanticLabelTable->ForeachRow<FSemanticLabel>(TEXT(""),
-			[&OverridableLabelRowName, &OverridingLabelRowName, &OverridableLabel, &OverridingLabel]
-			(const FName& Key, const FSemanticLabel& Value)
-			{
-				if (Key == OverridableLabelRowName)
-				{
-					OverridableLabel = Value.Label;
-				}
-				if (Key == OverridingLabelRowName)
-				{
-					OverridingLabel = Value.Label;
-				}
-			});
-	}
-
-	if (OverridableLabel.IsSet() && OverridingLabel.IsSet())
-	{
-		MaterialInstance->SetScalarParameterValue(TEXT("OverridableLabel"), OverridableLabel.GetValue());
-		MaterialInstance->SetScalarParameterValue(TEXT("OverridingLabel"), OverridingLabel.GetValue());
+		MaterialInstance->SetScalarParameterValue(TEXT("OverridableLabel"), OverridableLabel);
+		MaterialInstance->SetScalarParameterValue(TEXT("OverridingLabel"), OverridingLabel);
 	}
 	else
 	{

--- a/TempoSensors/Source/TempoSensors/Private/TempoTiledSceneCaptureComponent.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoTiledSceneCaptureComponent.cpp
@@ -83,9 +83,6 @@ void UTempoTiledSceneCaptureComponent::BeginPlay()
 	SyncTiles();
 	UpdateInternalMirrors();
 
-	GetMutableDefault<UTempoSensorsSettings>()->TempoSensorsLabelOverridesChangedEvent.AddUObject(
-		this, &UTempoTiledSceneCaptureComponent::ApplyLabelOverridesToTiles);
-
 	if (UTempoCoreUtils::IsGameWorld(this))
 	{
 		// Activate() runs when added to a live world, but may be skipped in some registration
@@ -117,6 +114,21 @@ void UTempoTiledSceneCaptureComponent::Deactivate()
 			World->GetTimerManager().ClearTimer(TimerHandle);
 		}
 		TextureReadQueue.Empty();
+	}
+}
+
+void UTempoTiledSceneCaptureComponent::OnRegister()
+{
+	Super::OnRegister();
+
+	// Paired with the unbind in OnUnregister. Binding in BeginPlay instead would leave the sensor
+	// deaf to later override changes: FComponentReregisterContext (any Details-panel edit during
+	// PIE) and ReregisterComponent() run OnUnregister/OnRegister without EndPlay/BeginPlay, so the
+	// unbind would happen with nothing to re-bind it.
+	if (!IsTemplate())
+	{
+		GetMutableDefault<UTempoSensorsSettings>()->TempoSensorsLabelOverridesChangedEvent.AddUObject(
+			this, &UTempoTiledSceneCaptureComponent::ApplyLabelOverridesToTiles);
 	}
 }
 

--- a/TempoSensors/Source/TempoSensors/Private/Tests/TempoLabelTableTest.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/Tests/TempoLabelTableTest.cpp
@@ -11,8 +11,9 @@
 // Covers importing a semantic label table from JSON, the path LabelService's LoadLabelTable RPC
 // takes. FSemanticLabel's columns are TSets — of classes, of soft mesh pointers, of names — so
 // this pins down that the runtime DataTable JSON importer handles them, and that a malformed
-// table is reported rather than silently accepted. Run via Scripts/Test.sh, or from the editor
-// console with
+// table is reported rather than silently accepted. The importer only reports what it could not
+// parse, so the validation cases cover the second half of that: tables that parse but would
+// mislabel the world. Run via Scripts/Test.sh, or from the editor console with
 //   Automation RunTests Tempo.Sensors.LabelTable
 
 #if WITH_DEV_AUTOMATION_TESTS
@@ -107,6 +108,79 @@ bool FTempoLabelTableImportProblemsTest::RunTest(const FString& Parameters)
 
 	ImportLabelTable(TEXT(R"([ { "Name": "Tree", "Label": 3, "NotAColumn": 1 } ])"), Problems);
 	TestFalse(TEXT("An unrecognized column is a problem"), Problems.IsEmpty());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoLabelTableValidationTest,
+	"Tempo.Sensors.LabelTable.Validation", TempoLabelTableTestFlags)
+bool FTempoLabelTableValidationTest::RunTest(const FString& Parameters)
+{
+	// Everything here parses cleanly — the importer reports none of it — so these are exactly the
+	// tables that used to be accepted and then quietly mislabel the world.
+	auto ValidateJson = [this](const TCHAR* What, const FString& Json)
+	{
+		TArray<FString> ImportProblems;
+		const UDataTable* Table = ImportLabelTable(Json, ImportProblems);
+		TestTrue(FString::Printf(TEXT("%s: imports cleanly (got: %s)"), What, *FString::Join(ImportProblems, TEXT(" "))),
+			ImportProblems.IsEmpty());
+		return ValidateSemanticLabelTable(Table);
+	};
+
+	TestTrue(TEXT("Null table is a problem"), ValidateSemanticLabelTable(nullptr).Num() > 0);
+
+	TestEqual(TEXT("A good table has no problems"),
+		ValidateJson(TEXT("Good table"), TEXT(R"([
+			{ "Name": "NoLabel", "Label": 0 },
+			{ "Name": "Vehicle", "Label": 14, "ActorTypes": [ "/Script/Engine.StaticMeshActor" ], "ActorTags": [ "Parked" ] }
+		])")).Num(), 0);
+
+	TestTrue(TEXT("A label ID above the encodable range is a problem"),
+		ValidateJson(TEXT("Label 255"), TEXT(R"([
+			{ "Name": "NoLabel", "Label": 0 },
+			{ "Name": "Vehicle", "Label": 255 }
+		])")).Num() > 0);
+
+	TestTrue(TEXT("A missing NoLabel row is a problem"),
+		ValidateJson(TEXT("No NoLabel row"), TEXT(R"([
+			{ "Name": "Vehicle", "Label": 14 }
+		])")).Num() > 0);
+
+	// Unmatched objects are labeled 0 whatever this row says, so a non-zero NoLabel names a class
+	// nothing is ever drawn with.
+	TestTrue(TEXT("A non-zero NoLabel row is a problem"),
+		ValidateJson(TEXT("NoLabel 200"), TEXT(R"([
+			{ "Name": "NoLabel", "Label": 200 },
+			{ "Name": "Vehicle", "Label": 14 }
+		])")).Num() > 0);
+
+	TestTrue(TEXT("An unresolvable actor type is a problem"),
+		ValidateJson(TEXT("Bad class path"), TEXT(R"([
+			{ "Name": "NoLabel", "Label": 0 },
+			{ "Name": "Vehicle", "Label": 14, "ActorTypes": [ "/Script/Engine.NoSuchActorClass" ] }
+		])")).Num() > 0);
+
+	TestTrue(TEXT("An unresolvable mesh path is a problem"),
+		ValidateJson(TEXT("Bad mesh path"), TEXT(R"([
+			{ "Name": "NoLabel", "Label": 0 },
+			{ "Name": "Vehicle", "Label": 14, "StaticMeshTypes": [ "/Game/Nope/SM_NoSuchMesh.SM_NoSuchMesh" ] }
+		])")).Num() > 0);
+
+	// Two rows claiming one key is a silent partial loss: BuildLabelMaps keeps the first, so the
+	// second row's entry never labels anything.
+	TestTrue(TEXT("An actor type claimed by two rows is a problem"),
+		ValidateJson(TEXT("Duplicate actor type"), TEXT(R"([
+			{ "Name": "NoLabel", "Label": 0 },
+			{ "Name": "Vehicle", "Label": 14, "ActorTypes": [ "/Script/Engine.StaticMeshActor" ] },
+			{ "Name": "Building", "Label": 7, "ActorTypes": [ "/Script/Engine.StaticMeshActor" ] }
+		])")).Num() > 0);
+
+	TestTrue(TEXT("An actor tag claimed by two rows is a problem"),
+		ValidateJson(TEXT("Duplicate actor tag"), TEXT(R"([
+			{ "Name": "NoLabel", "Label": 0 },
+			{ "Name": "Vehicle", "Label": 14, "ActorTags": [ "Parked" ] },
+			{ "Name": "Building", "Label": 7, "ActorTags": [ "Parked" ] }
+		])")).Num() > 0);
 
 	return true;
 }

--- a/TempoSensors/Source/TempoSensors/Public/Labels.proto
+++ b/TempoSensors/Source/TempoSensors/Public/Labels.proto
@@ -59,7 +59,9 @@ message SetActorTagSemanticIdRequest {
 }
 
 message SetStaticMeshTypeSemanticIdRequest {
-  string static_mesh_path = 1;  // Full asset path, e.g., "/Game/Meshes/SM_Tree.SM_Tree"
+  // Full asset path of a static mesh, e.g., "/Game/Meshes/SM_Tree.SM_Tree". A path naming anything
+  // else is rejected; skeletal meshes are set with SetSkeletalMeshTypeSemanticId.
+  string static_mesh_path = 1;
   int32 semantic_id = 2;        // 0-253 to set, -1 to clear override
 }
 
@@ -74,6 +76,24 @@ message GetAllStaticMeshTypesResponse {
   repeated StaticMeshTypeInfo mesh_types = 1;
 }
 
+message SetSkeletalMeshTypeSemanticIdRequest {
+  // Full asset path of a skeletal mesh, e.g., "/Game/Characters/SK_Ped.SK_Ped". A path naming
+  // anything else is rejected; static meshes are set with SetStaticMeshTypeSemanticId.
+  string skeletal_mesh_path = 1;
+  int32 semantic_id = 2;        // 0-253 to set, -1 to clear override
+}
+
+message SkeletalMeshTypeInfo {
+  string mesh_path = 1;          // Full asset path
+  string display_name = 2;       // Short name extracted from path
+  int32 instance_count = 3;      // Number of skinned components using this mesh
+  int32 current_semantic_id = 4; // Current semantic ID (-1 if none)
+}
+
+message GetAllSkeletalMeshTypesResponse {
+  repeated SkeletalMeshTypeInfo mesh_types = 1;
+}
+
 // The global label type. Determines what the label image and lidar label channel carry:
 // the semantic class ID shared by every object of a class, or a per-object instance ID.
 enum LabelType {
@@ -86,15 +106,22 @@ message SetLabelTypeRequest {
   LabelType label_type = 1;
 }
 
-// The table is supplied either inline or by path. Exactly one of json and json_file must be set.
+// The table is supplied either inline or by path; at most one of json and json_file may be set.
+// Setting neither reverts to the table configured in the project's settings, discarding whatever
+// table was last loaded here.
 message LoadLabelTableRequest {
   // The label table as an Unreal DataTable JSON document: a JSON array of row objects, each
   // with a "Name" key (the label's row name) plus any of the row's columns — "Label" (the
   // integer ID written to the label image), "ActorTypes", "ActorTags", "StaticMeshTypes",
   // "SkeletalMeshTypes", "ComponentTags".
   // Asset references are full object paths, e.g. "/Game/Vehicles/BP_Car.BP_Car_C". A column a row
-  // omits is left empty; an unrecognized column name is an error. Include a "NoLabel" row: it
-  // names the ID used for everything the table does not otherwise match.
+  // omits is left empty; an unrecognized column name is an error. Include a "NoLabel" row with
+  // label 0: it names the ID used for everything the table does not otherwise match.
+  //
+  // The table is checked before it is installed and the whole request is rejected, leaving the
+  // active table in place, if any row has a label ID outside 0-253, names an asset path that does
+  // not resolve, claims an actor type / mesh / tag another row already claims, or if the NoLabel
+  // row is missing or non-zero. The error message lists every problem found.
   string json = 1;
   // Path to a file holding the same JSON document. Relative paths resolve against the
   // project directory.
@@ -141,6 +168,10 @@ service LabelService {
   rpc GetAllStaticMeshTypes(TempoCore.Empty) returns (GetAllStaticMeshTypesResponse);
 
   rpc SetStaticMeshTypeSemanticId(SetStaticMeshTypeSemanticIdRequest) returns (TempoCore.Empty);
+
+  rpc GetAllSkeletalMeshTypes(TempoCore.Empty) returns (GetAllSkeletalMeshTypesResponse);
+
+  rpc SetSkeletalMeshTypeSemanticId(SetSkeletalMeshTypeSemanticIdRequest) returns (TempoCore.Empty);
 
   rpc SetActorTagSemanticId(SetActorTagSemanticIdRequest) returns (TempoCore.Empty);
 

--- a/TempoSensors/Source/TempoSensors/Public/TempoActorLabeler.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoActorLabeler.h
@@ -57,6 +57,8 @@ namespace TempoSensors
 	class SetActorTypeSemanticIdRequest;
 	class GetAllStaticMeshTypesResponse;
 	class SetStaticMeshTypeSemanticIdRequest;
+	class GetAllSkeletalMeshTypesResponse;
+	class SetSkeletalMeshTypeSemanticIdRequest;
 	class SetActorTagSemanticIdRequest;
 	class GetLabelTableAsJsonResponse;
 	class SetLabelTypeRequest;
@@ -97,6 +99,10 @@ public:
 	void HandleGetAllStaticMeshTypes(const TempoCore::Empty& Request, const TResponseDelegate<TempoSensors::GetAllStaticMeshTypesResponse>& ResponseContinuation);
 
 	void HandleSetStaticMeshTypeSemanticId(const TempoSensors::SetStaticMeshTypeSemanticIdRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
+
+	void HandleGetAllSkeletalMeshTypes(const TempoCore::Empty& Request, const TResponseDelegate<TempoSensors::GetAllSkeletalMeshTypesResponse>& ResponseContinuation);
+
+	void HandleSetSkeletalMeshTypeSemanticId(const TempoSensors::SetSkeletalMeshTypeSemanticIdRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
 
 	void HandleSetActorTagSemanticId(const TempoSensors::SetActorTagSemanticIdRequest& Request, const TResponseDelegate<TempoCore::Empty>& ResponseContinuation);
 
@@ -139,6 +145,19 @@ protected:
 	// over the label table.
 	TOptional<int32> ResolveMeshSemanticId(const FString& MeshPath) const;
 
+	// The row name a semantic ID belongs to, for reporting an ID back as a class. Unset when no row
+	// carries the ID, which a runtime override to an ID the table doesn't define can produce.
+	TOptional<FName> ResolveSemanticIdRowName(int32 SemanticId) const;
+
+	// Shared body of the static and skeletal SetMeshTypeSemanticId RPCs: record or clear the
+	// override in the given map, then re-label every component rendering that mesh. The caller has
+	// already validated the ID range and that the path names an asset of its map's type.
+	void SetMeshTypeSemanticIdOverride(const FString& MeshPath, int32 SemanticId, TMap<FString, int32>& Overrides);
+
+	// Shared body of the GetAllStaticMeshTypes and GetAllSkeletalMeshTypes RPCs: count the world's
+	// components rendering each mesh of the requested kind, keyed by asset path.
+	void CountMeshInstances(bool bSkeletal, TMap<FString, int32>& OutMeshInstanceCounts) const;
+
 	// The mesh assets a Component renders: its own static or skeletal mesh, or the meshes a Niagara
 	// system instances.
 	static void GetComponentMeshPaths(const UPrimitiveComponent* Component, TArray<FString>& OutMeshPaths);
@@ -180,12 +199,6 @@ protected:
 	UPROPERTY(VisibleAnywhere)
 	TMap<FName, int32> SemanticIds;
 
-	UPROPERTY(VisibleAnywhere)
-	FName NoLabelName = TEXT("NoLabel");
-
-	UPROPERTY(VisibleAnywhere)
-	int32 NoLabelId = 0;
-
 	UPROPERTY()
 	TMap<const UObject*, FInstanceSemanticIdPair> LabeledObjects;
 
@@ -202,6 +215,14 @@ protected:
 	// Takes precedence over DataTable definitions (StaticMeshLabels)
 	UPROPERTY()
 	TMap<FString, int32> StaticMeshTypeSemanticIdOverrides;
+
+	// Runtime overrides for skeletal mesh types (full mesh path -> semantic ID)
+	// Takes precedence over DataTable definitions (SkeletalMeshLabels)
+	// Kept separate from the static map so each reporting RPC can list exactly what its setter
+	// accepts. The two never hold the same path: an asset is a UStaticMesh or a USkeletalMesh, and
+	// each setter rejects a path that isn't its own type.
+	UPROPERTY()
+	TMap<FString, int32> SkeletalMeshTypeSemanticIdOverrides;
 
 	// Runtime overrides for actor tags (tag -> semantic ID)
 	// Takes precedence over DataTable definitions (ActorTagLabels)

--- a/TempoSensors/Source/TempoSensors/Public/TempoLabelTypes.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoLabelTypes.h
@@ -8,6 +8,11 @@
 
 #include "TempoLabelTypes.generated.h"
 
+// The row naming the label ID worn by everything the table does not otherwise match. Objects that
+// resolve to no row are labeled 0, so this row's Label must be 0 for the table to describe what
+// the label image actually contains; ValidateSemanticLabelTable enforces both.
+inline constexpr const TCHAR* GNoLabelRowName = TEXT("NoLabel");
+
 USTRUCT(BlueprintInternalUseOnly)
 struct FSemanticLabel: public FTableRowBase
 {

--- a/TempoSensors/Source/TempoSensors/Public/TempoSensorsSettings.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoSensorsSettings.h
@@ -41,8 +41,10 @@ public:
 	ELabelType GetLabelType() const { return LabelType; }
 	bool GetGloballyUniqueInstanceLabels() const { return bGloballyUniqueInstanceLabels; }
 	bool GetInstantaneouslyUniqueInstanceLabels() const { return bInstantaneouslyUniqueInstanceLabels; }
-	// Supersede the configured SemanticLabelTable with a table built at runtime, for the life of the
-	// process. Pass nullptr to fall back to the configured asset.
+	// Supersede the configured SemanticLabelTable with a table built at runtime. Pass nullptr to fall
+	// back to the configured asset — UTempoActorLabeler::Deinitialize does that at world teardown,
+	// so a table loaded over the API is scoped to the world it was loaded into rather than to this
+	// (rooted, and in the editor long-lived) CDO.
 	void SetRuntimeSemanticLabelTable(UDataTable* SemanticLabelTableIn);
 	void SetLabelType(ELabelType LabelTypeIn);
 	void SetGloballyUniqueInstanceLabels(bool bGloballyUniqueInstanceLabelsIn);
@@ -91,7 +93,8 @@ private:
 	TSoftObjectPtr<UDataTable> SemanticLabelTable;
 
 	// A label table built at runtime (from JSON, via the API), which supersedes SemanticLabelTable
-	// while set. Not Config: a table with no asset behind it has no path to save.
+	// while set. Not Config: a table with no asset behind it has no path to save. Cleared at world
+	// teardown, so it cannot silently outlive the session that loaded it.
 	UPROPERTY(Transient)
 	TObjectPtr<UDataTable> RuntimeSemanticLabelTable;
 

--- a/TempoSensors/Source/TempoSensors/Public/TempoSensorsUtils.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoSensorsUtils.h
@@ -18,6 +18,28 @@ void TEMPOSENSORS_API OptimizeShowFlagsForNoColor(FEngineShowFlags& ShowFlags);
 void TEMPOSENSORS_API ApplyPhotorealisticRenderSettings(FPostProcessSettings& OutPostProcess,
 	FEngineShowFlags& OutShowFlags, bool& OutUseRayTracingIfEnabled);
 
+// Every problem that makes a semantic label table unfit to label a world with: a label ID the
+// camera cannot encode, a missing or non-zero NoLabel row, an entry that resolves to no class or
+// no loadable mesh, or an actor type / mesh / tag two rows both claim. Empty means the table is
+// good. UDataTable::CreateTableFromJSONString reports none of these — it only reports what it
+// could not parse — so a table arriving over the API has to be checked separately before it is
+// installed.
+//
+// Returns the problems rather than logging them so LoadLabelTable can hand them back to the
+// client that sent the table; BuildLabelMaps logs the same list for a table set in the editor.
+TArray<FString> TEMPOSENSORS_API ValidateSemanticLabelTable(const UDataTable* SemanticLabelTable);
+
+// Resolve the settings' overridable/overriding row-name pair against a table, yielding the two
+// label IDs the substitution runs on. False — leaving the outputs untouched — whenever the pair is
+// unset, the table is null, or either row name is absent from the table, which are the same thing
+// as far as the material is concerned: no substitution.
+//
+// Silent by design: this runs once per tile per sensor, so a table that does not carry the named
+// rows would warn many times over. UTempoActorLabeler::OnLabelSettingsChanged does that warning
+// once, for the world.
+bool TEMPOSENSORS_API ResolveLabelRowOverrides(const UDataTable* SemanticLabelTable,
+	int32& OutOverridableLabel, int32& OutOverridingLabel);
+
 // Resolve the settings' overridable/overriding label row names against the active semantic label
 // table and push the resulting label IDs onto a sensor's post-process material instance, which
 // substitutes the overriding label wherever an object labeled overridable carries a non-zero

--- a/TempoSensors/Source/TempoSensors/Public/TempoTiledSceneCaptureComponent.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoTiledSceneCaptureComponent.h
@@ -24,6 +24,9 @@ public:
 	virtual void BeginPlay() override;
 	virtual void Activate(bool bReset = false) override;
 	virtual void Deactivate() override;
+	// Bind the label-override listener. Registration, not BeginPlay, is the right pair for the
+	// unbind in OnUnregister — a re-register cycle runs both without touching BeginPlay/EndPlay.
+	virtual void OnRegister() override;
 	// Release per-tile render resources (view states + PPMs) when the component unregisters from the
 	// scene. USceneCaptureComponent::OnUnregister only destroys the inherited ViewStates array; our
 	// per-tile FSceneViewStateReferences aren't in it, so without this they (and the render-thread

--- a/docs/plugins/tempo-sensors.md
+++ b/docs/plugins/tempo-sensors.md
@@ -242,7 +242,8 @@ across many scenes rather than hand-editing a `DataTable`. Reading what's in eff
 | `get_semantic_classes` | List the semantic classes in the label table, and what each one matches. |
 | `get_all_actor_labels` | Every actor's current label. |
 | `get_labeled_actor_types` | The actor classes the table assigns labels to. |
-| `get_all_static_mesh_types` | The static meshes the table knows about. |
+| `get_all_static_mesh_types` | Every static mesh rendered in the world, with instance counts and current label. |
+| `get_all_skeletal_mesh_types` | The same for skeletal meshes. |
 | `get_instance_to_semantic_id_map` | Map instance IDs back to semantic IDs, for decoding instance label images. |
 | `get_label_table_as_json` | The whole table, in exactly the format `load_label_table` reads. |
 
@@ -253,15 +254,20 @@ Per-entry overrides, each taking `-1` to revert to whatever the table says:
 | `set_actor_type_semantic_id` | Assign a semantic ID to an actor class. |
 | `set_actor_tag_semantic_id` | Assign a semantic ID to an Actor tag — beats the actor's class. |
 | `set_static_mesh_type_semantic_id` | Assign a semantic ID to a static mesh — beats both of the above. |
+| `set_skeletal_mesh_type_semantic_id` | The same for a skeletal mesh. |
 
 These sit in a layer *above* the table and survive a `load_label_table`, so clear one with `-1` if
 you want a newly loaded table to decide.
+
+The two mesh RPCs are each strict about their asset type: a skeletal mesh path handed to
+`set_static_mesh_type_semantic_id` is rejected rather than silently accepted, so an override always
+shows up in the `get_all_*_mesh_types` call that can read it back.
 
 Whole-table and mode changes, each of which re-labels the world in place:
 
 | RPC | What it does |
 |---|---|
-| `load_label_table` | Replace the entire table from a JSON string (`json`) or a file (`json_file`) — Unreal's DataTable JSON format, an array of rows keyed by `"Name"`. Supersedes the configured `SemanticLabelTable` for the life of the process. A table that fails to import is rejected whole, leaving the active one in place. |
+| `load_label_table` | Replace the entire table from a JSON string (`json`) or a file (`json_file`) — Unreal's DataTable JSON format, an array of rows keyed by `"Name"`. Supersedes the configured `SemanticLabelTable` until the world is torn down. Send it with neither field set to go back to the configured table. A table that fails to import *or* to validate is rejected whole, leaving the active one in place. |
 | `set_label_type` | Switch between `LT_SEMANTIC` and `LT_INSTANCE`. |
 | `set_instance_label_uniqueness` | Set the two instance-ID reuse flags. Governs future allocations only — already-labeled objects keep their IDs. |
 | `set_label_row_overrides` | Set the `OverridableLabelRowName` / `OverridingLabelRowName` pair driving the subsurface-color per-pixel override, or clear both to disable it. Live sensors pick it up without a capture restart. |
@@ -272,9 +278,14 @@ Whole-table and mode changes, each of which re-labels the world in place:
     two fetches of the same table are byte-identical and a diff shows only what you changed. Round
     trip it: fetch, edit, `load_label_table`.
 
-    One sharp edge: an asset path the importer cannot resolve is accepted without complaint — an
-    unknown class lands in the row as a null, an unknown mesh as a soft pointer that never loads.
-    Check the result with `get_semantic_classes` if a label doesn't appear where you expect.
+    `load_label_table` checks the table before installing it and rejects the whole request with the
+    list of problems, so a typo'd asset path, a label ID outside 0–253, a missing or non-zero
+    `NoLabel` row, or an actor type / mesh / tag two rows both claim comes back as an error rather
+    than as quietly wrong images.
+
+    Note that `set_label_row_overrides` names its rows by name, and those names are held separately
+    from the table. Loading a table without those rows disables the per-pixel override and logs a
+    warning — re-send `set_label_row_overrides` after a load that renames them.
 
 ## Timing: pipelined or synchronous
 


### PR DESCRIPTION
Follow-up to #566. A review of that commit turned up ten correctness findings; this fixes all of
them plus the cleanups that came with them. They share a shape: an RPC returns `OK` and the world
is quietly wrong afterward.

## Instance ID accounting

`LabelActor` / `LabelComponent` allocate an instance ID whatever the label type is, but the unlabel
side only returned one in `Instance` mode — and tested "was an ID ever allocated" against
`NoLabelId`, which is the `NoLabel` row's *semantic* ID, not the `FInstanceSemanticIdPair`
sentinel.

`SetLabelType` mutates `LabelType` before it broadcasts, so the unlabel pass that precedes
re-labeling already saw the new type: `set_label_type(LT_SEMANTIC)` with 200 labeled actors
returned zero IDs and then allocated 200 more. Those 200 were gone for the life of the world, so
live actors started sharing instance IDs well short of 253 (or, with `instantaneously_unique`,
going unlabeled). Plain spawn/destroy churn in Semantic mode leaked identically.

Reclamation is now unconditional, against a `NoInstanceId` sentinel. That leaves `NoLabelId` with
no readers, so it's gone; validation instead enforces the `NoLabel` label of 0 that `LabelActor`
already assumes for every unmatched object.

## Table validation

`CreateTableFromJSONString` reports only what it could not *parse*. Everything that makes a parsed
table unusable — a label ID outside 0–253, an asset path that doesn't resolve, a missing `NoLabel`
row, a key two rows both claim — was a `UE_LOG` inside `BuildLabelMaps`, i.e. invisible to the
client that just sent the table. An out-of-range label is not a cosmetic problem: the ID rides in
the exponent field of the tile atlas's fp32 alpha, so it corrupts the **depth** of every pixel it
covers too.

Those checks are now `ValidateSemanticLabelTable` in `TempoSensorsUtils`. `load_label_table` runs
it before installing and rejects with the full list; `BuildLabelMaps` logs the same list for tables
set in the editor.

## Mesh overrides — split by asset kind

`GetComponentMeshPaths` returns skeletal paths and `ResolveMeshSemanticId` consulted the static
override map for all of them, so `set_static_mesh_type_semantic_id` silently relabeled skeletal
meshes — while `get_semantic_classes` listed the result under the wrong field and
`get_all_static_mesh_types` never listed the mesh at all, leaving its ID undiscoverable.

Rather than make the static RPC honest by dropping the capability, the override maps are split by
asset kind, each setter rejects a path that isn't its own type, and the missing counterparts are
added:

- `get_all_skeletal_mesh_types`
- `set_skeletal_mesh_type_semantic_id`

The path space is shared but disjoint (an asset is a `UStaticMesh` or a `USkeletalMesh`, never
both), so the two maps can't collide and the reverse-map reporting falls out symmetrically.

## Also fixed

| | |
|---|---|
| Tag override precedence | Overrides get a pass of their own, so an override on a later tag no longer loses to a table entry on an earlier one. |
| Runtime table lifetime | Cleared at world teardown instead of living on the settings CDO for the process, and an empty `LoadLabelTableRequest` reverts to the configured asset. Previously a table loaded in one PIE session silently superseded Project Settings in the next, with no log line. |
| Sensors going deaf | Tiled sensors bind the label-override event in `OnRegister`, paired with the existing `OnUnregister` unbind. Binding in `BeginPlay` meant any Details-panel edit during PIE (which runs a re-register cycle without `BeginPlay`/`EndPlay`) left that sensor stuck on stale labels. |
| `GetActorClassification` | Routes through `ResolveActorSemanticId`, so TempoWorld's overlap events and the label image agree about tags and runtime overrides. |
| Superclass catch-alls | The most-derived matching `ActorType` wins. This also makes the "overlapping actor types" error unreachable — single inheritance means two matching types are always comparable — so that branch is gone. |
| `set_label_type` cost | `OnLabelSettingsChanged` rebuilds the label maps only when the table pointer actually changed, instead of reloading every mesh soft reference on a mode switch. |

Plus the smaller cleanups: the triplicated `semantic_id` range check, the five copy-paste reverse-map
blocks in `HandleGetSemanticClasses`, `GetRowNames()` allocating inside a validation loop, and
hand-rolled relative-path resolution.

## API changes

Additive except where noted:

- **New:** `GetAllSkeletalMeshTypes`, `SetSkeletalMeshTypeSemanticId`.
- **Behavior change:** `SetStaticMeshTypeSemanticId` now rejects a non-static-mesh path with
  `INVALID_ARGUMENT`. Only reachable by a client that was relying on the same-commit accident above,
  where the result was unreportable anyway.
- **Behavior change:** `LoadLabelTable` with neither field set now reverts to the configured table
  instead of returning `INVALID_ARGUMENT`.
- **Behavior change:** `LoadLabelTable` rejects tables that parse but would mislabel the world.
- **Scope change:** a table loaded over the API no longer outlives its world.

## Testing

- `Scripts/Build.sh` clean, no new warnings in the touched files.
- `Scripts/Test.sh` — 35/35 pass, including the new `Tempo.Sensors.LabelTable.Validation` covering
  the tables that parse cleanly and would still mislabel the world (out-of-range label, missing and
  non-zero `NoLabel`, unresolvable class and mesh paths, keys claimed twice).
- Generated Python client picks up both new RPCs.
- The `set_static_mesh_type_semantic_id` fixture in `Tests/Python/test_sensor_readback.py` feeds
  paths from `get_all_static_mesh_types`, which are all static meshes, so the new type check doesn't
  affect it. Not run here — needs a packaged build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3sULMW2quDhrE4MZyZwMJ