### PR TITLE
Prefer cmd //c with a relative path over 8.3-shortening for Windows Spaces

### DIFF
--- a/Scripts/Build.bat
+++ b/Scripts/Build.bat
@@ -18,9 +18,6 @@ if not defined PROJECT_NAME (
 for /f "usebackq delims=" %%I in (`"%SCRIPT_DIR%FindUnreal.bat"`) do set "UNREAL_ENGINE_PATH=%%I"
 if not defined UNREAL_ENGINE_PATH exit /b 1
 
-REM Use 8.3 short form so spaces in paths like "Program Files" don't trip up nested .bat invocations
-for %%I in ("!UNREAL_ENGINE_PATH!") do set "UNREAL_ENGINE_PATH=%%~sI"
-
 cd /d "!UNREAL_ENGINE_PATH!"
 call "Engine\Build\BatchFiles\Build.bat" "!PROJECT_NAME!Editor" Development Win64 -Project="!PROJECT_ROOT!\!PROJECT_NAME!.uproject" -WaitMutex -FromMsBuild %*
 exit /b %ERRORLEVEL%

--- a/Scripts/Build.sh
+++ b/Scripts/Build.sh
@@ -12,12 +12,6 @@ UNREAL_ENGINE_PATH=$("$SCRIPT_DIR"/FindUnreal.sh)
 PLATFORM=""
 if [[ "$OSTYPE" = "msys" ]]; then
   PLATFORM="Win64"
-  # 8.3 short form removes the space in "Program Files" so PWD is spaces-free
-  # when we invoke .bat files — otherwise cmd.exe's strip-outer-quotes rule
-  # mangles the path when another argument (e.g. -Project=...) is also quoted.
-  UNREAL_ENGINE_PATH=$(cygpath -w -s "$UNREAL_ENGINE_PATH")
-  # Drop any trailing separator so the path can be appended to below.
-  UNREAL_ENGINE_PATH="${UNREAL_ENGINE_PATH%[\\/]}"
 elif [[ "$OSTYPE" = "darwin"* ]]; then
   PLATFORM="Mac"
 elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
@@ -29,10 +23,10 @@ fi
 
 cd "$UNREAL_ENGINE_PATH"
 if [ "$PLATFORM" = "Win64" ]; then
-  # Invoke the .bat by absolute short path, not relatively: MSYS resolves a
-  # relative program path through the real filesystem, which restores the long
-  # "Program Files" form and reintroduces the space the 8.3 conversion removed.
-  "$UNREAL_ENGINE_PATH\\Engine\\Build\\BatchFiles\\Build.bat" "${PROJECT_NAME}Editor" Development "$PLATFORM" -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -WaitMutex -FromMsBuild "$@"
+  # Run the .bat through cmd explicitly with a relative, space-free path. Letting bash spawn the
+  # .bat directly puts its absolute path (e.g. C:\Program Files\...) first on cmd's /c line, and
+  # cmd strips the outer quotes whenever another argument is also quoted, breaking at the space.
+  cmd //c 'Engine\Build\BatchFiles\Build.bat' "${PROJECT_NAME}Editor" Development "$PLATFORM" -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -WaitMutex -FromMsBuild "$@"
 else
   ./Engine/Build/BatchFiles/"$PLATFORM"/Build.sh "${PROJECT_NAME}Editor" Development "$PLATFORM" -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -buildscw "$@"
 fi

--- a/Scripts/Clean.sh
+++ b/Scripts/Clean.sh
@@ -12,12 +12,6 @@ UNREAL_ENGINE_PATH=$("$SCRIPT_DIR"/FindUnreal.sh)
 PLATFORM=""
 if [[ "$OSTYPE" = "msys" ]]; then
   PLATFORM="Win64"
-  # 8.3 short form removes the space in "Program Files" so PWD is spaces-free
-  # when we invoke .bat files — otherwise cmd.exe's strip-outer-quotes rule
-  # mangles the path when another argument (e.g. -Project=...) is also quoted.
-  UNREAL_ENGINE_PATH=$(cygpath -w -s "$UNREAL_ENGINE_PATH")
-  # Drop any trailing separator so the path can be appended to below.
-  UNREAL_ENGINE_PATH="${UNREAL_ENGINE_PATH%[\\/]}"
 elif [[ "$OSTYPE" = "darwin"* ]]; then
   PLATFORM="Mac"
 elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
@@ -29,11 +23,8 @@ fi
 
 cd "$UNREAL_ENGINE_PATH"
 if [ "$PLATFORM" = "Win64" ]; then
-  # Windows build script is a little different.
-  # Invoke the .bat by absolute short path, not relatively: MSYS resolves a
-  # relative program path through the real filesystem, which restores the long
-  # "Program Files" form and reintroduces the space the 8.3 conversion removed.
-  "$UNREAL_ENGINE_PATH\\Engine\\Build\\BatchFiles\\Build.bat" "${PROJECT_NAME}Editor" Development $PLATFORM -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -WaitMutex -FromMsBuild -clean "$@"
+  # See Build.sh for why the .bat is run through cmd with a relative path.
+  cmd //c 'Engine\Build\BatchFiles\Build.bat' "${PROJECT_NAME}Editor" Development "$PLATFORM" -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -WaitMutex -FromMsBuild -clean "$@"
 else
   ./Engine/Build/BatchFiles/$PLATFORM/Build.sh "${PROJECT_NAME}Editor" Development $PLATFORM -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -buildscw -clean "$@"
 fi

--- a/Scripts/Clean.sh
+++ b/Scripts/Clean.sh
@@ -3,28 +3,5 @@
 set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-PROJECT_ROOT=$("$SCRIPT_DIR"/FindProjectRoot.sh)
-cd "$PROJECT_ROOT"
-PROJECT_NAME=$(find . -maxdepth 1 -name "*.uproject" -exec basename {} .uproject \;)
 
-UNREAL_ENGINE_PATH=$("$SCRIPT_DIR"/FindUnreal.sh)
-
-PLATFORM=""
-if [[ "$OSTYPE" = "msys" ]]; then
-  PLATFORM="Win64"
-elif [[ "$OSTYPE" = "darwin"* ]]; then
-  PLATFORM="Mac"
-elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
-  PLATFORM="Linux"
-else
-  echo "Unsupported platform"
-  exit 1
-fi
-
-cd "$UNREAL_ENGINE_PATH"
-if [ "$PLATFORM" = "Win64" ]; then
-  # See Build.sh for why the .bat is run through cmd with a relative path.
-  cmd //c 'Engine\Build\BatchFiles\Build.bat' "${PROJECT_NAME}Editor" Development "$PLATFORM" -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -WaitMutex -FromMsBuild -clean "$@"
-else
-  ./Engine/Build/BatchFiles/$PLATFORM/Build.sh "${PROJECT_NAME}Editor" Development $PLATFORM -Project="$PROJECT_ROOT/$PROJECT_NAME.uproject" -buildscw -clean "$@"
-fi
+exec "$SCRIPT_DIR/Build.sh" -clean "$@"

--- a/Scripts/InstallEngineMods.sh
+++ b/Scripts/InstallEngineMods.sh
@@ -168,13 +168,8 @@ REBUILD_PLUGIN() {
   PLUGIN_BUILD_DIR=$(mktemp -d)
   cd "$UNREAL_ENGINE_PATH"
   if [[ "$OSTYPE" = "msys" ]]; then
-    # Absolute short path, not relative: MSYS resolves a relative program path through the real
-    # filesystem, which restores the long "Program Files" form and reintroduces the space the 8.3
-    # conversion removed. Computed locally (not via UNREAL_ENGINE_PATH itself, unlike Build.sh) since
-    # this script uses UNREAL_ENGINE_PATH elsewhere as a normal long, forward-slash path.
-    UNREAL_ENGINE_SHORT_PATH=$(cygpath -w -s "$UNREAL_ENGINE_PATH")
-    UNREAL_ENGINE_SHORT_PATH="${UNREAL_ENGINE_SHORT_PATH%[\\/]}"
-    "$UNREAL_ENGINE_SHORT_PATH\\Engine\\Build\\BatchFiles\\RunUAT.bat" BuildPlugin -Plugin="$TEMP/$ROOT/$PLUGIN_NAME.uplugin" -Package="$PLUGIN_BUILD_DIR" -Rocket -TargetPlatforms=Win64
+    # See Build.sh for why the .bat is run through cmd with a relative path.
+    cmd //c 'Engine\Build\BatchFiles\RunUAT.bat' BuildPlugin -Plugin="$TEMP/$ROOT/$PLUGIN_NAME.uplugin" -Package="$PLUGIN_BUILD_DIR" -Rocket -TargetPlatforms=Win64
   elif [[ "$OSTYPE" = "darwin"* ]]; then
     ./Engine/Build/BatchFiles/RunUAT.sh BuildPlugin -Plugin="$TEMP/$ROOT/$PLUGIN_NAME.uplugin" -Package="$PLUGIN_BUILD_DIR" -Rocket -TargetPlatforms=Mac
   elif [[ "$OSTYPE" = "linux-gnu"* ]]; then

--- a/Scripts/Package.bat
+++ b/Scripts/Package.bat
@@ -22,9 +22,6 @@ if not defined PROJECT_NAME (
 for /f "usebackq delims=" %%I in (`"%SCRIPT_DIR%FindUnreal.bat"`) do set "UNREAL_ENGINE_PATH=%%I"
 if not defined UNREAL_ENGINE_PATH exit /b 1
 
-REM Use 8.3 short form so spaces in paths like "Program Files" don't trip up nested .bat invocations
-for %%I in ("!UNREAL_ENGINE_PATH!") do set "UNREAL_ENGINE_PATH=%%~sI"
-
 set "TARGET_PLATFORM=Win64"
 if /i "%~1"=="Linux" (
     if not defined LINUX_MULTIARCH_ROOT (

--- a/Scripts/Package.sh
+++ b/Scripts/Package.sh
@@ -52,12 +52,6 @@ HOST_PLATFORM=""
 TARGET_PLATFORM=""
 if [[ "$OSTYPE" = "msys" ]]; then
   HOST_PLATFORM="Win64"
-  # 8.3 short form removes the space in "Program Files" so PWD is spaces-free
-  # when we invoke .bat files — otherwise cmd.exe's strip-outer-quotes rule
-  # mangles the path when another argument (e.g. -project=...) is also quoted.
-  export UNREAL_ENGINE_PATH=$(cygpath -w -s "$UNREAL_ENGINE_PATH")
-  # Drop any trailing separator so the path can be appended to below.
-  export UNREAL_ENGINE_PATH="${UNREAL_ENGINE_PATH%[\\/]}"
   if [ "$1" = "Linux" ]; then
     if [ -z ${LINUX_MULTIARCH_ROOT+x} ]; then
       echo "LINUX_MULTIARCH_ROOT not set, cannot cross-compile for Linux"
@@ -95,21 +89,14 @@ PACKAGE_COMMAND="Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIf
 
 echo "Packaging $PROJECT_NAME in $BUILD_CONFIGURATION configuration -> $PROJECT_ROOT/Packaged"
 
-# Add platform-specific parts. The launcher is kept out of PACKAGE_COMMAND and
-# expanded by the eval below instead: on Windows its 8.3 path is backslashed,
-# and backslashes embedded in an eval'd string are consumed as escapes.
+# Add platform-specific parts
 if [ "$HOST_PLATFORM" = "Win64" ]; then
-  # Absolute short path, not relative: MSYS resolves a relative program path
-  # through the real filesystem, which restores the long "Program Files" form
-  # and reintroduces the space the 8.3 conversion removed.
-  UAT_LAUNCHER="$UNREAL_ENGINE_PATH\\Engine\\Build\\BatchFiles\\RunUAT.bat"
-  PACKAGE_COMMAND="$PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd.exe\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
+  # See Build.sh for why the .bat is run through cmd with a relative path.
+  PACKAGE_COMMAND="cmd //c 'Engine\\Build\\BatchFiles\\RunUAT.bat' $PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd.exe\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
 elif [ "$HOST_PLATFORM" = "Mac" ]; then
-  UAT_LAUNCHER="./Engine/Build/BatchFiles/RunUAT.sh"
-  PACKAGE_COMMAND="$PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd\" -archive -archivedirectory=\"$PROJECT_ROOT/Packaged\""
+  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.sh $PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd\" -archive -archivedirectory=\"$PROJECT_ROOT/Packaged\""
 elif [ "$HOST_PLATFORM" = "Linux" ]; then
-  UAT_LAUNCHER="./Engine/Build/BatchFiles/RunUAT.sh"
-  PACKAGE_COMMAND="$PACKAGE_COMMAND -unrealexe=\"UnrealEditor\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
+  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.sh $PACKAGE_COMMAND -unrealexe=\"UnrealEditor\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
 else
   echo "Unsupported platform"
   exit 1
@@ -143,10 +130,8 @@ for arg in "$@"; do
   esac
 done
 
-# Execute the command with any additional arguments. UAT_LAUNCHER is expanded
-# (quoted) at eval time so its backslashes survive, rather than being baked into
-# the string above where eval would strip them.
-eval "\"\$UAT_LAUNCHER\" $PACKAGE_COMMAND" "${PASSTHROUGH_ARGS[@]}"
+# Execute the command with any additional arguments
+eval "$PACKAGE_COMMAND" "${PASSTHROUGH_ARGS[@]}"
 
 # Copy cook metadata (including chunk manifests) to the package directory
 if [[ "$TARGET_PLATFORM" = "Win64" ]]; then

--- a/Scripts/Package.sh
+++ b/Scripts/Package.sh
@@ -84,37 +84,43 @@ fi
 
 cd "$UNREAL_ENGINE_PATH"
 
-# Build the base command with common arguments
-PACKAGE_COMMAND="Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIfNeeded -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" BuildCookRun -nop4 -utf8output -nocompileeditor -skipbuildeditor -cook -target=\"$PROJECT_NAME\" -platform=$TARGET_PLATFORM -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" -installed -stage -package -pak -build -prereqs -clientconfig=$BUILD_CONFIGURATION"
+UPROJECT="$PROJECT_ROOT/$PROJECT_NAME.uproject"
+
+PACKAGE_ARGS=(
+  Turnkey -command=VerifySdk -platform="$TARGET_PLATFORM" -UpdateIfNeeded -project="$UPROJECT"
+  BuildCookRun -nop4 -utf8output -nocompileeditor -skipbuildeditor -cook -target="$PROJECT_NAME"
+  -platform="$TARGET_PLATFORM" -project="$UPROJECT" -installed -stage -package -pak -build -prereqs
+  -clientconfig="$BUILD_CONFIGURATION"
+)
 
 echo "Packaging $PROJECT_NAME in $BUILD_CONFIGURATION configuration -> $PROJECT_ROOT/Packaged"
 
-# Add platform-specific parts
 if [ "$HOST_PLATFORM" = "Win64" ]; then
   # See Build.sh for why the .bat is run through cmd with a relative path.
-  PACKAGE_COMMAND="cmd //c 'Engine\\Build\\BatchFiles\\RunUAT.bat' $PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd.exe\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
+  UAT=(cmd //c 'Engine\Build\BatchFiles\RunUAT.bat')
+  PACKAGE_ARGS+=(-unrealexe="UnrealEditor-Cmd.exe" -stagingdirectory="$PROJECT_ROOT/Packaged")
 elif [ "$HOST_PLATFORM" = "Mac" ]; then
-  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.sh $PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd\" -archive -archivedirectory=\"$PROJECT_ROOT/Packaged\""
+  UAT=(./Engine/Build/BatchFiles/RunUAT.sh)
+  PACKAGE_ARGS+=(-unrealexe="UnrealEditor-Cmd" -archive -archivedirectory="$PROJECT_ROOT/Packaged")
 elif [ "$HOST_PLATFORM" = "Linux" ]; then
-  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.sh $PACKAGE_COMMAND -unrealexe=\"UnrealEditor\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
+  UAT=(./Engine/Build/BatchFiles/RunUAT.sh)
+  PACKAGE_ARGS+=(-unrealexe="UnrealEditor" -stagingdirectory="$PROJECT_ROOT/Packaged")
 else
   echo "Unsupported platform"
   exit 1
 fi
 
-# Add ScriptDir argument if TempoROS is enabled
 if [ "$TEMPOROS_ENABLED" = "true" ]; then
-  PACKAGE_COMMAND="$PACKAGE_COMMAND -ScriptDir=\"$PROJECT_ROOT/Plugins/Tempo/TempoROS/Scripts\""
+  PACKAGE_ARGS+=(-ScriptDir="$PROJECT_ROOT/Plugins/Tempo/TempoROS/Scripts")
 fi
 
-# Add low memory options if requested
 if [ "$LOW_MEMORY_MODE" = "true" ]; then
   # The cooker and C++ build have independent concurrency controls. A single
   # cook process alone does not prevent UBT/UBA from scheduling enough compiler
   # actions to exhaust available memory on lower-memory machines. Three local
   # actions leave headroom for UAT, the linker, and the cook commandlet while
   # retaining useful parallelism.
-  PACKAGE_COMMAND="$PACKAGE_COMMAND -CookPartialGC -NoXGE -UbtArgs=\"-MaxParallelActions=3 -NoUBA -NoXGE\" -AdditionalCookerOptions=\"-cookprocesscount=1\""
+  PACKAGE_ARGS+=(-CookPartialGC -NoXGE -UbtArgs="-MaxParallelActions=3 -NoUBA -NoXGE" -AdditionalCookerOptions="-cookprocesscount=1")
   echo "Low memory mode enabled: at most 3 compile actions, single cook process, partial GC, no UBA/XGE"
 fi
 
@@ -130,8 +136,7 @@ for arg in "$@"; do
   esac
 done
 
-# Execute the command with any additional arguments
-eval "$PACKAGE_COMMAND" "${PASSTHROUGH_ARGS[@]}"
+"${UAT[@]}" "${PACKAGE_ARGS[@]}" "${PASSTHROUGH_ARGS[@]}"
 
 # Copy cook metadata (including chunk manifests) to the package directory
 if [[ "$TARGET_PLATFORM" = "Win64" ]]; then


### PR DESCRIPTION
#577 fixed Build.sh/Clean.sh/Package.sh invoking their .bat by a relative path, which MSYS resolves through the real filesystem, restoring the long "Program Files" form and reintroducing the space that breaks cmd.exe's argument quoting. Its fix shortens the engine path (cygpath -w -s) so it has no space, then invokes the .bat directly.

That depends on Windows 8.3 short-name generation being enabled for the engine's install directory - commonly disabled on hardened/enterprise machines, and only ever populated for a user-created directory (e.g. under "C:\Users\Jane Doe\...", exactly where spaces are likely) if it was on when that directory was created. Where it's off, cygpath silently returns the long path unchanged and the original bug resurfaces with no signal.

Use cmd //c 'relative\path' instead, which never depends on shortening: a process's working directory is passed to CreateProcess as its own parameter, not as a space-delimited argv token, so cd-ing into the long path and letting cmd resolve a relative .bat path against it keeps the space out of argv entirely rather than working around its presence there. Apply the same fix to InstallEngineMods.sh, which invokes RunUAT.bat the same way and was never covered by #577.

Claude-Session: https://claude.ai/code/session_01NJ7LAX1P9vi6g8cg81qFuy