### PR TITLE
Key CI Caches and Images on the Engine Build, and Disable UBA Detours

### DIFF
--- a/.github/workflows/build_and_package.yml
+++ b/.github/workflows/build_and_package.yml
@@ -290,6 +290,40 @@ jobs:
         echo "REPO_LOWERCASE=${REPO_UPPERCASE,,}" >> $GITHUB_OUTPUT
       env:
         REPO_UPPERCASE: ${{ github.event.repository.name }}
+    # Epic's base image tag (dev-slim-<version>) moves — it is republished as the release branch
+    # advances, so the same tag can be two different engines weeks apart. Resolve it to a digest
+    # here, before anything is restored or built, and carry that digest through everything that is
+    # only valid for one engine: the build cache (PCHs and object files are compiled against one set
+    # of engine headers), the engine mods cache (engine folders copied out of the image), and the
+    # pre-modded image tag (via the engine mods hash). Without it a run silently mixes engines,
+    # which surfaces as a stale-PCH compile error at best and a bad link at worst.
+    # This needs its own login because it runs before the pre-modded pull; the later Epic login
+    # re-establishes these credentials for the image build, after the pre-modded registry login
+    # (same host, different token) has overwritten them.
+    - name: Log in to Epic Container Registry (to resolve the base image)
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.EPIC_DOCKER_USERNAME }}
+        password: ${{ secrets.EPIC_DOCKER_TOKEN }}
+    - name: Resolve Engine Base Image Digest
+      id: engine_base_image
+      run: |
+        BASE_IMAGE="ghcr.io/epicgames/unreal-engine:dev-slim-${UNREAL_VERSION}"
+        DIGEST=$(docker buildx imagetools inspect "$BASE_IMAGE" --format '{{.Manifest.Digest}}')
+        case "$DIGEST" in
+          sha256:*) ;;
+          *)
+            echo "Error: could not resolve a digest for $BASE_IMAGE (got '$DIGEST')"
+            exit 1
+            ;;
+        esac
+        SHORT="${DIGEST#sha256:}"
+        echo "IMAGE=ghcr.io/epicgames/unreal-engine@$DIGEST" >> $GITHUB_OUTPUT
+        echo "DIGEST=$DIGEST" >> $GITHUB_OUTPUT
+        # Short form for cache keys, which are prefix-matched and easier to eyeball.
+        echo "ID=${SHORT:0:12}" >> $GITHUB_OUTPUT
+        echo "Engine base image: $BASE_IMAGE -> $DIGEST"
     - name: Restore Build Cache (if clean not specified)
       if: ${{ ! inputs.clean }}
       id: restore_build_cache
