### PR TITLE
Fix Build, Clean, and Package Scripts on Paths With Spaces

### DIFF
--- a/Scripts/Build.sh
+++ b/Scripts/Build.sh
@@ -16,6 +16,8 @@ if [[ "$OSTYPE" = "msys" ]]; then
   # when we invoke .bat files — otherwise cmd.exe's strip-outer-quotes rule
   # mangles the path when another argument (e.g. -Project=...) is also quoted.
   UNREAL_ENGINE_PATH=$(cygpath -w -s "$UNREAL_ENGINE_PATH")
+  # Drop any trailing separator so the path can be appended to below.
+  UNREAL_ENGINE_PATH="${UNREAL_ENGINE_PATH%[\\/]}"
 elif [[ "$OSTYPE" = "darwin"* ]]; then
   PLATFORM="Mac"
 elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
@@ -27,7 +29,10 @@ fi
 
 cd "$UNREAL_ENGINE_PATH"
 if [ "$PLATFORM" = "Win64" ]; then
-  ./Engine/Build/BatchFiles/Build.bat "${PROJECT_NAME}Editor" Development "$PLATFORM" -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -WaitMutex -FromMsBuild "$@"
+  # Invoke the .bat by absolute short path, not relatively: MSYS resolves a
+  # relative program path through the real filesystem, which restores the long
+  # "Program Files" form and reintroduces the space the 8.3 conversion removed.
+  "$UNREAL_ENGINE_PATH\\Engine\\Build\\BatchFiles\\Build.bat" "${PROJECT_NAME}Editor" Development "$PLATFORM" -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -WaitMutex -FromMsBuild "$@"
 else
   ./Engine/Build/BatchFiles/"$PLATFORM"/Build.sh "${PROJECT_NAME}Editor" Development "$PLATFORM" -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -buildscw "$@"
 fi

--- a/Scripts/Clean.sh
+++ b/Scripts/Clean.sh
@@ -12,6 +12,12 @@ UNREAL_ENGINE_PATH=$("$SCRIPT_DIR"/FindUnreal.sh)
 PLATFORM=""
 if [[ "$OSTYPE" = "msys" ]]; then
   PLATFORM="Win64"
+  # 8.3 short form removes the space in "Program Files" so PWD is spaces-free
+  # when we invoke .bat files — otherwise cmd.exe's strip-outer-quotes rule
+  # mangles the path when another argument (e.g. -Project=...) is also quoted.
+  UNREAL_ENGINE_PATH=$(cygpath -w -s "$UNREAL_ENGINE_PATH")
+  # Drop any trailing separator so the path can be appended to below.
+  UNREAL_ENGINE_PATH="${UNREAL_ENGINE_PATH%[\\/]}"
 elif [[ "$OSTYPE" = "darwin"* ]]; then
   PLATFORM="Mac"
 elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
@@ -23,8 +29,11 @@ fi
 
 cd "$UNREAL_ENGINE_PATH"
 if [ "$PLATFORM" = "Win64" ]; then
-  # Windows build script is a little different
-  ./Engine/Build/BatchFiles/Build.bat "${PROJECT_NAME}Editor" Development $PLATFORM -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -WaitMutex -FromMsBuild -clean "$@"
+  # Windows build script is a little different.
+  # Invoke the .bat by absolute short path, not relatively: MSYS resolves a
+  # relative program path through the real filesystem, which restores the long
+  # "Program Files" form and reintroduces the space the 8.3 conversion removed.
+  "$UNREAL_ENGINE_PATH\\Engine\\Build\\BatchFiles\\Build.bat" "${PROJECT_NAME}Editor" Development $PLATFORM -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -WaitMutex -FromMsBuild -clean "$@"
 else
   ./Engine/Build/BatchFiles/$PLATFORM/Build.sh "${PROJECT_NAME}Editor" Development $PLATFORM -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -buildscw -clean "$@"
 fi

--- a/Scripts/Package.sh
+++ b/Scripts/Package.sh
@@ -56,6 +56,8 @@ if [[ "$OSTYPE" = "msys" ]]; then
   # when we invoke .bat files — otherwise cmd.exe's strip-outer-quotes rule
   # mangles the path when another argument (e.g. -project=...) is also quoted.
   export UNREAL_ENGINE_PATH=$(cygpath -w -s "$UNREAL_ENGINE_PATH")
