### PR TITLE
Skip GI, reflections, MegaLights and ray tracing in the camera proxy capture

### DIFF
--- a/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCamera.cpp
@@ -1563,8 +1563,38 @@ void UTempoCamera::RenderCapture()
 			ProxyPP.bOverride_AutoExposureBias = true;
 			ProxyPP.AutoExposureBias = 0.0f;
 
+			// The PPM sits at "scene color before bloom" and samples only the stitched HDR target, so
+			// everything the renderer produces upstream of it is discarded. With no geometry drawn,
+			// global illumination, reflections, MegaLights and the ray tracing scene would run over an
+			// empty scene for nothing; turn them off for this render. Lighting itself stays on above
+			// so the exposure histogram is still read back.
+			const uint8 SavedOverrideGI = ProxyPP.bOverride_DynamicGlobalIlluminationMethod;
+			const uint8 SavedOverrideReflections = ProxyPP.bOverride_ReflectionMethod;
+			const uint8 SavedOverrideMegaLights = ProxyPP.bOverride_bMegaLights;
+			const TEnumAsByte<EDynamicGlobalIlluminationMethod::Type> SavedGI = ProxyPP.DynamicGlobalIlluminationMethod;
+			const TEnumAsByte<EReflectionMethod::Type> SavedReflections = ProxyPP.ReflectionMethod;
+			const uint8 SavedMegaLights = ProxyPP.bMegaLights;
+			const bool SavedUseRayTracing = bUseRayTracingIfEnabled;
+			ProxyPP.bOverride_DynamicGlobalIlluminationMethod = true;
+			ProxyPP.DynamicGlobalIlluminationMethod = EDynamicGlobalIlluminationMethod::None;
+			ProxyPP.bOverride_ReflectionMethod = true;
+			ProxyPP.ReflectionMethod = EReflectionMethod::None;
+			ProxyPP.bOverride_bMegaLights = true;
+			ProxyPP.bMegaLights = false;
+			// UpdateSceneCaptureContents pins the ray tracing scene's readback buffers ahead of this
+			// render, which is what makes a render without ray tracing safe while the main viewport
+			// still builds the ray tracing scene every frame.
+			bUseRayTracingIfEnabled = false;
+
 			CaptureScene();
 
+			bUseRayTracingIfEnabled = SavedUseRayTracing;
+			ProxyPP.bOverride_DynamicGlobalIlluminationMethod = SavedOverrideGI;
+			ProxyPP.DynamicGlobalIlluminationMethod = SavedGI;
+			ProxyPP.bOverride_ReflectionMethod = SavedOverrideReflections;
+			ProxyPP.ReflectionMethod = SavedReflections;
+			ProxyPP.bOverride_bMegaLights = SavedOverrideMegaLights;
+			ProxyPP.bMegaLights = SavedMegaLights;
 			ProxyPP.bOverride_AutoExposureMethod = SavedOverrideMethod;
 			ProxyPP.AutoExposureMethod = SavedMethod;
 			ProxyPP.bOverride_AutoExposureMinBrightness = SavedOverrideMinBrightness;


### PR DESCRIPTION
The multi-tile camera renders its stitched HDR output through a proxy scene capture so the engine's bloom, auto exposure and tonemapper run over it. The proxy's post-process material sits at "scene color before bloom" and samples only the stitched target, so everything the renderer produces upstream of it is discarded. World geometry was already hidden by the proxy's show flags, yet each capture still built the ray tracing scene and ran Lumen's screen probe gather, Lumen reflections and MegaLights over an empty scene.

Override global illumination and reflections to None and MegaLights off for the proxy capture only, and clear bUseRayTracingIfEnabled around it, restoring all of them afterwards. Lighting stays on so the exposure histogram is still read back. Cameras that requested depth from their first capture, and so never seeded the exposure controller from the single-tile fast path, converged to the same exposure as before, which confirms the histogram readback is unaffected.

UpdateSceneCaptureContents already pins the ray tracing scene's readback buffers ahead of every capture, which is what keeps a render without ray tracing safe while the main viewport builds the ray tracing scene each frame.


Claude-Session: https://claude.ai/code/session_018HAP3YgCiV7HvFE7T9WHZ3