### PR TITLE
Fix Ensure from TempoActorLabeler on PIE Exit

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoActorLabeler.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoActorLabeler.cpp
@@ -31,79 +31,66 @@
 FInstanceIdAllocator::FInstanceIdAllocator(int32 MinIdIn, int32 MaxIdIn)
 	: MinId(MinIdIn), MaxId(MaxIdIn)
 {
-	TSet<int32>& Ids = AvailableIds.AddDefaulted_GetRef();
-	for (int32 I = MinId; I <= MaxId; ++I)
+	TSet<int32>& UnallocatedIds = IdsByLiveCount.AddDefaulted_GetRef();
+	for (int32 Id = MinId; Id <= MaxId; ++Id)
 	{
-		Ids.Add(I);
+		UnallocatedIds.Add(Id);
 	}
 }
 
-TOptional<int32> FInstanceIdAllocator::Allocate()
+TOptional<int32> FInstanceIdAllocator::Allocate(bool bAllowSharedIds)
 {
-	for (TSet<int32>& Ids : AvailableIds)
+	// Every ID is in exactly one set, so the first non-empty set holds the least-shared IDs.
+	for (int32 LiveCount = 0; LiveCount < IdsByLiveCount.Num(); ++LiveCount)
 	{
-		if (auto IdIt = Ids.CreateIterator())
+		TSet<int32>& Ids = IdsByLiveCount[LiveCount];
+		if (Ids.IsEmpty())
 		{
-			const int32 Id = *IdIt;
-			IdIt.RemoveCurrent();
-			return Id;
+			continue;
 		}
+
+		if (LiveCount > 0 && !bAllowSharedIds)
+		{
+			return TOptional<int32>();
+		}
+
+		const int32 Id = *Ids.CreateConstIterator();
+		Ids.Remove(Id);
+		if (!IdsByLiveCount.IsValidIndex(LiveCount + 1))
+		{
+			IdsByLiveCount.AddDefaulted();
+		}
+		IdsByLiveCount[LiveCount + 1].Add(Id);
+		return Id;
 	}
 
-	const UTempoSensorsSettings* TempoSensorsSettings = GetDefault<UTempoSensorsSettings>();
-	if (TempoSensorsSettings->GetInstantaneouslyUniqueInstanceLabels())
-	{
-		// We are not allowed to reuse allocated IDs
-		return TOptional<int32>();
-	}
-
-	// Reuse allocated IDs by making them available, at a higher count
-	TSet<int32>& NextAvailableIds = AvailableIds.AddDefaulted_GetRef();
-	for (int32 I = MinId + 1; I <= MaxId; ++I)
-	{
-		NextAvailableIds.Add(I);
-	}
-
-	// We reserved MinId above to be the one we will allocate
-	return MinId;
+	// Only an empty range gets here.
+	return TOptional<int32>();
 }
 
 void FInstanceIdAllocator::Return(int32 Id)
 {
-	const UTempoSensorsSettings* TempoSensorsSettings = GetDefault<UTempoSensorsSettings>();
-	if (TempoSensorsSettings->GetGloballyUniqueInstanceLabels())
-	{
-		// We are not allowed to reuse IDs once they have been allocated
-		return;
-	}
-	if (!ensureMsgf(Id >= MinId && Id <= MaxId, TEXT("Reclaimed Available Id %d outside original min/max"), Id))
+	if (!ensureMsgf(Id >= MinId && Id <= MaxId, TEXT("Returned instance ID %d is outside the allocated range %d-%d"), Id, MinId, MaxId))
 	{
 		return;
 	}
-	for (auto AvailableIdsIt = AvailableIds.CreateIterator(); AvailableIdsIt; ++AvailableIdsIt)
+
+	for (int32 LiveCount = 1; LiveCount < IdsByLiveCount.Num(); ++LiveCount)
 	{
-		if (AvailableIdsIt->Contains(Id))
+		if (IdsByLiveCount[LiveCount].Remove(Id) > 0)
 		{
-			AvailableIdsIt->Remove(Id);
-			// If this wasn't the first element in AvailableIds, make this ID available at the lower count
-			if (auto PrevAvailableIdsIt = AvailableIdsIt - 1)
+			IdsByLiveCount[LiveCount - 1].Add(Id);
+			while (IdsByLiveCount.Num() > 1 && IdsByLiveCount.Last().IsEmpty())
 			{
-				PrevAvailableIdsIt->Add(Id);
-			}
-			// If that was the last ID in the group, we don't need this group anymore.
-			if (AvailableIdsIt->IsEmpty())
-			{
-				AvailableIdsIt.RemoveCurrent();
+				IdsByLiveCount.Pop();
 			}
 			return;
 		}
 	}
 
-	// If we never found the ID at a higher count, make sure we mark it available at count 0
-	if (ensureMsgf(AvailableIds.Num() > 0, TEXT("AvailableIds was empty!")))
-	{
-		AvailableIds[0].Add(Id);
-	}
+	// The ID's only remaining home is the unallocated set: it was returned more times than it was
+	// handed out. Counting it would understate how shared it is and hand it out ahead of freer IDs.
+	ensureMsgf(false, TEXT("Instance ID %d was returned with no live allocation"), Id);
 }
 
 using LabelService = TempoSensors::LabelService;