+  # Drop any trailing separator so the path can be appended to below.
+  export UNREAL_ENGINE_PATH="${UNREAL_ENGINE_PATH%[\\/]}"
   if [ "$1" = "Linux" ]; then
     if [ -z ${LINUX_MULTIARCH_ROOT+x} ]; then
       echo "LINUX_MULTIARCH_ROOT not set, cannot cross-compile for Linux"
@@ -93,13 +95,21 @@ PACKAGE_COMMAND="Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIf
 
 echo "Packaging $PROJECT_NAME in $BUILD_CONFIGURATION configuration -> $PROJECT_ROOT/Packaged"
 
-# Add platform-specific parts
+# Add platform-specific parts. The launcher is kept out of PACKAGE_COMMAND and
+# expanded by the eval below instead: on Windows its 8.3 path is backslashed,
+# and backslashes embedded in an eval'd string are consumed as escapes.
 if [ "$HOST_PLATFORM" = "Win64" ]; then
-  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.bat $PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd.exe\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
+  # Absolute short path, not relative: MSYS resolves a relative program path
+  # through the real filesystem, which restores the long "Program Files" form
+  # and reintroduces the space the 8.3 conversion removed.
+  UAT_LAUNCHER="$UNREAL_ENGINE_PATH\\Engine\\Build\\BatchFiles\\RunUAT.bat"
+  PACKAGE_COMMAND="$PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd.exe\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
 elif [ "$HOST_PLATFORM" = "Mac" ]; then
-  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.sh $PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd\" -archive -archivedirectory=\"$PROJECT_ROOT/Packaged\""
+  UAT_LAUNCHER="./Engine/Build/BatchFiles/RunUAT.sh"
+  PACKAGE_COMMAND="$PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd\" -archive -archivedirectory=\"$PROJECT_ROOT/Packaged\""
 elif [ "$HOST_PLATFORM" = "Linux" ]; then
-  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.sh $PACKAGE_COMMAND -unrealexe=\"UnrealEditor\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
+  UAT_LAUNCHER="./Engine/Build/BatchFiles/RunUAT.sh"
+  PACKAGE_COMMAND="$PACKAGE_COMMAND -unrealexe=\"UnrealEditor\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
 else
   echo "Unsupported platform"
   exit 1
@@ -133,8 +143,10 @@ for arg in "$@"; do
   esac
 done
 
-# Execute the command with any additional arguments
-eval "$PACKAGE_COMMAND" "${PASSTHROUGH_ARGS[@]}"
+# Execute the command with any additional arguments. UAT_LAUNCHER is expanded
+# (quoted) at eval time so its backslashes survive, rather than being baked into
+# the string above where eval would strip them.
+eval "\"\$UAT_LAUNCHER\" $PACKAGE_COMMAND" "${PASSTHROUGH_ARGS[@]}"
 
 # Copy cook metadata (including chunk manifests) to the package directory
 if [[ "$TARGET_PLATFORM" = "Win64" ]]; then

--- a/Scripts/Setup.sh
+++ b/Scripts/Setup.sh
@@ -28,12 +28,19 @@ ADD_COMMAND_TO_HOOK() {
   if [ ! -f "$HOOK_FILE" ]; then
     touch "$HOOK_FILE"
     echo -e "#!/usr/bin/env bash\n" > "$HOOK_FILE"
+    # Prompting from a hook needs the terminal on stdin, but opening it must not
+    # fail the hook (and so the checkout) where there is no controlling
+    # terminal, e.g. CI or a GUI git client. Testing for existence is not
+    # enough: the node exists there, and only opening it fails.
     # https://stackoverflow.com/questions/3417896/how-do-i-prompt-the-user-from-within-a-commit-msg-hook
-    echo "exec < /dev/tty" >> "$HOOK_FILE"
+    echo 'if { : < /dev/tty; } 2>/dev/null; then exec < /dev/tty; fi' >> "$HOOK_FILE"
     chmod +x "$HOOK_FILE"
   fi
 
-  if ! grep -qF "\"$COMMAND\"" "$HOOK_FILE"; then
+  # Match on the bare path so an existing hook line is recognised whether it was
+  # written quoted or, by an older Setup.sh, unquoted. Matching the quoted form
+  # would miss a legacy unquoted line and append a duplicate beside it.
+  if ! grep -qF "$COMMAND" "$HOOK_FILE"; then
     echo "\"$COMMAND\"" >> "$HOOK_FILE"
   fi
 }


### PR DESCRIPTION
### Problem

On Windows, with the engine installed at the default `C:\Program Files\Epic Games\UE_5.8`,
`Scripts/Build.sh` fails immediately:

