### PR TITLE
Bail Out of the ROS Bridges When Node Creation Fails

### DIFF
--- a/TempoROSBridge/Source/TempoCoreROSBridge/Private/TempoTimeROSBridgeSubsystem.cpp
+++ b/TempoROSBridge/Source/TempoCoreROSBridge/Private/TempoTimeROSBridgeSubsystem.cpp
@@ -20,6 +20,11 @@ void UTempoTimeROSBridgeSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 	}
 
 	ROSNode = UTempoROSNode::Create("TempoTime", this);
+	if (!ROSNode)
+	{
+		return;
+	}
+
 	BindServiceToROS<FTempoAdvanceStepsService>(ROSNode, "AdvanceSteps", this, &UTempoTimeROSBridgeSubsystem::AdvanceSteps);
 	BindServiceToROS<FTempoSetSimStepsPerSecondService>(ROSNode, "SetSimStepsPerSecond", this, &UTempoTimeROSBridgeSubsystem::SetSimStepsPerSecond);
 	BindServiceToROS<FTempoSetTimeModeService>(ROSNode, "SetTimeMode", this, &UTempoTimeROSBridgeSubsystem::SetTimeMode);

--- a/TempoROSBridge/Source/TempoGeographicROSBridge/Private/TempoGeographicROSBridgeSubsystem.cpp
+++ b/TempoROSBridge/Source/TempoGeographicROSBridge/Private/TempoGeographicROSBridgeSubsystem.cpp
@@ -19,6 +19,10 @@ void UTempoGeographicROSBridgeSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 	}
 
 	ROSNode = UTempoROSNode::Create("TempoGeographic", this);
+	if (!ROSNode)
+	{
+		return;
+	}
 
 	BindServiceToROS<FTempoSetDayCycleRateService>(ROSNode, "SetDayCycleRate", this, &UTempoGeographicROSBridgeSubsystem::SetDayCycleRelativeRate);
 	BindServiceToROS<FTempoSetTimeOfDayService>(ROSNode, "SetTimeOfDay", this, &UTempoGeographicROSBridgeSubsystem::SetTimeOfDay);

--- a/TempoROSBridge/Source/TempoMovementROSBridge/Private/TempoMovementROSBridgeSubsystem.cpp
+++ b/TempoROSBridge/Source/TempoMovementROSBridge/Private/TempoMovementROSBridgeSubsystem.cpp
@@ -18,6 +18,11 @@ void UTempoMovementROSBridgeSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 	}
 
 	ROSNode = UTempoROSNode::Create("TempoMovement", this);
+	if (!ROSNode)
+	{
+		return;
+	}
+
 	BindServiceToROS<FTempoGetCommandablePawnsService>(ROSNode, "GetCommandablePawns", this, &UTempoMovementROSBridgeSubsystem::GetCommandablePawns);
 	BindServiceToROS<FTempoCommandVehicleService>(ROSNode, "CommandVehicle", this, &UTempoMovementROSBridgeSubsystem::CommandVehicle);
 	BindServiceToROS<FTempoCommandVelocityService>(ROSNode, "CommandVelocity", this, &UTempoMovementROSBridgeSubsystem::CommandVelocity);

--- a/TempoROSBridge/Source/TempoSensorsROSBridge/Private/TempoSensorsROSBridgeSubsystem.cpp
+++ b/TempoROSBridge/Source/TempoSensorsROSBridge/Private/TempoSensorsROSBridgeSubsystem.cpp
@@ -85,6 +85,11 @@ void UTempoSensorsROSBridgeSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 	}
 
 	ROSNode = UTempoROSNode::Create("TempoSensors", this);
+	if (!ROSNode)
+	{
+		return;
+	}
+
 	BindServiceToROS<FTempoGetAvailableSensors, UTempoSensorServiceSubsystem>(ROSNode, "GetAvailableSensors", this, &UTempoSensorsROSBridgeSubsystem::GetAvailableSensors);
 
 	InWorld.GetTimerManager().SetTimer(UpdatePublishersTimerHandle, this, &UTempoSensorsROSBridgeSubsystem::UpdatePublishers, UpdatePublishersPeriod, true, 0.0);


### PR DESCRIPTION
Companion to tempo-sim/TempoROS#76, which makes `UTempoROSNode::Create` return `nullptr` when
`rclcpp` was never initialized instead of letting an rclcpp exception escape and kill the editor.

### Problem

Each ROS bridge subsystem passes the result of `Create` straight into `BindServiceToROS` without
checking it:

```cpp
ROSNode = UTempoROSNode::Create("TempoTime", this);
BindServiceToROS<FTempoAdvanceStepsService>(ROSNode, "AdvanceSteps", ...);
```

That is safe while `Create` can only succeed or throw. Once it can report failure by returning
`nullptr`, this dereferences null.

### Changes

An early return after `Create` in all four bridges — `TempoTime`, `TempoGeographic`,
`TempoMovement`, `TempoSensors`. 19 added lines, no other change.

### Ordering

Harmless and unreachable on its own: until `Plugins/TempoROS` is bumped to include the companion
change, `Create` cannot return `nullptr`, so the new branch is never taken. Nothing changes when ROS
is up either way.

So this can merge before or after the TempoROS PR — it just does not *do* anything until the
submodule bump lands. No bump is included here, following the convention of doing that separately
(#571, #579).

### Testing

Built against UE 5.8.2 on Windows alongside the TempoROS change. With `rclcpp::init` failing, each
bridge now logs and returns instead of crashing; with ROS up, no behavioural difference observed.