@@ -924,6 +911,25 @@ void UTempoActorLabeler::BuildLabelMaps()
 	});
 }
 
+TOptional<int32> UTempoActorLabeler::AllocateInstanceId()
+{
+	// An instantaneously unique label may not name two live objects at once, so once every ID is
+	// held the object goes without one rather than sharing.
+	return InstanceIdAllocator.Allocate(!GetDefault<UTempoSensorsSettings>()->GetInstantaneouslyUniqueInstanceLabels());
+}
+
+void UTempoActorLabeler::ReturnInstanceId(int32 InstanceId)
+{
+	// A globally unique label is never handed out again once its object is gone, so it is never
+	// handed back.
+	if (GetDefault<UTempoSensorsSettings>()->GetGloballyUniqueInstanceLabels())
+	{
+		return;
+	}
+
+	InstanceIdAllocator.Return(InstanceId);
+}
+
 void UTempoActorLabeler::LabelAllActors()
 {
 	for (TActorIterator<AActor> ActorItr(GetWorld()); ActorItr; ++ActorItr)
@@ -953,7 +959,7 @@ void UTempoActorLabeler::LabelActor(AActor* Actor)
 	if (const TOptional<int32> SemanticId = ResolveActorSemanticId(Actor))
 	{
 		ActorIdPair.SemanticId = *SemanticId;
-		if (const TOptional<int32> InstanceId = InstanceIdAllocator.Allocate())
+		if (const TOptional<int32> InstanceId = AllocateInstanceId())
 		{
 			ActorIdPair.InstanceId = *InstanceId;
 			// Track actor class names that have been assigned instance IDs
@@ -1092,7 +1098,7 @@ void UTempoActorLabeler::LabelComponent(UPrimitiveComponent* Component, FInstanc
 
 		FInstanceSemanticIdPair IdPair;
 		IdPair.SemanticId = *ComponentSemanticId;
-		if (TOptional<int32> InstanceId = InstanceIdAllocator.Allocate())
+		if (const TOptional<int32> InstanceId = AllocateInstanceId())
 		{
 			IdPair.InstanceId = *InstanceId;
 		}
@@ -1262,7 +1268,7 @@ void UTempoActorLabeler::UnLabelActor(AActor* Actor)
 	// Semantic mode passed through.
 	if (const FInstanceSemanticIdPair* IdPair = LabeledObjects.Find(Actor); IdPair->InstanceId != NoInstanceId)
 	{
-		InstanceIdAllocator.Return(IdPair->InstanceId);
+		ReturnInstanceId(IdPair->InstanceId);
 	}
 
 	LabeledObjects.Remove(Actor);
@@ -1303,7 +1309,7 @@ void UTempoActorLabeler::UnLabelComponent(UPrimitiveComponent* Component)
 		const FInstanceSemanticIdPair* ActorIdPair = LabeledObjects.Find(Component->GetOwner());
 		if (!ActorIdPair || ActorIdPair->InstanceId != ComponentIdPair->InstanceId)
 		{
-			InstanceIdAllocator.Return(ComponentIdPair->InstanceId);
+			ReturnInstanceId(ComponentIdPair->InstanceId);
 		}
 	}
 

--- a/TempoSensors/Source/TempoSensors/Private/TempoSensorsSettings.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoSensorsSettings.cpp
@@ -93,8 +93,8 @@ void UTempoSensorsSettings::SetLabelType(ELabelType LabelTypeIn)
 
 void UTempoSensorsSettings::SetGloballyUniqueInstanceLabels(bool bGloballyUniqueInstanceLabelsIn)
 {
-	// Read live by the instance ID allocator, so this only governs allocations from here on.
-	// Instance IDs already assigned keep theirs.
+	// Read live by the labeler as objects go away, so this only governs objects destroyed from here
+	// on. Instance IDs already reclaimed stay reclaimed.
 	bGloballyUniqueInstanceLabels = bGloballyUniqueInstanceLabelsIn;
 }
 

--- a/TempoSensors/Source/TempoSensors/Private/Tests/TempoInstanceIdAllocatorTest.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/Tests/TempoInstanceIdAllocatorTest.cpp
@@ -1,0 +1,128 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#include "TempoActorLabeler.h"
+
+#include "Misc/AutomationTest.h"
+
+// Covers FInstanceIdAllocator, which hands out the labeler's instance IDs and takes them back as
+// labeled objects go away. Only 253 IDs exist, so a large world shares them between live objects,
+// and the allocator has to keep count of every ID's sharing through arbitrary interleavings of
+// allocations and returns. Run via Scripts/Test.sh, or from the editor console with
+//   Automation RunTests Tempo.Sensors.InstanceIdAllocator
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+namespace
+{
+	constexpr EAutomationTestFlags TempoInstanceIdAllocatorTestFlags =
+		EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter;
+
+	// Allocates Count IDs, or fewer if the allocator refuses first.
+	TArray<int32> AllocateMany(FInstanceIdAllocator& Allocator, bool bAllowSharedIds, int32 Count)
+	{
+		TArray<int32> Ids;
+		for (int32 I = 0; I < Count; ++I)
+		{
+			const TOptional<int32> Id = Allocator.Allocate(bAllowSharedIds);
+			if (!Id.IsSet())
+			{
+				break;
+			}
+			Ids.Add(*Id);
+		}
+		return Ids;
+	}
+
+	// The IDs in ascending order, for comparing against an expected set of IDs whatever order they
+	// were handed out in.
+	TArray<int32> Sorted(TArrayView<const int32> Ids)
+	{
+		TArray<int32> SortedIds(Ids.GetData(), Ids.Num());
+		SortedIds.Sort();
+		return SortedIds;
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoInstanceIdAllocatorExclusiveTest,
+	"Tempo.Sensors.InstanceIdAllocator.Exclusive", TempoInstanceIdAllocatorTestFlags)
+bool FTempoInstanceIdAllocatorExclusiveTest::RunTest(const FString& Parameters)
+{
+	FInstanceIdAllocator Allocator(1, 3);
+
+	// Every ID goes out once, in some order, and then nothing more while sharing is disallowed.
+	const TArray<int32> Ids = AllocateMany(Allocator, false, 4);
+	TestEqual(TEXT("IDs handed out before refusing"), Ids.Num(), 3);
+	TestEqual(TEXT("Distinct IDs handed out"), Sorted(Ids), TArray<int32>({ 1, 2, 3 }));
+	TestFalse(TEXT("Refuses once every ID is held"), Allocator.Allocate(false).IsSet());
+
+	// A returned ID is the one handed out next, and it is the only one available.
+	Allocator.Return(2);
+	TestEqual(TEXT("Returned ID is handed out again"), Allocator.Allocate(false).Get(-1), 2);
+	TestFalse(TEXT("Refuses again once the returned ID is retaken"), Allocator.Allocate(false).IsSet());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoInstanceIdAllocatorSharedTest,
+	"Tempo.Sensors.InstanceIdAllocator.Shared", TempoInstanceIdAllocatorTestFlags)
+bool FTempoInstanceIdAllocatorSharedTest::RunTest(const FString& Parameters)
+{
+	FInstanceIdAllocator Allocator(1, 3);
+
+	// With sharing allowed, exhausting the range starts a second round over every ID rather than
+	// piling onto one: after six allocations each ID is held exactly twice.
+	const TArray<int32> Ids = AllocateMany(Allocator, true, 6);
+	TestEqual(TEXT("Sharing never refuses"), Ids.Num(), 6);
+	TestEqual(TEXT("First round covers every ID"), Sorted(TArrayView<const int32>(Ids).Left(3)), TArray<int32>({ 1, 2, 3 }));
+	TestEqual(TEXT("Second round covers every ID"), Sorted(TArrayView<const int32>(Ids).Right(3)), TArray<int32>({ 1, 2, 3 }));
+
+	// Returning one allocation of an ID makes it the least shared, so it goes out next, but it is
+	// still held once, so an exclusive allocation is refused.
+	Allocator.Return(2);
+	TestFalse(TEXT("Refuses an exclusive ID while every ID is held"), Allocator.Allocate(false).IsSet());
+	TestEqual(TEXT("Least-shared ID is handed out first"), Allocator.Allocate(true).Get(-1), 2);
+
+	// Returning every allocation of an ID frees it outright.
+	Allocator.Return(3);
+	Allocator.Return(3);
+	TestEqual(TEXT("Fully returned ID is free again"), Allocator.Allocate(false).Get(-1), 3);
+
+	return true;
+}
+
+// Tearing down a world returns IDs in whatever order its components unregister, which for a
+// shared ID means all of its allocations coming back at once rather than interleaved with other
+// IDs'. The allocator has to come back to a clean slate from any such ordering.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTempoInstanceIdAllocatorTeardownOrderTest,
+	"Tempo.Sensors.InstanceIdAllocator.TeardownOrder", TempoInstanceIdAllocatorTestFlags)
+bool FTempoInstanceIdAllocatorTeardownOrderTest::RunTest(const FString& Parameters)
+{
+	FInstanceIdAllocator Allocator(1, 3);
+
+	// Three IDs, five holders: two IDs are shared.
+	const TArray<int32> Ids = AllocateMany(Allocator, true, 5);
+	TestEqual(TEXT("Sharing never refuses"), Ids.Num(), 5);
+
+	// Return every allocation of one ID before moving to the next.
+	TMap<int32, int32> LiveCounts;
+	for (const int32 Id : Ids)
+	{
+		++LiveCounts.FindOrAdd(Id);
+	}
+	for (const auto& [Id, LiveCount] : LiveCounts)
+	{
+		for (int32 I = 0; I < LiveCount; ++I)
+		{
+			Allocator.Return(Id);
+		}
+	}
+
+	// Everything is free again: every ID goes out exclusively, exactly once.
+	const TArray<int32> IdsAfter = AllocateMany(Allocator, false, 4);
+	TestEqual(TEXT("IDs handed out exclusively after full teardown"), IdsAfter.Num(), 3);
+	TestEqual(TEXT("Distinct IDs after full teardown"), Sorted(IdsAfter), TArray<int32>({ 1, 2, 3 }));
+
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/TempoSensors/Source/TempoSensors/Public/TempoActorLabeler.h
+++ b/TempoSensors/Source/TempoSensors/Public/TempoActorLabeler.h
@@ -15,23 +15,30 @@
 
 #include "TempoActorLabeler.generated.h"
 
+// Hands out the IDs in [MinId, MaxId], always the one with the fewest live allocations, so IDs are
+// only shared between live objects once every ID is held, and then as evenly as possible. Knows
+// nothing of the instance label uniqueness settings; the labeler applies those.
 struct FInstanceIdAllocator
 {
 	FInstanceIdAllocator() = default;
 	FInstanceIdAllocator(int32 MinIdIn, int32 MaxIdIn);
 
-	TOptional<int32> Allocate();
+	// The ID with the fewest live allocations. Unset when every ID is already held and
+	// bAllowSharedIds is false, or the range is empty.
+	TOptional<int32> Allocate(bool bAllowSharedIds);
 
+	// Gives back one allocation of Id. Returning an ID with no live allocation is a caller bug,
+	// and is reported rather than counted.
 	void Return(int32 Id);
 
 private:
-	int32 MinId, MaxId;
-	// Array of available IDs, where each element is the IDs that have been allocated that index's number of times.
-	// For example, at the beginning this has one element, index 0, with all available IDs.
-	// IDs are always allocated from the lowest-count element.
-	// Once all IDs have been allocated once, another element is added, with all available IDs.
-	// When an ID is returned, if reusing IDs is allowed, the ID is moved from its current count to the next lower one.
-	TArray<TSet<int32>> AvailableIds;
+	int32 MinId = 0;
+	int32 MaxId = -1;
+	// IdsByLiveCount[N] is the set of IDs with exactly N live allocations. Every ID in
+	// [MinId, MaxId] is in exactly one of these sets at all times: Allocate moves it from its set
+	// to the next one up, Return from its set to the next one down. Index 0 always exists; higher
+	// sets are added as IDs come to be shared and trimmed once no ID is shared that many times.
+	TArray<TSet<int32>> IdsByLiveCount;
 };
 
 USTRUCT()
@@ -171,6 +178,12 @@ protected:
 	void UnLabelComponent(UActorComponent* Component);
 
 	void UnLabelComponent(UPrimitiveComponent* Component);
+
+	// The allocator applied through the instance label uniqueness settings. Both read the settings
+	// live, so a change governs only the allocations and returns that follow it.
+	TOptional<int32> AllocateInstanceId();
+
+	void ReturnInstanceId(int32 InstanceId);
 
 	// Re-derive everything cached from the semantic label table, then re-label the world from
 	// scratch. Bound to the settings' label-settings-changed event.


### PR DESCRIPTION
Ending PIE in a world with more than 253 labeled objects tripped `ensure(AvailableIds.Num() > 0)` in `FInstanceIdAllocator::Return`.

**Cause**

The allocator tracked IDs in per-count "available" sets, but `Allocate` only removed an ID from its set without moving it up, so an ID handed out more than once lived in no set. Returning it fell through to the count-0 set while it still had a live holder; the next return of the same ID found it there, removed it, and deleted the set if it was now empty. World teardown returns IDs in component-unregister order, so the sets collapsed from the bottom up until the array was empty. #573 made returns unconditional (previously Instance mode only), so a default Semantic-mode session now reaches this at teardown.

**Fix**

- Rebuild the allocator around one invariant: every ID is in exactly one set, indexed by its number of live holders. `Allocate` moves an ID up a set, `Return` moves it down. Set 0 always exists, and a return with no live holder is reported as a caller bug rather than miscounted.
- Move the uniqueness-setting reads out of the allocator into the labeler (`AllocateInstanceId` / `ReturnInstanceId`), so the allocator is a plain struct that can be unit tested. Both flags behave as before.
- Add `Tempo.Sensors.InstanceIdAllocator.*` automation tests covering exclusive allocation, even sharing after exhaustion, and the teardown return ordering that emptied the old array.

**Testing**

`Scripts/Test.sh Tempo.Sensors.InstanceIdAllocator` passes (3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJadrhE6LPAbD27ymDprhc