@@ -305,14 +339,16 @@ jobs:
           ${{ github.workspace }}/${{ inputs.project_root }}/Plugins/**/Intermediate/**
           ${{ github.workspace }}/${{ inputs.project_root }}/Plugins/**/Binaries/**
           .engine-ddc-cache/**
-        key: ${{ steps.repo_lowercase.outputs.REPO_LOWERCASE }}-build-${{ env.UNREAL_VERSION }}-${{ steps.common_ancestor.outputs.COMMON_ANCESTOR }}
+        key: ${{ steps.repo_lowercase.outputs.REPO_LOWERCASE }}-build-${{ env.UNREAL_VERSION }}-${{ steps.engine_base_image.outputs.ID }}-${{ steps.common_ancestor.outputs.COMMON_ANCESTOR }}
         # Fall back to the most recent prior build cache when the exact key misses. This is what lets
         # main builds run warm: on a push to main, COMMON_ANCESTOR resolves to HEAD itself (origin/main
         # == HEAD), whose key was never saved, so the exact key always misses; the prefix matches the
         # previous main build's cache instead. (A prefix match sets cache-matched-key but leaves
         # cache-hit false — see the DDC-init step's condition below.)
+        # The engine digest sits inside the prefix, so a cache built against a different engine is
+        # never restored — a miss (one cold build) is the correct outcome there, not a mixed tree.
         restore-keys: |
-          ${{ steps.repo_lowercase.outputs.REPO_LOWERCASE }}-build-${{ env.UNREAL_VERSION }}-
+          ${{ steps.repo_lowercase.outputs.REPO_LOWERCASE }}-build-${{ env.UNREAL_VERSION }}-${{ steps.engine_base_image.outputs.ID }}-
     - name: Restore Engine Mods Cache (if clean not specified and not using pre-modded image)
       if: ${{ ! inputs.clean && inputs.engine_mods_image == '' }}
       id: restore_engine_mods_cache
@@ -332,7 +368,7 @@ jobs:
           .engine-mods-cache/Engine/Source/Programs/Shared/**
           .engine-mods-cache/Engine/Binaries/DotNET/UnrealBuildTool/**
           .engine-mods-cache/Engine/Binaries/DotNET/AutomationTool/**
-        key: tempo-engine-mods-${{ env.UNREAL_VERSION }}-${{ hashFiles(format('{0}/EngineMods/**', inputs.tempo_root)) }}
+        key: tempo-engine-mods-${{ env.UNREAL_VERSION }}-${{ steps.engine_base_image.outputs.ID }}-${{ hashFiles(format('{0}/EngineMods/**', inputs.tempo_root)) }}
     - name: Run Post-Checkout Script (if specified)
       if: ${{ inputs.post_checkout_script != '' }}
       working-directory: ${{ github.workspace }}/${{ inputs.project_root }}
@@ -399,12 +435,16 @@ jobs:
           echo "Dockerfile not found at $DOCKERFILE"
           exit 1
         fi
+        # The base image digest is part of the hash: a pre-modded image is the engine plus the mods,
+        # so one built from a different engine must not answer to the same tag.
         # Must stay in sync with the matching computation in publish_engine_mods.yml.
         ENGINE_MODS_HASH=$(cd "$ENGINE_MODS_DIR" && find . -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)
         DOCKERFILE_HASH=$(sha256sum "$DOCKERFILE" | cut -d' ' -f1)
-        HASH=$(printf '%s\n%s\n' "$ENGINE_MODS_HASH" "$DOCKERFILE_HASH" | sha256sum | cut -d' ' -f1)
+        HASH=$(printf '%s\n%s\n%s\n' "$ENGINE_MODS_HASH" "$DOCKERFILE_HASH" "$ENGINE_BASE_DIGEST" | sha256sum | cut -d' ' -f1)
         echo "HASH=$HASH" >> $GITHUB_OUTPUT
         echo "Engine mods hash: $HASH"
+      env:
+        ENGINE_BASE_DIGEST: ${{ steps.engine_base_image.outputs.DIGEST }}
     # --- Pre-modded image registry auth (generic: static credentials or AWS ECR). Independent of the
     #     Epic base-image registry (ghcr.io), which is logged into separately in the fallback path. ---
     - name: Configure AWS Credentials for ECR (OIDC)
@@ -483,7 +523,11 @@ jobs:
     - name: Build Tempo Unreal Docker Image
       if: ${{ steps.pull_modded.outputs.used != 'true' }}
       run: |
-        docker build --build-arg UNREAL_VERSION=${{ env.UNREAL_VERSION }} --tag 'tempo_unreal_image' -f ${{ github.workspace }}/${{ inputs.tempo_root }}/Dockerfile .
+        docker build \
+          --build-arg UNREAL_VERSION=${{ env.UNREAL_VERSION }} \
+          --build-arg ENGINE_BASE_IMAGE=${{ steps.engine_base_image.outputs.IMAGE }} \
+          --tag 'tempo_unreal_image' \
+          -f ${{ github.workspace }}/${{ inputs.tempo_root }}/Dockerfile .
     - name: Initialize Engine Mods Cache (if not restored from cache and not using pre-modded image)
       if: ${{ steps.restore_engine_mods_cache.outputs.cache-hit != 'true' && steps.pull_modded.outputs.used != 'true' }}
       run: |
@@ -677,7 +721,7 @@ jobs:
           .engine-mods-cache/Engine/Source/Programs/Shared/**
           .engine-mods-cache/Engine/Binaries/DotNET/UnrealBuildTool/**
           .engine-mods-cache/Engine/Binaries/DotNET/AutomationTool/**
-        key: tempo-engine-mods-${{ env.UNREAL_VERSION }}-${{ hashFiles(format('{0}/EngineMods/**', inputs.tempo_root)) }}
+        key: tempo-engine-mods-${{ env.UNREAL_VERSION }}-${{ steps.engine_base_image.outputs.ID }}-${{ hashFiles(format('{0}/EngineMods/**', inputs.tempo_root)) }}
     - name: Cache Build (if building cache branch)
       if: ${{ github.event_name != 'pull_request_target' && github.ref == format('refs/heads/{0}', inputs.cache_branch) }}
       uses: actions/cache/save@v4
@@ -692,13 +736,14 @@ jobs:
           ${{ github.workspace }}/${{ inputs.project_root }}/Plugins/**/Intermediate/**
           ${{ github.workspace }}/${{ inputs.project_root }}/Plugins/**/Binaries/**
           .engine-ddc-cache/**
-        key: ${{ steps.repo_lowercase.outputs.REPO_LOWERCASE }}-build-${{ env.UNREAL_VERSION }}-${{ github.sha }}
+        key: ${{ steps.repo_lowercase.outputs.REPO_LOWERCASE }}-build-${{ env.UNREAL_VERSION }}-${{ steps.engine_base_image.outputs.ID }}-${{ github.sha }}
     - name: Prune Old Build Caches (keep only the one just saved)
       # Build cache keys are immutable and rolling (suffixed with the commit SHA), so each main
       # build saves a new entry and the old same-version ones linger until the 10GB LRU sweep
       # evicts them - which can starve a less-frequently-built engine version. Delete every cache
       # sharing this version's prefix except the one this run just saved, leaving exactly one per
-      # engine version. Requires 'actions: write' on the calling job; if it wasn't granted we warn
+      # engine version. The prefix deliberately stops short of the engine digest, so caches keyed to
+      # an engine build this branch has moved off of are pruned too. Requires 'actions: write' on the calling job; if it wasn't granted we warn
       # and continue rather than fail, so downstream callers that omit it still build fine.
       if: ${{ github.event_name != 'pull_request_target' && github.ref == format('refs/heads/{0}', inputs.cache_branch) }}
       shell: bash
@@ -709,7 +754,7 @@ jobs:
         # repo whose caches we want to prune rather than failing to determine a base repo.
         GH_REPO: ${{ github.repository }}
         PREFIX: ${{ steps.repo_lowercase.outputs.REPO_LOWERCASE }}-build-${{ env.UNREAL_VERSION }}-
-        KEEP: ${{ steps.repo_lowercase.outputs.REPO_LOWERCASE }}-build-${{ env.UNREAL_VERSION }}-${{ github.sha }}
+        KEEP: ${{ steps.repo_lowercase.outputs.REPO_LOWERCASE }}-build-${{ env.UNREAL_VERSION }}-${{ steps.engine_base_image.outputs.ID }}-${{ github.sha }}
       run: |
         # Surface gh's real error rather than asserting a cause - a 403 means 'actions: write' is
         # missing on the calling job, but other failures (auth, repo resolution, gh version) read

--- a/.github/workflows/build_and_package.yml
+++ b/.github/workflows/build_and_package.yml
@@ -182,6 +182,16 @@ on:
 
 env:
   UNREAL_VERSION: "${{ inputs.unreal_version }}"
+  # UE 5.8's UBA detour library (libUbaDetours.so, LD_PRELOADed into every compile) livelocks
+  # clang++ on this engine: a SIGSEGV under opendir/directory iteration is caught by UBA's
+  # ChainedSigaction, chained back to clang's own handler, and re-faults on the same instruction
+  # forever - tens of thousands of "[CHAINED-SIGNAL 11]" reports per minute with no action ever
+  # completing. Opt out of detouring (equivalent to -UBANoDetour): UBA still schedules actions,
+  # but runs them as ordinary local processes. UBT materializes UnrealBuildTool_<Category>__<Field>
+  # environment variables into a BuildConfiguration.xml that it reads last, so this overrides the
+  # engine defaults for every UBT invocation in the container - including the ones UAT spawns.
+  # Remove once the detour layer is fixed upstream; it costs UBA's file virtualization and caching.
+  UBA_NO_DETOUR: -e UnrealBuildTool_UnrealBuildAccelerator__AllowDetour=false
 
 jobs:
   build:
@@ -586,6 +596,7 @@ jobs:
         timeout_seconds: 60
         command: |
           docker run --rm \
+            ${UBA_NO_DETOUR} \
             ${ENGINE_MODS_MOUNTS} \
             -e GITHUB_TOKEN \
             -v ${{ github.workspace }}/.engine-ddc-cache/Engine/DerivedDataCache:/home/ue4/UnrealEngine/Engine/DerivedDataCache \
@@ -596,6 +607,7 @@ jobs:
       if: ${{ steps.pull_modded.outputs.used != 'true' }}
       run: |
         docker run --rm \
+          ${UBA_NO_DETOUR} \
           ${ENGINE_MODS_MOUNTS} \
           -v ${{ github.workspace }}/.engine-ddc-cache/Engine/DerivedDataCache:/home/ue4/UnrealEngine/Engine/DerivedDataCache \
           -v ${{ github.workspace }}/${{ inputs.project_root }}:/home/ue4/${{ inputs.project_root }} \
@@ -605,6 +617,7 @@ jobs:
       if: ${{ inputs.clean }}
       run: |
         docker run --rm \
+          ${UBA_NO_DETOUR} \
           ${ENGINE_MODS_MOUNTS} \
           -v ${{ github.workspace }}/.engine-ddc-cache/Engine/DerivedDataCache:/home/ue4/UnrealEngine/Engine/DerivedDataCache \
           -v ${{ github.workspace }}/${{ inputs.project_root }}:/home/ue4/${{ inputs.project_root }} \
@@ -613,6 +626,7 @@ jobs:
     - name: Build
       run: |
         docker run --rm \
+          ${UBA_NO_DETOUR} \
           ${ENGINE_MODS_MOUNTS} \
           -v ${{ github.workspace }}/.engine-ddc-cache/Engine/DerivedDataCache:/home/ue4/UnrealEngine/Engine/DerivedDataCache \
           -v ${{ github.workspace }}/${{ inputs.project_root }}:/home/ue4/${{ inputs.project_root }} \
@@ -624,6 +638,7 @@ jobs:
       if: ${{ inputs.automation_test_filter != '' }}
       run: |
         docker run --rm \
+          ${UBA_NO_DETOUR} \
           ${ENGINE_MODS_MOUNTS} \
           -v ${{ github.workspace }}/.engine-ddc-cache/Engine/DerivedDataCache:/home/ue4/UnrealEngine/Engine/DerivedDataCache \
           -v ${{ github.workspace }}/${{ inputs.project_root }}:/home/ue4/${{ inputs.project_root }} \
@@ -645,6 +660,7 @@ jobs:
           PACKAGE_ARGS="$PACKAGE_ARGS -generatepatch -basedonreleaseversion=${{ inputs.release_id }} -basedonreleaseversionbasepath=/home/ue4/${{ inputs.project_root }}/Releases"
         fi
         docker run --rm \
+          ${UBA_NO_DETOUR} \
           ${ENGINE_MODS_MOUNTS} \
           -v ${{ github.workspace }}/.engine-ddc-cache/Engine/DerivedDataCache:/home/ue4/UnrealEngine/Engine/DerivedDataCache \
           -v ${{ github.workspace }}/.releases:/home/ue4/${{ inputs.project_root }}/Releases \
@@ -658,6 +674,7 @@ jobs:
       if: ${{ inputs.patch }}
       run: |
         docker run --rm \
+          ${UBA_NO_DETOUR} \
           ${ENGINE_MODS_MOUNTS} \
           -v ${{ github.workspace }}/.engine-ddc-cache/Engine/DerivedDataCache:/home/ue4/UnrealEngine/Engine/DerivedDataCache \
           -v ${{ github.workspace }}/${{ inputs.project_root }}:/home/ue4/${{ inputs.project_root }} \

--- a/.github/workflows/publish_engine_mods.yml
+++ b/.github/workflows/publish_engine_mods.yml
@@ -2,7 +2,8 @@
 # Publish a Tempo Unreal Docker image with engine mods pre-applied to a container registry.
 # This reusable workflow builds the base Tempo Unreal Docker image (from the Epic-distributed image),
 # runs the Tempo engine-mods install script inside a container, then commits and pushes the resulting
-# image to a parameterized registry repository (image_name) tagged with <unreal_version>-<hashFiles(EngineMods/**)>.
+# image to a parameterized registry repository (image_name) tagged with <unreal_version>-<hash>, where
+# the hash covers EngineMods/, the Dockerfile, and the digest of the Epic base image it was built from.
 # A consumer build workflow can then `docker pull` this image instead of running the
 # "Initialize Engine Mods Cache" + "Install Engine Mods" steps each build.
 # The skip-if-tag-exists check makes the workflow idempotent on no-op merges to main.
@@ -139,6 +140,32 @@ jobs:
         path: checkout
         submodules: recursive
         token: ${{ steps.submodules_app_token.outputs.token != '' && steps.submodules_app_token.outputs.token || (inputs.submodules_token != '' && inputs.submodules_token || github.token) }}
+    # Epic's base image tag (dev-slim-<version>) moves as the release branch advances, so a published
+    # image must be identified by the engine it was built from, not just by the mods applied to it.
+    # Resolve the digest before the tag is computed and build from that digest below, so the tag and
+    # the image can't disagree. Must stay in sync with build_and_package.yml, which resolves the same
+    # digest to decide whether this image answers for its engine.
+    - name: Log in to Epic Container Registry (to resolve the base image)
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.EPIC_DOCKER_USERNAME }}
+        password: ${{ secrets.EPIC_DOCKER_TOKEN }}
+    - name: Resolve Engine Base Image Digest
+      id: engine_base_image
+      run: |
+        BASE_IMAGE="ghcr.io/epicgames/unreal-engine:dev-slim-${UNREAL_VERSION}"
+        DIGEST=$(docker buildx imagetools inspect "$BASE_IMAGE" --format '{{.Manifest.Digest}}')
+        case "$DIGEST" in
+          sha256:*) ;;
+          *)
+            echo "Error: could not resolve a digest for $BASE_IMAGE (got '$DIGEST')"
+            exit 1
+            ;;
+        esac
+        echo "IMAGE=ghcr.io/epicgames/unreal-engine@$DIGEST" >> $GITHUB_OUTPUT
+        echo "DIGEST=$DIGEST" >> $GITHUB_OUTPUT
+        echo "Engine base image: $BASE_IMAGE -> $DIGEST"
     - name: Compute Engine Mods Hash and Tag
       id: tag
       run: |
@@ -152,16 +179,19 @@ jobs:
           echo "Error: Dockerfile not found at $DOCKERFILE"
           exit 1
         fi
-        # Hash includes both EngineMods and the Dockerfile so changes to either invalidate
-        # the published tag (e.g. tooling added to the image must produce a fresh image).
+        # Hash includes EngineMods, the Dockerfile and the base image digest so changes to any of
+        # them invalidate the published tag (e.g. tooling added to the image, or Epic republishing
+        # dev-slim-<version>, must produce a fresh image).
         # Must stay in sync with the matching computation in build_and_package.yml.
         ENGINE_MODS_HASH=$(cd "$ENGINE_MODS_DIR" && find . -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)
         DOCKERFILE_HASH=$(sha256sum "$DOCKERFILE" | cut -d' ' -f1)
-        HASH=$(printf '%s\n%s\n' "$ENGINE_MODS_HASH" "$DOCKERFILE_HASH" | sha256sum | cut -d' ' -f1)
+        HASH=$(printf '%s\n%s\n%s\n' "$ENGINE_MODS_HASH" "$DOCKERFILE_HASH" "$ENGINE_BASE_DIGEST" | sha256sum | cut -d' ' -f1)
         TAG="${{ inputs.image_name }}:${{ env.UNREAL_VERSION }}-$HASH"
         echo "HASH=$HASH" >> $GITHUB_OUTPUT
         echo "TAG=$TAG" >> $GITHUB_OUTPUT
         echo "Target tag: $TAG"
+      env:
+        ENGINE_BASE_DIGEST: ${{ steps.engine_base_image.outputs.DIGEST }}
     # --- Target registry auth (generic: static credentials or AWS ECR). Used for the tag-existence
     #     check below and for the final push. Independent of the Epic base-image registry (ghcr.io). ---
     - name: Configure AWS Credentials for ECR (OIDC)
@@ -238,6 +268,7 @@ jobs:
       run: |
         docker build \
           --build-arg UNREAL_VERSION=${{ env.UNREAL_VERSION }} \
+          --build-arg ENGINE_BASE_IMAGE=${{ steps.engine_base_image.outputs.IMAGE }} \
           --tag tempo_unreal_image \
           -f ${{ github.workspace }}/checkout/${{ inputs.tempo_root }}/Dockerfile \
           ${{ github.workspace }}/checkout/${{ inputs.tempo_root }}

--- a/.github/workflows/publish_engine_mods.yml
+++ b/.github/workflows/publish_engine_mods.yml
@@ -104,6 +104,16 @@ on:
 
 env:
   UNREAL_VERSION: "${{ inputs.unreal_version }}"
+  # UE 5.8's UBA detour library (libUbaDetours.so, LD_PRELOADed into every compile) livelocks
+  # clang++ on this engine: a SIGSEGV under opendir/directory iteration is caught by UBA's
+  # ChainedSigaction, chained back to clang's own handler, and re-faults on the same instruction
+  # forever - tens of thousands of "[CHAINED-SIGNAL 11]" reports per minute with no action ever
+  # completing. Opt out of detouring (equivalent to -UBANoDetour): UBA still schedules actions,
+  # but runs them as ordinary local processes. UBT materializes UnrealBuildTool_<Category>__<Field>
+  # environment variables into a BuildConfiguration.xml that it reads last, so this overrides the
+  # engine defaults for every UBT invocation in the container - including the ones UAT spawns.
+  # Remove once the detour layer is fixed upstream; it costs UBA's file virtualization and caching.
+  UBA_NO_DETOUR: -e UnrealBuildTool_UnrealBuildAccelerator__AllowDetour=false
 
 jobs:
   publish:
@@ -281,6 +291,7 @@ jobs:
       if: ${{ steps.skip.outputs.skip != 'true' }}
       run: |
         docker run --name modded_engine \
+          ${UBA_NO_DETOUR} \
           -v ${{ github.workspace }}/checkout/${{ inputs.tempo_root }}:/home/ue4/Tempo \
           tempo_unreal_image \
           /home/ue4/Tempo/Scripts/InstallEngineMods.sh


### PR DESCRIPTION
## Why

The 5.8 jobs have failed three different ways this week, all from one cause: `ghcr.io/epicgames/unreal-engine:dev-slim-5.8` is a moving tag, and nothing keyed on *which engine* noticed when it moved.

- main's 5.8 job runs on the pre-modded image published **2026-07-06** from `dev-slim-5.8@sha256:daac0262…`, and `publish_engine_mods.yml` skips when the tag already exists — so main has been on the July engine ever since.
- Any branch that changes the engine-mods hash misses that image and builds from whatever the tag points at today (`@sha256:6840106f…`) — a two-month-newer engine.

That mismatch produced, in order:

1. A **6-hour hang** in the prebuild — the newer UBA forks a `uba-orphankill` watchdog that inherits a UBT child's stdout/stderr, so a pipe-capturing parent never sees EOF (fixed separately in TempoROS `gen_ros_idl.py`).
2. `fatal error: file 'Matrix.inl' has been modified since the precompiled header … was built` — main's July build cache restored into a September container. The key was `<repo>-build-<version>-<sha>`: engine *version*, not engine *build*.
3. **clang++ livelocking** under the newer UBA detour library.

## What

**Key everything engine-specific on the base image digest.** Resolve `dev-slim-<version>` to a digest before anything is restored or built, and carry it into the build cache key *and* its `restore-keys` prefix, the engine-mods cache key, and the engine-mods hash — so the pre-modded image tag identifies the engine it was built from. Build from the digest rather than the tag, so the image can't differ from what was hashed. `publish_engine_mods.yml` resolves and folds in the same digest, keeping the two hash computations in sync.

A new engine is now a guaranteed cache miss — one cold build — instead of a silently mixed tree.

**Run without UBA detours.** `libUbaDetours.so` livelocks clang++ on this engine: a SIGSEGV under `opendir` is caught by UBA's `ChainedSigaction`, chained back to clang's own handler, and re-faults on the same instruction forever. Observed on the 5.8 job: a 24-action batch made zero progress in 15 minutes while emitting ~5k `[CHAINED-SIGNAL 11]` reports a minute from the same two pids (80,925 lines in one job log), with UBT's log parser burning 55% of a core. `UnrealBuildTool_UnrealBuildAccelerator__AllowDetour=false` on every container run opts out (equivalent to `-UBANoDetour`); UBA still schedules actions, they just run as ordinary local processes.

## What to expect on merge

- **One cold build on main** — the cache key shape changed, so the existing entry can't match.
- **One engine-mods publish**, since the tag now includes the base digest. Until it lands, runs fall back to building the image and installing mods in-workflow (~25 min).
- Builds lose UBA's file virtualization and caching until the detour opt-out is removed. Both the opt-out and the digest scoping are commented as such.

## Note

`tempo_build_and_package.yml` references the reusable workflow as `./.github/workflows/build_and_package.yml`, and `pull_request_target` resolves local references against the **base** branch — so none of this takes effect on PR runs until it is on main. This PR's own CI exercises main's copy of the workflow (July engine, warm cache), not the changes in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZzhqhVCownsBHxTitM7JR