### PR TITLE
Fix plugin engine mod rebuilds failing under UBA on Mac

### DIFF
--- a/Scripts/InstallEngineMods.sh
+++ b/Scripts/InstallEngineMods.sh
@@ -165,7 +165,13 @@ REBUILD_PLUGIN() {
 
   echo "Rebuilding plugin $PLUGIN_NAME with Tempo mods"
 
-  PLUGIN_BUILD_DIR=$(mktemp -d)
+  # Resolve symlinks in the package directory. UE 5.8 always runs builds through Unreal Build
+  # Accelerator, which detours the compiler and tracks its outputs through its own virtual
+  # filesystem. On Mac, mktemp -d returns a path under /var/folders, and /var is a symlink to
+  # /private/var: UBA registers the writes under the /var form but the detoured clang reports the
+  # resolved /private/var form, so UBA refuses to flush the shared PCH ("dir not populated") and
+  # every subsequent compile fails with "PCH file not found". Both forms have to agree.
+  PLUGIN_BUILD_DIR=$(cd "$(mktemp -d)" && pwd -P)
   cd "$UNREAL_ENGINE_PATH"
   if [[ "$OSTYPE" = "msys" ]]; then
     # Absolute short path, not relative: MSYS resolves a relative program path through the real


### PR DESCRIPTION
## Problem

On UE 5.8 / macOS, `Scripts/InstallEngineMods.sh` fails to rebuild any `Plugin`-type engine mod. Every compile after the shared PCH dies:

```
error: unable to read PCH file /var/folders/.../HostProject/Intermediate/Build/Mac/x64/UnrealEditor/Development/UnrealEd/SharedPCH.UnrealEd.Cpp20.h.gch: 'No such file or directory'
fatal error: PCH file '...SharedPCH.UnrealEd.Cpp20.h.gch' not found: module file not found
```

Both the `arm64` and `x64` slices are affected, so `BuildPlugin` never gets past action 3 of 87.

## Cause

UE 5.8 added `Engine/Source/Programs/UnrealBuildTool/Executors/ExecutorFactory.cs` — a file that does not exist in 5.7 — which makes Unreal Build Accelerator the executor unconditionally:

```csharp
// We always use the UBA executor, but we disable detouring to mirror legacy behaviour if the config disables it.
if (!buildConfiguration.bAllowUBAExecutor)
{
    Config.bAllowDetour = false;
}
```

In 5.7, `bAllowUBAExecutor = false` selected `ParallelExecutor` instead. In 5.8 there is no non-UBA path, so every plugin rebuild now runs through UBA's compiler detour and its virtual filesystem. (`-NoUBA` would not help even if `BuildPlugin` forwarded arbitrary UBT args, which it does not — it only clears `bAllowDetour`.)

`REBUILD_PLUGIN` passes an `mktemp -d` directory as `BuildPlugin`'s `-Package`, and `BuildPlugin` creates `HostProject` inside it. On Mac that lands under `/var/folders/…`, where `/var` is a symlink to `/private/var`. The two path forms never reconcile inside UBA:

```
Refusing to register create-for-write '/var/folders/.../SharedPCH.UnrealEd.Cpp20.h.gch': dir not populated.
  dir='/var/folders/.../UnrealEd' dirKey=3270a089637d93ebe7894fc95eda8b33 populatedOffset=2 latestOffset=0
UbaSessionServer - Failed to get file information for /private/var/folders/.../SharedPCH.UnrealEd.Cpp20.h-8422d39b.gch.tmp
  while checking file added for write. This should not happen! (No such file or directory) [size=368337872 ...]
[1/87] Compile [Intel] SharedPCH.UnrealEd.Cpp20.h     <- reports success, writes nothing
[3/87] Compile [Intel] ZoneShapeActor.cpp
error: unable to read PCH file ...
```

UBA registers the write under the `/var` form, the detoured clang reports the resolved `/private/var` form, the directory lookup misses, and the 368 MB `.gch` is silently dropped while the action still reports success.

## Fix

Resolve the symlink so both forms agree:

```bash
PLUGIN_BUILD_DIR=$(cd "$(mktemp -d)" && pwd -P)
```

Only the `-Package` directory matters — the plugin *source* temp dir can stay under `/var`. Windows has no such symlink, so `InstallEngineMods.bat` needs no change.

## Verification

On UE 5.8, macOS 15.6, arm64:

| Test | Result |
| --- | --- |
| `BuildPlugin` with `-Package` under `$HOME` | BUILD SUCCESSFUL, 57s, 0 errors |
| `BuildPlugin` with `-Package` at resolved `/private/var` | BUILD SUCCESSFUL, 0 `Refusing to register` |
| Full `InstallEngineMods.sh` with this patch | ZoneGraph + MassCrowd rebuilt, all 5 `mods_applied.patch` records written |

Confirmed the patched code landed in the installed engine (`UpdateConnectedShapes` present in `ZoneGraphBuilder.cpp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)