```
$ ./Plugins/Tempo/Scripts/Build.sh
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
```

`Scripts/Clean.sh` and `Scripts/Package.sh` fail the same way. This is separate from the hook
quoting fixed in #572 and the TempoROS script fixes in tempo-sim/TempoROS#73 — those addressed
spaces in the *project* path; this is the *engine* path reaching cmd.exe.

### Root cause

`Build.sh` already converts the engine path to its 8.3 short form specifically to keep the space
out of cmd.exe's hands:

```bash
UNREAL_ENGINE_PATH=$(cygpath -w -s "$UNREAL_ENGINE_PATH")   # C:\PROGRA~1\EPICGA~1\UE_5.8
```

That conversion works. The problem is what happens next: after `cd`-ing there, the batch file is
invoked by a **relative** path (`./Engine/Build/BatchFiles/Build.bat`). MSYS resolves a relative
*program* path through the real filesystem, so the long form comes back and the space returns:

```
$PWD    = /c/PROGRA~1/EPICGA~1/UE_5.8        # short, as intended
pwd -P  = /c/Program Files/Epic Games/UE_5.8 # what the program path actually resolves against
```

cmd.exe then splits at the space and tries to run a command named `C:\Program`.

Confirmed with a probe `.bat` printing `%~dp0` and its arguments:

| Invocation | Result |
|---|---|
| Relative (current) | `'C:\Program' is not recognized` |
| **Absolute short path** | **works** — `%~dp0` short, `-Project` intact |
| Absolute short + 8.3 `-Project` | breaks: cmd splits on `=`, and 8.3 truncates `.uproject` to `.UPR` |

### Changes

- **`Build.sh`, `Clean.sh`** — invoke `Build.bat` by absolute short path. Also strip the trailing
  separator `FindUnreal.sh` returns, so the path can be appended to. `Clean.sh` additionally had no
  `cygpath -w -s` conversion at all, so it gets one.
- **`Package.sh`** — same fix for `RunUAT.bat`, but its command is assembled as a string for `eval`,
  where backslashes are consumed as escapes (`C:PROGRA~1EPICGA~1...`). The launcher is therefore kept
  out of that string and expanded, quoted, at eval time.
- **`Setup.sh`** — two follow-ups to #572, see below.

That third row of the table is why `-Project` is deliberately **left as the long path**: MSYS quotes
it, which is sufficient, whereas its 8.3 form both splits on the `=` and mangles the extension.

The Mac and Linux branches are untouched: there is no cmd.exe there, so ordinary shell quoting
already suffices.

#### Setup.sh follow-ups to #572

1. **Dedup matches the bare path.** #572 made the guard `grep -qF "\"$COMMAND\""`, which does not
   match a line written by an *older* `Setup.sh` — so re-running setup on an existing hook appends a
   quoted duplicate beside the broken unquoted line, which still runs first and still fails.
   Verified against a hook containing a legacy unquoted line:

   ```
   before (#572 behaviour):        after (this PR):
   .../SyncDeps.sh                 .../SyncDeps.sh
   ".../SyncDeps.sh"               (nothing appended)
   ```

2. **Guarded `/dev/tty` redirect.** A bare `exec < /dev/tty` fails where there is no controlling
   terminal (CI, some GUI git clients), which fails the hook and so the checkout. Testing for
   existence is not enough — the device node exists there and only *opening* it fails — hence
   `if { : < /dev/tty; } 2>/dev/null; then exec < /dev/tty; fi`.

Note that neither #572 nor this PR repairs an already-broken hook; both only prevent writing new
ones. An existing hook still needs fixing by hand or by deleting it and re-running `Setup.sh`.

### Testing

- `Build.sh` run from a project path containing a space (`…\Documents\Unreal Projects\TempoTutorial`)
  against UE 5.8.2 installed at `C:\Program Files\Epic Games\UE_5.8`: previously failed instantly,
  now `Result: Succeeded` (131/131 actions). A later incremental build relinked all 12 Tempo modules
  cleanly.
- Hook generation exercised directly against a path containing spaces: correct shebang, quoted
  command, executable bit, and no duplicate line on a second run.
- `bash -n` clean on all four scripts.
- Windows only. I have no Mac or Linux machine to hand, but those branches are unchanged.

### Not included

No `TempoROS` submodule bump here, deliberately — that follows separately once
tempo-sim/TempoROS#75 lands, matching the existing convention (#571, #552). This PR is the four
scripts only, and does not depend on #75.
